### PR TITLE
OBGUI.cpp: Fix compile

### DIFF
--- a/src/GUI/OBGUI.cpp
+++ b/src/GUI/OBGUI.cpp
@@ -691,7 +691,7 @@ with the output format.\nDo you wish to continue the conversion?"),
     }
   }
 
-  m_pMessages->AppendText(smes.str().c_str());
+  m_pMessages->AppendText(wxString(smes.str().c_str(), wxConvUTF8));
   //Restore cerr and clog
   std::cerr.rdbuf(sbcerrOld);
   std::clog.rdbuf(sbclogOld);


### PR DESCRIPTION
Complained about ambiguous conversion from const char\* to const
wxString.  Used UTF8 encoding as in example in wxWidgets wiki since that
covers also the ASCII case.
