### PR TITLE
mopacformat: Skip Tv line in optimized structure

### DIFF
--- a/src/formats/mopacformat.cpp
+++ b/src/formats/mopacformat.cpp
@@ -125,12 +125,15 @@ namespace OpenBabel
             tokenize(vs,buffer);
             while (vs.size() == 8)
               {
-                atom = mol.NewAtom();
-                atom->SetAtomicNum(etab.GetAtomicNum(vs[1].c_str()));
-                x = atof((char*)vs[2].c_str());
-                y = atof((char*)vs[4].c_str());
-                z = atof((char*)vs[6].c_str());
-                atom->SetVector(x,y,z);
+                if (strcmp(vs[1].c_str(), "Tv") != 0)
+                  {
+                    atom = mol.NewAtom();
+                    atom->SetAtomicNum(etab.GetAtomicNum(vs[1].c_str()));
+                    x = atof((char*)vs[2].c_str());
+                    y = atof((char*)vs[4].c_str());
+                    z = atof((char*)vs[6].c_str());
+                    atom->SetVector(x,y,z);
+                  }
 
                 if (!ifs.getline(buffer,BUFF_SIZE))
                   break;


### PR DESCRIPTION
Translation vector line should be skipped while reading the optimized structure from a mopac output file.
