### PR TITLE
print error message with filename when failing to initialize a database

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -1039,7 +1039,7 @@ namespace OpenBabel
         string s = "Cannot initialize database '";
         s += _filename;
         s += "' which may cause further errors.";
-        obErrorLog.ThrowError(__FUNCTION__, "Cannot initialize database", obWarning);
+        obErrorLog.ThrowError(__FUNCTION__, s, obWarning);
       }
 
   }


### PR DESCRIPTION
Code currently creates a pretty useful error message that tells you the name of the file it could not initialize, then prints a less useful error message. I think we should use the useful error message.
