### PR TITLE
Initialize lattice factor to 1.0 in PWSCF reader.

### DIFF
--- a/src/formats/pwscfformat.cpp
+++ b/src/formats/pwscfformat.cpp
@@ -81,7 +81,7 @@ namespace OpenBabel {
 
     char buffer[BUFF_SIZE], tag[BUFF_SIZE];
     double x,y,z;
-    double alat = 0;
+    double alat = 1.0;
     vector<string> vs;
     matrix3x3 ortho;
     int atomicNum;


### PR DESCRIPTION
Prevents NANs in output files lacking a lattice parameter definition.
