### PR TITLE
NULL check in OBUnitCell::FillUnitCell

### DIFF
--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -580,6 +580,9 @@ namespace OpenBabel
   {
     const SpaceGroup *sg = GetSpaceGroup(); // the actual space group and transformations for this unit cell
 
+    if(sg == NULL)
+      return ;
+
     // For each atom, we loop through: convert the coords back to inverse space, apply the transformations and create new atoms
     vector3 baseV, uniqueV, updatedCoordinate;
     list<vector3> transformedVectors; // list of symmetry-defined copies of the atom


### PR DESCRIPTION
This patch prevents obabel from being killed by SIGSEGV 
while converting a document with unit cell but without space group information.
