### PR TITLE
cppcheck: some cleanings

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -104,7 +104,7 @@ namespace OpenBabel
 
     if (buffer[0] != '#') // skip comment line (at the top)
       {
-        sscanf(buffer,"%d %4s %lf %lf %*f %lf %d %lf %lf %lf %lf %lf %lf %lf %255s",
+        sscanf(buffer,"%d %3s %lf %lf %*f %lf %d %lf %lf %lf %lf %lf %lf %lf %255s",
                &num,
                symbol,
                &ARENeg,

--- a/src/formats/cifformat.cpp
+++ b/src/formats/cifformat.cpp
@@ -860,7 +860,7 @@ namespace OpenBabel
     map<ci_string,string>::const_iterator positem;
 
     map<std::string, double> lbl2ox;
-    for(map<set<ci_string>, map<ci_string, vector<string> > >::const_iterator loop=mvLoop.begin(); loop!=mvLoop.end(); loop++)
+    for(map<set<ci_string>, map<ci_string, vector<string> > >::const_iterator loop=mvLoop.begin(); loop!=mvLoop.end(); ++loop)
     {
       //if(mvBond.size()>0) break;// Only allow one bond list
       map<ci_string,vector<string> >::const_iterator pos_symbol, pos_ox_number, posdist;
@@ -879,7 +879,7 @@ namespace OpenBabel
       }
     }
 
-    for (std::vector<CIFAtom>::iterator it = mvAtom.begin() ; it != mvAtom.end(); it++)
+    for (std::vector<CIFAtom>::iterator it = mvAtom.begin() ; it != mvAtom.end(); ++it)
     {
       string label = (*it).mLabel;
 

--- a/tools/obgen.cpp
+++ b/tools/obgen.cpp
@@ -51,7 +51,7 @@ int main(int argc,char **argv)
   list<string>::iterator optff = find(argl.begin(), argl.end(), "-ff");
   if (optff != argl.end()) {
     list<string>::iterator optffarg = optff;
-    optffarg++;
+    ++optffarg;
 
     if (optffarg != argl.end()) {
       ff = *optffarg;


### PR DESCRIPTION
Fix all Prefer prefix ++/-- operators for non-primitive type

[src/data.cpp:107]: (error) Width 4 given in format string (no. 2) is larger than destination buffer 'symbol[4]', use %3s to prevent overflowing it.
[src/formats/libinchi/ichimake.c:2088] -> [src/formats/libinchi/ichimake.c:2088]: (style) Same expression on both sides of '||'.
