### PR TITLE
Improved mmCIF reading

### DIFF
--- a/src/formats/mmcifformat.cpp
+++ b/src/formats/mmcifformat.cpp
@@ -825,7 +825,8 @@ namespace OpenBabel
            for (OBAtomIterator atom_x = pmol->BeginAtoms(), atom_y = pmol->EndAtoms(); atom_x != atom_y; ++ atom_x)
              {
              OBAtom * atom = (* atom_x);
-             atom->SetVector(pCell->FractionalToCartesian(atom->GetVector()));
+             atom->SetVector(pCell->FractionalToCartesian(
+                             pCell->WrapFractionalCoordinate(atom->GetVector())));
              }
            }
          }


### PR DESCRIPTION
Replaced:

```
atom->SetVector(atom->GetX() * cell_a, atom->GetY() * cell_b, atom->GetZ() * cell_c);
```

with:

```
atom->SetVector(pCell->FractionalToCartesian(atom->GetVector()));
```

The old logic fails on non-cubic unit cells. Before on left, after on right.

![output](https://cloud.githubusercontent.com/assets/1449833/3989685/fd6c2f54-28bd-11e4-8755-15c5e208b800.png)

The other edits are whitespace - just my vim autoremoving tabs.
