### PR TITLE
Added explicit spaces in output lines of MOL2 to avoid field overflowing...

### DIFF
--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -592,11 +592,11 @@ namespace OpenBabel
             snprintf(rnum,BUFF_SIZE,"%d",res->GetNum());
           }
 
-        snprintf(buffer,BUFF_SIZE,"%7d%1s%-6s%12.4f%10.4f%10.4f%1s%-5s%4s%1s %-8s%10.4f",
-                 atom->GetIdx(),"",label,
+        snprintf(buffer,BUFF_SIZE,"%7d %-6s   %9.4f %9.4f %9.4f %-5s %3s  %-8s %9.4f",
+                 atom->GetIdx(),label,
                  atom->GetX(),atom->GetY(),atom->GetZ(),
-                 "",str1.c_str(),
-                 rnum,"",rlabel,
+                 str1.c_str(),
+                 rnum,rlabel,
                  atom->GetPartialCharge());
         ofs << buffer << endl;
       }
@@ -617,9 +617,9 @@ namespace OpenBabel
         else
           snprintf(label,BUFF_SIZE,"%d",bond->GetBO());
 
-        snprintf(buffer, BUFF_SIZE,"%6d%6d%6d%3s%2s",
+        snprintf(buffer, BUFF_SIZE,"%6d %5d %5d   %2s",
                  bond->GetIdx()+1,bond->GetBeginAtomIdx(),bond->GetEndAtomIdx(),
-                 "",label);
+                 label);
         ofs << buffer << endl;
       }
     // NO trailing blank line (PR#1868929).


### PR DESCRIPTION
Hi,

I just fixed snprintf lines that were not properly separated by spaces in MOL2 format. Since MOL2 is a space/tab delimited format unlike PDB or SDF, the spaces between fields are important for identifying fields. Without explicit spaces may produce confusing mol2 files when the length of data was equal or longer than field length specified before.

For example:
- Wrong:

```
   4561  O1D        7.4440   16.4030   38.5240 O.co21690  HEM1690     0.0000
```
- Right:

```
   4561  O1D        7.4440   16.4030   38.5240 O.co 21690  HEM1690     0.0000
```
