### PR TITLE
Fix a performance problem with parsing PDB files that have overlapping

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -3543,7 +3543,7 @@ namespace OpenBabel
     double maxlength;
     vector<OBBond*>::iterator l;
     int valCount;
-
+    BeginModify(); //prevent needless re-perception in DeleteBond
     for (atom = BeginAtom(i);atom;atom = NextAtom(i))
       {
         while (atom->BOSum() > static_cast<unsigned int>(etab.GetMaxBonds(atom->GetAtomicNum()))
@@ -3587,7 +3587,7 @@ namespace OpenBabel
             DeleteBond(maxbond); // delete the new bond with the longest length
           }
       }
-
+    EndModify();
     if (unset)
       {
         _c = NULL;


### PR DESCRIPTION
fragments in them.  Since the fragments overlap, ConnectTheDots adds a
ton of bonds, most of which then need to be deleted (really shouldn't add any
considering there are connect records..).  The problem is that each
call to DeleteBond triggered a re-perception since it calls EndModify.

The fix is just to wrap the whole code in Being/EndModify.
The reduces the time to parse the PDB file from minutes/hours to less than a second.
