### PR TITLE
1. Use obsharedptr instead of shared_ptr. obsharedptr is #defined to the...

### DIFF
--- a/include/openbabel/reaction.h
+++ b/include/openbabel/reaction.h
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <openbabel/shared_ptr.h>
 #include <openbabel/mol.h>
 
+
 namespace OpenBabel
 {
 
@@ -35,10 +36,10 @@ namespace OpenBabel
 class OBReaction : public OBBase
 {
 private:
-  std::vector<shared_ptr<OBMol> > _reactants;
-  std::vector<shared_ptr<OBMol> > _products;
-  shared_ptr<OBMol> _ts;
-  shared_ptr<OBMol> _agent;
+  std::vector<obsharedptr<OBMol> > _reactants;
+  std::vector<obsharedptr<OBMol> > _products;
+  obsharedptr<OBMol> _ts;
+  obsharedptr<OBMol> _agent;
   std::string _title;
   std::string _comment;
   bool _reversible;
@@ -52,37 +53,37 @@ public:
   int NumProducts()const
   { return static_cast<int> (_products.size()); }
 
-  void AddReactant(const shared_ptr<OBMol> sp)
+  void AddReactant(const obsharedptr<OBMol> sp)
   { _reactants.push_back(sp); }
 
-  void AddProduct(const shared_ptr<OBMol> sp)
+  void AddProduct(const obsharedptr<OBMol> sp)
   { _products.push_back(sp); }
 
-  void SetTransitionState(const shared_ptr<OBMol> sp)
+  void SetTransitionState(const obsharedptr<OBMol> sp)
   { _ts = sp; }
 
-  void AddAgent(const shared_ptr<OBMol> sp)
+  void AddAgent(const obsharedptr<OBMol> sp)
   { _agent = sp; }
 
-  shared_ptr<OBMol> GetReactant(const unsigned i)
+  obsharedptr<OBMol> GetReactant(const unsigned i)
   {
-    shared_ptr<OBMol> sp;
+    obsharedptr<OBMol> sp;
     if(i<_reactants.size())
       sp = _reactants[i];
     return sp; //returns empty if out of range
   }
-  shared_ptr<OBMol> GetProduct(const unsigned i)
+  obsharedptr<OBMol> GetProduct(const unsigned i)
   {
-    shared_ptr<OBMol> sp;
+    obsharedptr<OBMol> sp;
     if(i<_products.size())
       sp = _products[i];
     return sp; //returns empty if out of range
   }
 
-  shared_ptr<OBMol> GetTransitionState()const
+  obsharedptr<OBMol> GetTransitionState()const
   { return _ts; }
 
-  shared_ptr<OBMol> GetAgent()const
+  obsharedptr<OBMol> GetAgent()const
   { return _agent; }
 
   std::string GetTitle()	const { return _title; }

--- a/include/openbabel/shared_ptr.h
+++ b/include/openbabel/shared_ptr.h
@@ -18,13 +18,13 @@ GNU General Public License for more details.
 
 #ifdef USE_BOOST
   #include <boost/shared_ptr.hpp>
-  #define shared_ptr boost::shared_ptr
+  #define obsharedptr boost::shared_ptr
 #else
   #include <memory>
   #if __GNUC__ == 4  //&& __GNUC_MINOR__ < 3  removed at the suggestion of Konstantin Tokarev
     #include <tr1/memory>
   #endif
-  using std::tr1::shared_ptr;
+  #define obsharedptr std::tr1::shared_ptr
 #endif
 
 #endif // OB_SHARED_PTR_H

--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -6,7 +6,7 @@
 #define USING_OBDLL
 #endif
 
-
+#include <openbabel/shared_ptr.h>
 #include <openbabel/obutil.h>
 #include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
@@ -73,6 +73,14 @@
 %include "std_vector.i"
 %include "std_string.i"
 %include "std_pair.i"
+#define SWIG_SHARED_PTR_SUBNAMESPACE tr1
+%include "std_shared_ptr.i"
+%shared_ptr(OpenBabel::OBBase)
+%shared_ptr(OpenBabel::OBMol)
+%shared_ptr(OpenBabel::OBReaction)
+%shared_ptr(OpenBabel::OBAtom)
+%shared_ptr(OpenBabel::OBBond)
+%shared_ptr(OpenBabel::OBResidue)
 
 namespace std {
 
@@ -217,6 +225,7 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 %ignore *::operator[];
 
 %import <openbabel/babelconfig.h>
+%import <openbabel/shared_ptr.h>
 
 %include <openbabel/data.h>
 %include <openbabel/rand.h>

--- a/src/formats/chemdrawcdx.cpp
+++ b/src/formats/chemdrawcdx.cpp
@@ -334,7 +334,7 @@ bool ChemDrawBinaryXFormat::DoReaction(CDXReader& cdxr, OBReaction* pReact)
         vector<OBMol*> molvec = LookupMol(id); //id could be a group with several mols
         for(unsigned i=0;i<molvec.size();++i)
           if(strcmp(molvec[i]->GetTitle(),"justplus"))
-            pReact->AddReactant(shared_ptr<OBMol>(molvec[i]));
+            pReact->AddReactant(obsharedptr<OBMol>(molvec[i]));
       }
     }
     else if(tag == kCDXProp_ReactionStep_Products)
@@ -346,7 +346,7 @@ bool ChemDrawBinaryXFormat::DoReaction(CDXReader& cdxr, OBReaction* pReact)
         vector<OBMol*> molvec = LookupMol(id); //id could be a group with several mols
         for(unsigned i=0;i<molvec.size();++i)
           if(strcmp(molvec[i]->GetTitle(),"justplus"))
-            pReact->AddProduct(shared_ptr<OBMol>(molvec[i]));
+            pReact->AddProduct(obsharedptr<OBMol>(molvec[i]));
       }
     }
     else if(tag==kCDXProp_ReactionStep_Arrows)

--- a/src/formats/chemkinformat.cpp
+++ b/src/formats/chemkinformat.cpp
@@ -30,7 +30,6 @@ GNU General Public License for more details.
 #include "openbabel/obmolecformat.h"
 
 using namespace std;
-//using std::tr1::shared_ptr;
 
 namespace OpenBabel
 {
@@ -78,7 +77,7 @@ private:
   bool              ReadHeader(istream& ifs, OBConversion* pConv);
   bool              ParseReactionLine(OBReaction* pReact, OBConversion* pConv);
   bool              ReadReactionQualifierLines(istream& ifs, OBReaction* pReact);
-  shared_ptr<OBMol> CheckSpecies(string& name, string& ln, bool MustBeKnown);
+  obsharedptr<OBMol> CheckSpecies(string& name, string& ln, bool MustBeKnown);
   bool              ReadThermo(OBConversion* pConv);
   bool              ReadStdThermo(const string& datafilename);
   OBFormat*         GetThermoFormat();
@@ -86,8 +85,8 @@ private:
   bool              WriteReactionLine(OBReaction* pReact, OBConversion* pConv);
   bool              WriteHeader(OBConversion* pConv);
 private:
-  typedef map<string,shared_ptr<OBMol> > MolMap;
-  typedef set<shared_ptr<OBMol> > MolSet;
+  typedef map<string,obsharedptr<OBMol> > MolMap;
+  typedef set<obsharedptr<OBMol> > MolSet;
   //used on input
   MolMap IMols;
   string ln;
@@ -215,7 +214,7 @@ void ChemKinFormat::Init()
     SpeciesListed=false;
     IMols.clear();
     //Special species name
-    shared_ptr<OBMol> sp(new OBMol);
+    obsharedptr<OBMol> sp(new OBMol);
     sp.get()->SetTitle("M");
     IMols["M"] = sp;
 }
@@ -280,7 +279,7 @@ bool ChemKinFormat::ReadHeader(istream& ifs, OBConversion* pConv)
           break;
         }
         //Add all species to IMols
-        shared_ptr<OBMol> sp(new OBMol);
+        obsharedptr<OBMol> sp(new OBMol);
         sp.get()->SetTitle(*itr);
         IMols[*itr] = sp;
       }
@@ -346,7 +345,7 @@ bool ChemKinFormat::ParseReactionLine(OBReaction* pReact, OBConversion* pConv)
   OBRateData* pRD = new OBRateData; //to store rate constant data. Attach only if rate data found
 
   int n=0;
-  shared_ptr<OBMol> sp;
+  obsharedptr<OBMol> sp;
 
   string::size_type eqpos = ln.find('=');
 
@@ -643,7 +642,7 @@ bool ChemKinFormat::ReadReactionQualifierLines(istream& ifs, OBReaction* pReact)
 }
 
 ///////////////////////////////////////////////////////////////
-shared_ptr<OBMol> ChemKinFormat::CheckSpecies(string& name, string& ln, bool MustBeKnown)
+obsharedptr<OBMol> ChemKinFormat::CheckSpecies(string& name, string& ln, bool MustBeKnown)
 {
   MolMap::iterator mapitr = IMols.find(name);
   if(mapitr==IMols.end())
@@ -653,14 +652,14 @@ shared_ptr<OBMol> ChemKinFormat::CheckSpecies(string& name, string& ln, bool Mus
     {
       obErrorLog.ThrowError(__FUNCTION__,
         name + " not recognized as a species in\n" + ln, obError);
-      shared_ptr<OBMol> sp;
+      obsharedptr<OBMol> sp;
       return sp; //empty
     }
     else
     {
       // There was no REACTIONS section in input file and probably no SPECIES section.
       // Unknown species that appear in a reaction can be made here with just a name.
-      shared_ptr<OBMol> sp(new OBMol);
+      obsharedptr<OBMol> sp(new OBMol);
       sp->SetTitle(name.c_str());
       return sp;
     }
@@ -697,7 +696,7 @@ bool ChemKinFormat::ReadThermo(OBConversion* pConv)
       MolMap::iterator mapitr = IMols.find(thmol.GetTitle());
       if(mapitr!=IMols.end())
       {
-        shared_ptr<OBMol> psnewmol(OBMoleculeFormat::MakeCombinedMolecule(mapitr->second.get(),&thmol));
+        obsharedptr<OBMol> psnewmol(OBMoleculeFormat::MakeCombinedMolecule(mapitr->second.get(),&thmol));
         IMols.erase(mapitr);
         IMols[thmol.GetTitle()] = psnewmol;
       }
@@ -743,7 +742,7 @@ bool ChemKinFormat::ReadStdThermo(const string& datafilename)
       OBMol thmol;
       stdthermo.seekg(itr->second);
       StdThermConv.Read(&thmol);
-      shared_ptr<OBMol> psnewmol(OBMoleculeFormat::MakeCombinedMolecule(mapitr->second.get(),&thmol));
+      obsharedptr<OBMol> psnewmol(OBMoleculeFormat::MakeCombinedMolecule(mapitr->second.get(),&thmol));
       IMols[thmol.GetTitle()] = psnewmol;
     }
     else
@@ -915,7 +914,7 @@ bool ChemKinFormat::WriteReactionLine(OBReaction* pReact, OBConversion* pConv)
   int i;
   for(i=0;i<pReact->NumReactants();++i)
   {
-    shared_ptr<OBMol> psMol = pReact->GetReactant(i);
+    obsharedptr<OBMol> psMol = pReact->GetReactant(i);
 //    if(strcasecmp(psMol->GetTitle(),"M"))
     OMols.insert(psMol);
 
@@ -954,7 +953,7 @@ bool ChemKinFormat::WriteReactionLine(OBReaction* pReact, OBConversion* pConv)
 
   for(i=0;i<pReact->NumProducts();++i)
   {
-    shared_ptr<OBMol> psMol = pReact->GetProduct(i);
+    obsharedptr<OBMol> psMol = pReact->GetProduct(i);
     if(strcasecmp(psMol->GetTitle(),"M"))
       OMols.insert(psMol);
 

--- a/src/formats/rsmiformat.cpp
+++ b/src/formats/rsmiformat.cpp
@@ -181,7 +181,7 @@ namespace OpenBabel
     }
     mols = jreactants.Separate();
     for(itr=mols.begin();itr!=mols.end();++itr)
-      pReact->AddReactant(shared_ptr<OBMol>(new OBMol(*itr)));
+      pReact->AddReactant(obsharedptr<OBMol>(new OBMol(*itr)));
 
     pos2 = rsmiles.find('>', pos+1);
     if(pos2==string::npos)
@@ -201,7 +201,7 @@ namespace OpenBabel
         delete pAgent;
         return false;
       }
-      pReact->AddAgent(shared_ptr<OBMol>(pAgent));
+      pReact->AddAgent(obsharedptr<OBMol>(pAgent));
     }
 
     //Extract products and split into separate molecules
@@ -215,7 +215,7 @@ namespace OpenBabel
     mols.clear();
     mols = jproducts.Separate();
     for(itr=mols.begin();itr!=mols.end();++itr)
-      pReact->AddProduct(shared_ptr<OBMol>(new OBMol(*itr)));
+      pReact->AddProduct(obsharedptr<OBMol>(new OBMol(*itr)));
 
     return true;
   }
@@ -247,7 +247,7 @@ namespace OpenBabel
 
     ofs << '>';
 
-    shared_ptr<OBMol> spAgent = pReact->GetAgent();
+    obsharedptr<OBMol> spAgent = pReact->GetAgent();
     if(spAgent.get())
       if(!pSmiFormat->WriteMolecule(spAgent.get(), pConv))
         return false;

--- a/src/formats/rxnformat.cpp
+++ b/src/formats/rxnformat.cpp
@@ -175,7 +175,7 @@ bool RXNFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
         obErrorLog.ThrowError(__FUNCTION__, "Failed to read a reactant", obWarning);
       else
       {
-        shared_ptr<OBMol> p(pmol);
+        obsharedptr<OBMol> p(pmol);
         pReact->AddReactant(p);
       }
     }
@@ -189,7 +189,7 @@ bool RXNFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
       else
       {
         //        pReact->products.push_back(pmol);
-        shared_ptr<OBMol> p(pmol);
+        obsharedptr<OBMol> p(pmol);
         pReact->AddProduct(p);
       }
     }

--- a/src/formats/xml/cmlreactformat.cpp
+++ b/src/formats/xml/cmlreactformat.cpp
@@ -19,7 +19,7 @@ GNU General Public License for more details.
 #include "openbabel/text.h"
 
 using namespace std;
-//using std::tr1::shared_ptr;
+
 namespace OpenBabel
 {
 
@@ -91,15 +91,15 @@ public:
   };
 
 private:
-  typedef map<string,shared_ptr<OBMol> > MolMap;
-  string AddMolToList(shared_ptr<OBMol> spmol, MolMap& mmap);
+  typedef map<string,obsharedptr<OBMol> > MolMap;
+  string AddMolToList(obsharedptr<OBMol> spmol, MolMap& mmap);
   bool WriteRateData(OBReaction* pReact, xmlChar* altprefix);
   void WriteMetadataList(OBReaction& react);
 
 private:
   OBReaction* _preact;
   OBMol* pmol;
-  shared_ptr<OBMol> _spmol;
+  obsharedptr<OBMol> _spmol;
   MolMap IMols; //used on input
   MolMap OMols; //used on output
   int nextmol;
@@ -123,7 +123,7 @@ bool CMLReactFormat::ReadChemObject(OBConversion* pConv)
   {
     IMols.clear();
     //add special species
-    shared_ptr<OBMol> sp(new OBMol);
+    obsharedptr<OBMol> sp(new OBMol);
     sp.get()->SetTitle("M");
     IMols["M"] = sp;
   }
@@ -192,7 +192,7 @@ bool CMLReactFormat::DoElement(const string& name)
     }
     else
     {
-      shared_ptr<OBMol> sp(new OBMol);
+      obsharedptr<OBMol> sp(new OBMol);
       OBFormat* pCMLFormat = OBConversion::FindFormat("cml");
       if(!pCMLFormat)
         return false;
@@ -331,7 +331,7 @@ bool CMLReactFormat::WriteChemObject(OBConversion* pConv)
     OBMol* pmol = dynamic_cast<OBMol*>(pOb);
     if(pmol!=NULL)
     {
-      shared_ptr<OBMol> sp(pmol);
+      obsharedptr<OBMol> sp(pmol);
       AddMolToList(sp, OMols);
       pConv->SetOutputIndex(-1); //Signals that molecules have been added
 
@@ -624,7 +624,7 @@ bool CMLReactFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
   return true;
 }
 
-string CMLReactFormat::AddMolToList(shared_ptr<OBMol> spmol, MolMap& mmap)
+string CMLReactFormat::AddMolToList(obsharedptr<OBMol> spmol, MolMap& mmap)
 {
   //Adds a molecule to the map
   string id = spmol->GetTitle();
@@ -664,7 +664,7 @@ string CMLReactFormat::AddMolToList(shared_ptr<OBMol> spmol, MolMap& mmap)
     {
       //already in map.
       //Get a molecule with the best bits of both old and new molecules and immediately make a shared_ ptr
-      shared_ptr<OBMol> spnew(OBMoleculeFormat::MakeCombinedMolecule(mapitr->second.get(), spmol.get()));
+      obsharedptr<OBMol> spnew(OBMoleculeFormat::MakeCombinedMolecule(mapitr->second.get(), spmol.get()));
       if(spnew)
       {
         spmol.swap(spnew);

--- a/src/obmolecformat.cpp
+++ b/src/obmolecformat.cpp
@@ -439,7 +439,7 @@ namespace OpenBabel
     //Output all the constituent molecules of the reaction
 
     //Collect the molecules first, just for convenience
-    vector<shared_ptr<OBMol> > mols;
+    vector<obsharedptr<OBMol> > mols;
     unsigned i;
     for(i=0;i<pReact->NumReactants();i++)
       mols.push_back(pReact->GetReactant(i));

--- a/test/obtest.h
+++ b/test/obtest.h
@@ -38,7 +38,7 @@ const char* ob_expr(const char *expr);
 
 
 // some utility functions
-typedef shared_ptr<OpenBabel::OBMol> OBMolPtr;
+typedef obsharedptr<OpenBabel::OBMol> OBMolPtr;
 
 struct OBTestUtil
 {


### PR DESCRIPTION
... appropriate value
1. Add support for shared_ptrs to Python bindings. The following code now works:

r = OBReaction()
m = OBMol()
r.AddReactant(m)
