### PR TITLE
Remove unescaped quotes in UsePythonTest.cmake

### DIFF
--- a/cmake/modules/UsePythonTest.cmake
+++ b/cmake/modules/UsePythonTest.cmake
@@ -51,10 +51,10 @@ MACRO(ADD_PYTHON_TEST TESTNAME FILENAME)
   
   # Pass the output back to ctest
   IF(import_output)
-    MESSAGE("\${import_output}")
+    MESSAGE(\${import_output})
   ENDIF(import_output)
   IF(import_res)
-    MESSAGE(SEND_ERROR "\${import_res}")
+    MESSAGE(SEND_ERROR \${import_res})
   ENDIF(import_res)
 "
 )


### PR DESCRIPTION
UsePythonTest.cmake contains a template that is used to create a series of cmake files that execute tests for the python language bindings. Quotes within this template need to be escaped, otherwise they fail to appear in the resulting cmake files.

In this context, the unescaped quotes were optional so no error was actually caused. However, as of cmake 2.8.12, the unescaped quotes cause a warning when running cmake: "Argument not separated from preceding token by whitespace."

This change simply removes the unescaped quotes, causing no changes to the resulting cmake files.
