### PR TITLE
Fix garbage plugin strings bug with libc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,11 +321,6 @@ endif()
 if (${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
    set(SHARED_POINTER true)
    add_definitions(-DHAVE_SHARED_POINTER)
-   if (${CMAKE_CXX_COMPILER_VERSION} VERSION_EQUAL 5.0)
-      # there seems to be an issue with libc++ with garbage strings
-      set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
-      message(STATUS "Using libstdc++ to work around libc++ string bugs")
-   endif()
 endif()
 
 # Intel C++ Compiler

--- a/src/descriptors/groupcontrib.cpp
+++ b/src/descriptors/groupcontrib.cpp
@@ -39,11 +39,9 @@ namespace OpenBabel
    //Adds name of datafile containing SMARTS strings to the description
     static string txt;
     txt =  _descr;
-    /*
     txt += "\n Datafile: ";
     txt += _filename;
     txt += "\nOBGroupContrib is definable";
-    */
     return txt.c_str();
   }
 


### PR DESCRIPTION
With libc++, using OBDefine to load descriptors from plugindefines.txt would result in some plugin IDs and descriptions becoming garbage.

This was because plugins use const char\* pointers for their ID and description, which point towards strings stored in a vector by OBDefine. The problem was that as new strings were read from plugindefines.txt and added to the vector, reallocations can occur to expand the vector capacity, invalidating any existing const char\* created from the previously added strings using c_str().

This commit fixes this bug by reading in all descriptors from plugindefines.txt before creating the plugin instances. This ensures no changes are made to the string vector once a plugin instance has been created.
