### PR TITLE
Round 2: Updated IPython rendering

### DIFF
--- a/scripts/python/pybel.py
+++ b/scripts/python/pybel.py
@@ -470,10 +470,18 @@ class Molecule(object):
                    $d.imolecule.create($d, {drawingType: '%s',
                                             cameraType: '%s'});
                    $d.imolecule.draw(%s);
+
+                   $d.resizable({
+                       aspectRatio: %d / %d,
+                       resize: function (evt, ui) {
+                           $d.imolecule.renderer.setSize(ui.size.width,
+                                                         ui.size.height);
+                       }
+                   });
                });
                </script>""" % (div_id, local_path[:-3], remote_path[:-3],
                                div_id, size[0], size[1], drawing_type,
-                               camera_type, json_mol)
+                               camera_type, json_mol, size[0], size[1])
 
     def calcdesc(self, descnames=[]):
         """Calculate descriptor values.


### PR DESCRIPTION
Replaces #80. Decided on a new pull request to clean up the commit history.

Changes:
- `imolecule.min.js` uses version in openbabel/contributed - no build changes to openbabel.
- On first run, attempts to grab `imolecule.min.js` from internet and install in `~/.ipython/nbextensions`. Enables subsequent local usage if successful, falls back to remote library otherwise.
- Notebooks now statically render in e.g. nbviewer ([example](http://nbviewer.ipython.org/github/patrickfuller/nbviewer-test/blob/master/openbabel_test.ipynb)).
- Uses IPython's require.js to significantly lower memory usage for multiple molecules in one notebook.
