### PR TITLE
Parse HND1 etc atoms in DUD-E

### DIFF
--- a/src/formats/pdbformat.cpp
+++ b/src/formats/pdbformat.cpp
@@ -848,7 +848,8 @@ namespace OpenBabel
         // fix: #2002557
         if (atmid[0] == 'H' &&
             (atmid[1] == 'D' || atmid[1] == 'E' ||
-             atmid[1] == 'G' || atmid[1] == 'H')) // HD, HE, HG, HH, ..
+             atmid[1] == 'G' || atmid[1] == 'H' ||
+             atmid[1] == 'N')) // HD, HE, HG, HH, HN...
           type = "H";
       } else { //must be hetatm record
         if (isalpha(element[1]) && (isalpha(element[0]) || (element[0] == ' '))) {


### PR DESCRIPTION
Dock 3.7 receptor files contain HND1 etc atoms, to parse them correctly we need to accept HN\* as a hydrogen.

Eg.
ATOM     67 HN12 ARG   419      13.144  19.110  -1.468
ATOM     68 HN11 ARG   419      14.216  18.411  -2.711
ATOM     69 HN22 ARG   419      13.007  21.429  -1.225
ATOM     70 HN21 ARG   419      13.976  22.488  -2.284
