### PR TITLE
Set cmake policy CMP0042 to continue old behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS 1)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
   cmake_policy(SET CMP0005 OLD) # add_definitions need updating to set to NEW
-  cmake_policy(SET CMP0042 OLD)
+  if(POLICY CMP0042)
+    cmake_policy(SET CMP0042 OLD)
+  endif()
 endif()
 
 include (CheckCXXCompilerFlag)


### PR DESCRIPTION
Cmake 3.0.0 gives the following warning when compiling Open Babel on OS X:

```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   openbabel
```

To suppress the warning, policy CMP0042 needs to be set to `OLD` or `NEW` in CMakeLists.txt. This commit simply sets CMP0042 to `OLD`, to continue the pre-3.0 behaviour.

From reading the cmake documentation, it looks like setting the policy to `NEW` _should_ be fine, because CMakeLists.txt defines `CMAKE_INSTALL_NAME_DIR`, which acts as a manual override to any of the changes in default behaviour caused by the new policy. However, I think sticking with `OLD` for now would be best to maintain backwards compatibility with older versions of Cmake (just like what is already done with CMP0005).

More details here:

http://www.cmake.org/cmake/help/v3.0/policy/CMP0042.html
http://www.cmake.org/Wiki/CMake_RPATH_handling
http://www.cmake.org/Wiki/CMake/Policies
http://www.cmake.org/cmake/help/v3.0/prop_tgt/INSTALL_NAME_DIR.html
http://www.cmake.org/cmake/help/v3.0/prop_tgt/MACOSX_RPATH.html
