### PR TITLE
ifdef for eigen3 in eqeq partial charges

### DIFF
--- a/src/charges/eqeq.cpp
+++ b/src/charges/eqeq.cpp
@@ -16,7 +16,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 ***********************************************************************/
 
-#ifdef HAVE_EIGEN
+#ifdef HAVE_EIGEN3
 
 #include "eqeq.h"
 #include <openbabel/locale.h>
@@ -255,7 +255,7 @@ namespace OpenBabel
 
 }//namespace
 
-#endif //HAVE_EIGEN2
+#endif //HAVE_EIGEN3
 
 //! \file eqeq.cpp
 //! \brief Assign EQEq partial charges.

--- a/src/charges/eqeq.h
+++ b/src/charges/eqeq.h
@@ -24,7 +24,7 @@ GNU General Public License for more details.
 
 #include <math.h>
 
-#ifdef HAVE_EIGEN
+#ifdef HAVE_EIGEN3
 
 #include <Eigen/LU>
 #include <Eigen/SVD>
@@ -64,5 +64,5 @@ private:
 };
 
 }; //namespace OpenBabel
-#endif //HAVE_EIGEN
+#endif //HAVE_EIGEN3
 #endif //__EQEQ_H__


### PR DESCRIPTION
mentioned on devel that eqeq does not work with eigen2.

This changes the ifdef guards to check specifically for eigen3.
