### PR TITLE
Fix normal mode parsing in Gaussian format

### DIFF
--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -806,7 +806,7 @@ namespace OpenBabel
           tokenize(vs, buffer);
           vector<vector3> vib1, vib2, vib3;
           double x, y, z;
-          while(vs.size() > 5) {
+          while(vs.size() >= 5) {
             for (unsigned int i = 2; i < vs.size()-2; i += 3) {
               x = atof(vs[i].c_str());
               y = atof(vs[i+1].c_str());


### PR DESCRIPTION
This fixes a bug in the parsing of normal modes in the Gaussian format
where values in a single column would not be parsed at all. This could
make openbabel crash in some cases.

The normal modes in the gaussian format are presented in stacked groups
of five columns.

```
 Atom AN      X      Y      Z        X      Y      Z        X      Y      Z
   1   6    -0.14   0.87   0.00     0.87   0.14   0.00     0.00   0.00   0.00
   2   8     0.05  -0.33   0.00    -0.33  -0.05   0.00     0.00   0.00   0.71
   3   8     0.05  -0.33   0.00    -0.33  -0.05   0.00     0.00   0.00  -0.71
```

The algorithm would parse the normal modes until `vs` contains less than
5 token. However, if the last set of normal modes is in a single column:

```
 Atom AN      X      Y      Z
   1   6     0.00   0.00   0.88
   2   8     0.00   0.00  -0.33
   3   8     0.00   0.00  -0.33
```

The size of `vs` actually _is_ 5, breaking the parsing loop early, and
eventually crashing openbabel.

Parsing normal modes until the columns are 'less than or equal to 5'
tokens fixes it.
