### PR TITLE
Fixing numerical instability in CalcTorsionAngle and updating OB::Set/GetTorsion accordingly

### DIFF
--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -542,9 +542,6 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
      *  WARNING: SetTorsion takes an angle in radians while GetTorsion returns it
      *  in degrees
      */
-    double np_cross(double a1, double a2, double a3, double b1, double b2, double b3);
-    double np_dot(double v1x, double v1y, double v1z, double v2x, double v2y, double v2z);
-    double CalcTorsionForSet(std::vector<int> tor);
     void SetTorsion(OBAtom*,OBAtom*,OBAtom*,OBAtom*,double ang);
     //@}
 

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -232,6 +232,7 @@ namespace OpenBabel
   OBAPI double CalcTorsionAngle(const vector3 &a, const vector3 &b,
                                 const vector3 &c, const vector3 &d)
   {
+
     double torsion;
     vector3 b1,b2,b3,c1,c2,c3;
 
@@ -239,11 +240,12 @@ namespace OpenBabel
     b2 = b - c;
     b3 = c - d;
 
+#ifdef OB_OLD_MATH_CHECKS
     c1 = cross(b1,b2);
     c2 = cross(b2,b3);
     c3 = cross(c1,c2);
 
-#ifdef OB_OLD_MATH_CHECKS
+
     if (c1.length() * c2.length() < 0.001)
     {
       torsion = 0.0;
@@ -251,14 +253,13 @@ namespace OpenBabel
     }
 #endif
 
-    torsion = vectorAngle(c1,c2);
-    if (dot(b2,c3) > 0.0)
-      torsion = -torsion;
+    double rb2 = sqrt(dot(b2, b2));
 
-    if (!isfinite(torsion))
-      torsion = 180.0;
+    vector3 b2xb3 = cross(b2, b3);
+    vector3 b1xb2 = cross(b1, b2);
+    torsion = - atan2(dot(rb2 * b1, b2xb3), dot(b1xb2, b2xb3));
 
-    return(torsion);
+    return(torsion * RAD_TO_DEG);
   }
 
   /*! \brief Construct a unit vector orthogonal to *this.

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -212,93 +212,6 @@ namespace OpenBabel
                             ((OBAtom*)_vatom[d-1])->GetVector()));
   }
 
-
-    double OBMol::np_cross(double a1, double a2, double a3,
-                           double b1, double b2, double b3) {
-
-        // double * cross[3];
-
-        // cross[0] = a2 * b3
-        //          - b2 * a3;
-
-        // cross[1] = a3 * b1
-        //          - b3 * a1;
-
-        // cross[2] = a1 * b2
-        //          - b1 * a2;
-
-        // return cross;
-        return 1;
-    }
-
-
-
-    double OBMol::np_dot(double v1x, double v1y, double v1z,
-                         double v2x, double v2y, double v2z) {
-
-        double dot = v1x * v2x
-                   + v1y + v2y
-                   + v1z * v2z;
-
-        return dot;
-    }
-
-    double OBMol::CalcTorsionForSet(vector<int> tor) {
-
-        // b1 = b - a
-        // b2 = c - b
-        // b3 = d - c
-        // rb2 = np.sqrt(np.dot(b2,b2))
-        // b2xb3 = np.cross(b2,b3)
-        // b1xb2 = np.cross(b1,b2)
-        // dihedral = math.atan2( np.dot(rb2*b1,b2xb3), np.dot(b1xb2,b2xb3) )
-        // return dihedral
-
-        //calculate the vectors between
-
-        double b1x = _c[tor[1]]   - _c[tor[0]];
-        double b1y = _c[tor[1]+1] - _c[tor[0]+1];
-        double b1z = _c[tor[1]+2] - _c[tor[0]+2];
-
-        double b2x = _c[tor[2]]   - _c[tor[1]];
-        double b2y = _c[tor[2]+1] - _c[tor[1]+1];
-        double b2z = _c[tor[2]+2] - _c[tor[1]+2];
-
-        double b3x = _c[tor[3]]   - _c[tor[2]];
-        double b3y = _c[tor[3]+1] - _c[tor[2]+1];
-        double b3z = _c[tor[3]+2] - _c[tor[2]+2];
-
-        double rb2 = sqrt(b2x * b2x + b2y * b2y + b2z * b2z);
-
-        // rv2 ~ rb2
-
-        double b2xb3x = b2y * b3z - b3y * b2z;
-        double b2xb3y = b2z * b3x - b3z * b2x;
-        double b2xb3z = b2x * b3y - b3x * b2y;
-
-        double b1xb2x = b1y * b2z - b2y * b1z;
-        double b1xb2y = b1z * b2x - b2z * b1x;
-        double b1xb2z = b1x * b2y - b2x * b1y;
-
-        double y = rb2 * (b1x * b2xb3x +
-                          b1y * b2xb3y +
-                          b1z * b2xb3z);
-
-        double x = b1xb2x * b2xb3x +
-                   b1xb2y * b2xb3y +
-                   b1xb2z * b2xb3z;
-
-
-        double dihedral = atan2(y, x);
-
-
-
-        return dihedral;
-
-    }
-
-
-
   void OBMol::SetTorsion(OBAtom *a,OBAtom *b,OBAtom *c, OBAtom *d, double ang)
   {
     vector<int> tor;
@@ -317,58 +230,15 @@ namespace OpenBabel
     for (j = 0 ; (unsigned)j < atoms.size() ; j++ )
       atoms[j] = (atoms[j] - 1) * 3;
 
-    double v1x,v1y,v1z,v2x,v2y,v2z,v3x,v3y,v3z;
-    double c1x,c1y,c1z,c2x,c2y,c2z,c3x,c3y,c3z;
-    double c1mag,c2mag,radang,costheta,m[9];
+    double v2x,v2y,v2z;
+    double radang,m[9];
     double x,y,z,mag,rotang,sn,cs,t,tx,ty,tz;
 
     //calculate the torsion angle
-
-    v1x = _c[tor[0]]   - _c[tor[1]];
-    v2x = _c[tor[1]]   - _c[tor[2]];
-    v1y = _c[tor[0]+1] - _c[tor[1]+1];
-    v2y = _c[tor[1]+1] - _c[tor[2]+1];
-    v1z = _c[tor[0]+2] - _c[tor[1]+2];
-    v2z = _c[tor[1]+2] - _c[tor[2]+2];
-    v3x = _c[tor[2]]   - _c[tor[3]];
-    v3y = _c[tor[2]+1] - _c[tor[3]+1];
-    v3z = _c[tor[2]+2] - _c[tor[3]+2];
-
-
-    c1x = v1y*v2z - v1z*v2y;
-    c2x = v2y*v3z - v2z*v3y;
-    c1y = -v1x*v2z + v1z*v2x;
-    c2y = -v2x*v3z + v2z*v3x;
-    c1z = v1x*v2y - v1y*v2x;
-    c2z = v2x*v3y - v2y*v3x;
-    c3x = c1y*c2z - c1z*c2y;
-    c3y = -c1x*c2z + c1z*c2x;
-    c3z = c1x*c2y - c1y*c2x;
-
-    c1mag = SQUARE(c1x)+SQUARE(c1y)+SQUARE(c1z);
-    c2mag = SQUARE(c2x)+SQUARE(c2y)+SQUARE(c2z);
-    if (c1mag*c2mag < 0.01)
-      costheta = 1.0; //avoid div by zero error
-    else
-      costheta = (c1x*c2x + c1y*c2y + c1z*c2z)/(sqrt(c1mag*c2mag));
-
-    if (costheta < -0.999999)
-      costheta = -0.999999;
-    if (costheta >  0.999999)
-      costheta =  0.999999;
-
-    if ((v2x*c3x + v2y*c3y + v2z*c3z) > 0.0)
-      radang = -acos(costheta);
-    else
-      radang = acos(costheta);
-
-
-    double new_radang = CalcTorsionForSet(tor);
-    std::cout << new_radang << std::endl;;
-    std::cout << radang << std::endl;;
-
-    radang = new_radang;
-
+    radang = CalcTorsionAngle(a->GetVector(),
+                              b->GetVector(),
+                              c->GetVector(),
+                              d->GetVector()) / RAD_TO_DEG;
     //
     // now we have the torsion angle (radang) - set up the rot matrix
     //
@@ -379,7 +249,12 @@ namespace OpenBabel
     sn = sin(rotang);
     cs = cos(rotang);
     t = 1 - cs;
-    //normalize the rotation vector
+
+    v2x = _c[tor[1]]   - _c[tor[2]];
+    v2y = _c[tor[1]+1] - _c[tor[2]+1];
+    v2z = _c[tor[1]+2] - _c[tor[2]+2];
+
+   //normalize the rotation vector
     mag = sqrt(SQUARE(v2x)+SQUARE(v2y)+SQUARE(v2z));
     x = v2x/mag;
     y = v2y/mag;


### PR DESCRIPTION
There were numerical instability in the way dihedral angles were calculated. The formula used relied on acos(x), which is ill-posed for several values of x. The old implementation also needed a workaround for a possible division by zero. 
As a result it was for instance not possible to set a dihedral angle to 180, but only 179.974376548 at best. This means that errors can accumulate when setting and getting torsion angles multiple times.

This update uses atan2 instead of acos and thus does not need any checks or thresholds since there are no divisions and relevant issues regarding numerical stability are resolved in <math.h>.

See for instance this discussion of torsion angles on stackexchange:
http://math.stackexchange.com/questions/47059/how-do-i-calculate-a-dihedral-angle-given-cartesian-coordinates.
