### PR TITLE
Add a threshold to single fragment scaling

### DIFF
--- a/src/mcdlutil.cpp
+++ b/src/mcdlutil.cpp
@@ -5406,8 +5406,8 @@ namespace OpenBabel {
     // LPW: Nearly horizontal molecules were being scaled which resulted in
     // some nonsensical structures.  This code ensures that coordinates with 
     // "almost" horizontal or vertical geometries don't get scaled.
-    bool Xeq = (abs(xMax - xMin) < 0.01);
-    bool Yeq = (abs(yMax - yMin) < 0.01);
+    bool Xeq = (fabs(xMax - xMin) < 0.01);
+    bool Yeq = (fabs(yMax - yMin) < 0.01);
     if ((Xeq) && (Yeq)) {
       for (i=0; i<atomList->size(); i++) {
         n=(*atomList)[i];


### PR DESCRIPTION
This fixes the issue described in my email:

Hi there,

When I use the following one-liner to convert in.xyz to out.svg, the CO2 molecule is incorrectly represented as three overlapping letters (so it looks like a single atom).  In the svg file, the coordinates are exactly the same.  I wonder what could be causing this?  I have tried to set all the coordinates to zero, and it gives the same result.

On the other hand, if the source is canonical SMILES then the depiction of the molecules is correct.

Thanks,
- Lee-Ping

```
python -c "import pybel ; p = pybel.readfile('xyz', 'in.xyz').next() ; p.title = 'Bottom left is supposed to be CO2' ; p.write('svg', 'out.svg', opt={'a':True})"
```

```
10
Cycle 0 Energy -433.7149076007
 C      -0.902916      -1.988988      -0.274821
 O      -0.722523      -2.463347      -1.324352
 O      -1.096398      -1.529671       0.786427
 N       1.281844       2.670488       0.052687
 C       0.707412       1.551601       0.193659
 O       0.621429       0.502822      -0.701410
 O       0.063991       1.238386       1.324166
 H       1.086408       0.727905      -1.518566
 H       1.728584       2.775041      -0.855281
 H      -0.305730       0.342851       1.262261
```

Original:
![image](https://cloud.githubusercontent.com/assets/1441560/4435612/f9b12960-474d-11e4-8d2f-867237b52841.png)

Fixed:
![image](https://cloud.githubusercontent.com/assets/1441560/4435616/208e4176-474e-11e4-9b07-0c5fef07a763.png)
