### PR TITLE
add .travis.yml file for travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: cpp
+
+compiler:
+ - gcc
+ - clang
+
+before_install:
+ - sudo apt-get update -qq
+
+install:
+ - sudo apt-get install -qq swig libeigen3-dev
+
+before_script:
+ - mkdir build
+ - cd build
+ - cmake -DPYTHON_BINDINGS=ON  -DRUN_SWIG=ON ..
+
+script:
+ - make
+ - ctest


### PR DESCRIPTION
In order for the travis CI to be activated on the main openbabel repo, steps one and two on http://about.travis-ci.org/docs/user/getting-started/ must be done as well by someone with permissions for the openbabel organization. For step two, there will be a list of accounts on the left side of the page, where you can choose the openbabel organization, rather than your personal account, and then switch on the continuous integration for the openbabel official repo.

You can see example results at https://travis-ci.org/Acpharis/openbabel
