### PR TITLE
scripts/openbabel-python.i: Revert shared_ptr changes

### DIFF
--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -6,7 +6,6 @@
 #define USING_OBDLL
 #endif
 
-#include <openbabel/shared_ptr.h>
 #include <openbabel/obutil.h>
 #include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
@@ -73,14 +72,6 @@
 %include "std_vector.i"
 %include "std_string.i"
 %include "std_pair.i"
-#define SWIG_SHARED_PTR_SUBNAMESPACE tr1
-%include "std_shared_ptr.i"
-%shared_ptr(OpenBabel::OBBase)
-%shared_ptr(OpenBabel::OBMol)
-%shared_ptr(OpenBabel::OBReaction)
-%shared_ptr(OpenBabel::OBAtom)
-%shared_ptr(OpenBabel::OBBond)
-%shared_ptr(OpenBabel::OBResidue)
 
 namespace std {
 
@@ -225,7 +216,6 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 %ignore *::operator[];
 
 %import <openbabel/babelconfig.h>
-%import <openbabel/shared_ptr.h>
 
 %include <openbabel/data.h>
 %include <openbabel/rand.h>


### PR DESCRIPTION
This reverts part of ce178cbbd3182aa3ef5729d2133f497248cf5250.
