### PR TITLE
Identify frequencies with header

### DIFF
--- a/src/formats/vaspformat.cpp
+++ b/src/formats/vaspformat.cpp
@@ -392,16 +392,16 @@ namespace OpenBabel {
           while (!strstr(buffer, "Eigenvectors")) {
             vector<vector3> vib;
             tokenize(vs, buffer);
-            if (vs.size() < 2) {
-              // No more frequencies
-              break;
-            }
             int freqnum = atoi(vs[0].c_str());
-            if (strstr(vs[1].c_str(), "f/i=")) {
+            if (vs[1].size() == 1 and vs[1].compare("f") == 0) {
+              // Real frequency
+              Frequencies.push_back(atof(vs[7].c_str()));
+            } else if (strstr(vs[1].c_str(), "f/i=")) {
               // Imaginary frequency
               Frequencies.push_back(-atof(vs[6].c_str()));
             } else {
-              Frequencies.push_back(atof(vs[7].c_str()));
+              // No more frequencies
+              break;
             }
             // TODO: Intensities not parsed yet
             Intensities.push_back(0.0);


### PR DESCRIPTION
In the VASP format, frequency parsing was done until tokenization
returned less than two elements.  However, the list of displacements may
be closed with a section such as the following:

```
Finite differences POTIM=  2.000000000000000E-002
LATTYP: Found a simple tetragonal cell.
ALAT       =    12.7378929000
C/A-ratio  =     2.5701183985

Lattice vectors:
```

that would not break from the frequency-parsing loop and keep parsing
nonexisting data, eventually leading to a crash.

Instead of breaking the loop on 'less than two tokens', we check whether
the header contains one of `f/i=` or `f`, if it does not, we break
the loop.
