### PR TITLE
scala: Add an example program in Scala using Java bindings

### DIFF
--- a/scripts/scala/OBTest.scala
+++ b/scripts/scala/OBTest.scala
@@ -1,0 +1,27 @@
+import org.openbabel._
+
+object OBTest {
+
+  def main(args: Array[String]) {
+    println("Loading openbabel_java...")
+    System.loadLibrary("openbabel_java")
+
+    println("Running OBTest...")
+    run
+  }
+
+  def run() {
+    val c = new OBConversion
+    val mol = new OBMol
+
+    c.SetInFormat("smi")
+    c.ReadString(mol, "c1ccccc1")
+
+    println("Benzene has " + mol.NumAtoms + " heavy atoms.")
+
+    mol.AddHydrogens
+
+    println("Benzene has " + mol.NumAtoms + " atoms in total.")
+    println("The molecular weight of benzene is " + mol.GetMolWt)
+  }
+}

--- a/scripts/scala/README
+++ b/scripts/scala/README
@@ -1,0 +1,14 @@
+Scala has native support for Java libraries. First compile Java bindings and
+then you can use them in Scala programs.
+
+There is a small test program OBTest.scala. Provided that Java bindings are
+installed in OB_JAVADIR:
+
+~$ CLASSPATH="$OB_JAVADIR/openbabel.jar" LD_LIBRARY_PATH="$OB_JAVADIR" scalac OBTest.scala
+~$ CLASSPATH=".:$OB_JAVADIR/openbabel.jar" LD_LIBRARY_PATH="$OB_JAVADIR" scala OBTest
+Loading openbabel_java...
+Running OBTest...
+Benzene has 6 heavy atoms.
+Benzene has 12 atoms in total.
+The molecular weight of benzene is 78.11184000000003
+


### PR DESCRIPTION
Just an example program I used when testing Java bindings. We already have similar thing in Java so it is of limited utility. But it works and I find Scala nicer, might as well preserve for posterity.
