### PR TITLE
Cmake python changes

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -38,15 +38,19 @@ endif()
 
 if (PYTHON_BINDINGS)
   if (EXISTS ${openbabel_SOURCE_DIR}/scripts/python/openbabel-python.cpp OR RUN_SWIG)
-    find_package(PythonLibs)
-    if (NOT PYTHONLIBS_FOUND)
-      message(STATUS "Python libraries NOT found")
-    endif (NOT PYTHONLIBS_FOUND)
-
     find_package(PythonInterp)
     if (NOT PYTHONINTERP_FOUND)
       message(STATUS "Python interpreter NOT found")
     endif (NOT PYTHONINTERP_FOUND)
+
+    if (PYTHONINTERP_FOUND AND NOT Python_ADDITIONAL_VERSIONS)
+      set(Python_ADDITIONAL_VERSIONS "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+    endif (PYTHONINTERP_FOUND AND NOT Python_ADDITIONAL_VERSIONS)
+
+    find_package(PythonLibs)
+    if (NOT PYTHONLIBS_FOUND)
+      message(STATUS "Python libraries NOT found")
+    endif (NOT PYTHONLIBS_FOUND)
 
     if(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
       set(DO_PYTHON_BINDINGS ON BOOL)


### PR DESCRIPTION
This involves two commits that:
1. install the python files into site-packages corresponding to the python used, rather than next to the libraries. eg /usr/lib64/python2.7/site-packages instead of /usr/lib64
2. CMake's PythonLibs and PythonInterp can find different versions of python. In my case, I had python3.2 and python2.7 installed. the PythonInterp found python2.7 since it was /usr/bin/python , but PythonLibs found the devel files for Python3 . This clearly did not work very well. Now, I search for the python first, then restrict the libraries found based on the version of the python interpreter.
