### PR TITLE
Suppress cout in CIF format unless verbose option set

### DIFF
--- a/src/formats/cifformat.cpp
+++ b/src/formats/cifformat.cpp
@@ -1441,7 +1441,7 @@ namespace OpenBabel
                   if(0!=sign) // no sign, no charge
                     {
                       if(charge==0) charge=1;
-                      cout<<tmpSymbol<<" / symbol="<<tmpSymbol.substr(0,nbc)<<" charge= "<<sign*charge<<endl;
+                      if(verbose) cout<<tmpSymbol<<" / symbol="<<tmpSymbol.substr(0,nbc)<<" charge= "<<sign*charge<<endl;
                       atom->SetFormalCharge(sign*charge);
                     }
                 }


### PR DESCRIPTION
A `cout` logging statement in cifformat.cpp was polluting stdout, which is an issue when writing the output molecule to stdout.

Also: Should all the `cout` statements in cifformat.cpp be changed to `obErrorLog`?
