### PR TITLE
Fix normal mode parsing in molden format

### DIFF
--- a/src/formats/moldenformat.cpp
+++ b/src/formats/moldenformat.cpp
@@ -185,17 +185,20 @@ bool OBMoldenFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
          } // "[FR-COORD]"
         if( lineBuffer.find( "[FR-NORM-COORD]" ) != string::npos ) {
           getline( ifs, lineBuffer );
+          vector<string> vs;
           while( ifs && lineBuffer.find( "ibration") != string::npos )
             {
               vector<vector3> vib;
               getline( ifs, lineBuffer );
-              while( ifs && lineBuffer.find( "ibration") == string::npos )
+              tokenize(vs, lineBuffer);
+              while( ifs && vs.size() == 3)
                 {
                   istringstream is( lineBuffer );
                   double x, y, z;
                   is >> x >> y >> z;
                   vib.push_back( vector3( x, y, z ) );
                   getline( ifs, lineBuffer );
+                  tokenize(vs, lineBuffer);
                 }
               Lx.push_back( vib );
            } // while


### PR DESCRIPTION
This fixes a bug in the parsing of the normal modes in the Molden format
where the parser would keep parsing "normal modes" after the relevant
section actually ended.

This could make openbabel crash in some cases.
