### PR TITLE
Still attempt to find Cairo even if pkgconfig fails

### DIFF
--- a/cmake/modules/FindCairo.cmake
+++ b/cmake/modules/FindCairo.cmake
@@ -17,25 +17,15 @@ if(CAIRO_INCLUDE_DIRS AND CAIRO_LIBRARIES)
 
 else(CAIRO_INCLUDE_DIRS AND CAIRO_LIBRARIES)
 
-if(NOT WIN32)
-  # use pkg-config to get the directories and then use these values
-  # in the FIND_PATH() and FIND_LIBRARY() calls
-  find_package(PkgConfig)
-  if(Cairo_FIND_VERSION_COUNT GREATER 0)
-    set(_cairo_version_cmp ">=${Cairo_FIND_VERSION}")
-  endif(Cairo_FIND_VERSION_COUNT GREATER 0)
-  pkg_check_modules(_pc_cairo cairo${_cairo_version_cmp})
-  if(_pc_cairo_FOUND)
-    set(CAIRO_FOUND TRUE)
-  endif(_pc_cairo_FOUND)
-else(NOT WIN32)
-  # assume so, for now
-  set(CAIRO_FOUND TRUE)
-endif(NOT WIN32)
-
-if(CAIRO_FOUND)
-  # set it back as false
-  set(CAIRO_FOUND FALSE)
+  if(NOT WIN32)
+    # use pkg-config to get the directories and then use these values
+    # in the FIND_PATH() and FIND_LIBRARY() calls
+    find_package(PkgConfig)
+    if(Cairo_FIND_VERSION_COUNT GREATER 0)
+      set(_cairo_version_cmp ">=${Cairo_FIND_VERSION}")
+    endif(Cairo_FIND_VERSION_COUNT GREATER 0)
+    pkg_check_modules(_pc_cairo cairo${_cairo_version_cmp})
+  endif(NOT WIN32)
 
   find_library(CAIRO_LIBRARY cairo
                HINTS ${_pc_cairo_LIBRARY_DIRS}
@@ -50,7 +40,6 @@ if(CAIRO_FOUND)
 
   include(FindPackageHandleStandardArgs)
   find_package_handle_standard_args(Cairo DEFAULT_MSG CAIRO_LIBRARIES CAIRO_INCLUDE_DIRS)
-endif(CAIRO_FOUND)
 
 endif(CAIRO_INCLUDE_DIRS AND CAIRO_LIBRARIES)
 


### PR DESCRIPTION
Under certain circumstances, pkgconfig won't successfully return the include and library paths for Cairo, however cmake will still manage to find them with find_path and find_library. This change just ensures find_path and find_library are still run, even if pkgconfig doesn't return any path hints.

Specifically, this can be an issue if Cairo is installed using Homebrew on Mac OS X, which just relies on X11/XQuartz for some of its dependencies. This is a problem because /opt/X11/lib/pkgconfig/ is not visible to pkgconfig by default, so instead of returning the include and library paths for Cairo, pkgconfig just complains that dependencies are missing (even though they aren't).

Even without the hints from pkgconfig, cmake will still manage to find the correct paths in most cases, especially if they are sensible like the Homebrew defaults of /usr/local/lib/libcairo.dylib and /usr/local/include/cairo.

Related bug report: http://sourceforge.net/p/openbabel/bugs/849/
Related homebrew issue: https://github.com/mxcl/homebrew/issues/14123
