### PR TITLE
PkgConfig should not be required - fail gracefully

### DIFF
--- a/cmake/modules/FindCairo.cmake
+++ b/cmake/modules/FindCairo.cmake
@@ -20,7 +20,7 @@ else(CAIRO_INCLUDE_DIRS AND CAIRO_LIBRARIES)
 if(NOT WIN32)
   # use pkg-config to get the directories and then use these values
   # in the FIND_PATH() and FIND_LIBRARY() calls
-  find_package(PkgConfig REQUIRED)
+  find_package(PkgConfig)
   if(Cairo_FIND_VERSION_COUNT GREATER 0)
     set(_cairo_version_cmp ">=${Cairo_FIND_VERSION}")
   endif(Cairo_FIND_VERSION_COUNT GREATER 0)


### PR DESCRIPTION
If PkgConfig is not available then we cannot find Cairo, but this should
fail gracefully so that systems without Cario can simply disbale options.
