### PR TITLE
Allow setting the formula multiple times.

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -1131,7 +1131,6 @@ namespace OpenBabel
     dp->SetValue( sformula );
     dp->SetOrigin( perceived ); // internal generation
     SetData(dp);
-
     return sformula;
   }
 
@@ -1139,17 +1138,15 @@ namespace OpenBabel
   {
     string attr = "Formula";
     OBPairData *dp = (OBPairData *) GetData(attr);
-
     if (dp == NULL)
       {
         dp = new OBPairData;
         dp->SetAttribute(attr);
+        SetData(dp);
       }
     dp->SetValue(molFormula);
     // typically file input, but this needs to be revisited
     dp->SetOrigin(fileformatInput);
-
-    SetData(dp);
   }
 
   void OBMol::SetTotalCharge(int charge)

--- a/test/mol.cpp
+++ b/test/mol.cpp
@@ -184,10 +184,18 @@ int mol(int argc, char* argv[])
         cout << "ok 12" << endl;
       else
         cout << "not ok 12 # failed empty InChI" << endl;
-      cout << "1..12\n";
     }
-  else
-    cout << "1..11\n"; // total number of tests for Perl's "prove" tool
 
+  OBMol testMolFormula;
+  string formula("C6");
+  testMolFormula.SetFormula(formula);
+  if ( testMolFormula.GetFormula() != formula ) {
+     cout << "ok 13" << endl;
+  } else {
+    cout << "not ok 13 # SetFormula "<< endl;
+  }
+  // Reset the formula to test for a double delete error
+  testMolFormula.SetFormula(formula);
+  cout << "1..13\n"; // total number of tests for Perl's "prove" tool
   return(0);
 }


### PR DESCRIPTION
The current scheme only allows for one formula per molecule, but
there is no restriction on calling SetFormula multiple times. If
this happens, there is a double delete OBPairData call.

This came up when converting mmcif to pdb, because both _chemical_formula_iupac and _chemical_formula_moiety were set.
