### PR TITLE
scripts/openbabel-python.i: Alias __next__ with next

### DIFF
--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -383,9 +383,6 @@ class OBIter(object):
     def __iter__(self):
         return self
 
-    def __next__(self):
-        return self.next()
-
     def next(self):
         if not self.finished:
             b = self.iter.__ref__()
@@ -396,6 +393,8 @@ class OBIter(object):
             return b
         else:
             raise StopIteration
+
+    __next__ = next
 
 class OBIterWithDepth(OBIter):
     def next(self):


### PR DESCRIPTION
Avoids an extra function call on every iteration.
