### PR TITLE
Fix problem with ConnectTheDots and z-ordering.

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -3454,6 +3454,7 @@ namespace OpenBabel
                           "Ran OpenBabel::ConnectTheDots", obAuditMsg);
 
     int j,k,max;
+    double maxrad = 0;
     bool unset = false;
     OBAtom *atom,*nbr;
     vector<OBAtom*>::iterator i;
@@ -3480,6 +3481,7 @@ namespace OpenBabel
       {
         atom   = zsortedAtoms[j].first;
         rad[j] = etab.GetCovalentRad(atom->GetAtomicNum());
+        maxrad = std::max(rad[j],maxrad);
         zsorted.push_back(atom->GetIdx()-1);
       }
 
@@ -3487,6 +3489,7 @@ namespace OpenBabel
     double d2,cutoff,zd;
     for (j = 0 ; j < max ; ++j)
       {
+    	double maxcutoff = SQUARE(rad[j]+maxrad+0.45);
         idx1 = zsorted[j];
         for (k = j + 1 ; k < max ; k++ )
           {
@@ -3496,9 +3499,10 @@ namespace OpenBabel
             cutoff = SQUARE(rad[j] + rad[k] + 0.45);
 
             zd  = SQUARE(c[idx1*3+2] - c[idx2*3+2]);
-            // bigger than max cutoff
+            // bigger than max cutoff, which is determined using largest radius,
+            // not the radius of k (which might be small, ie H, and cause an early  termination)
             // since we sort by z, anything beyond k will also fail
-            if (zd > cutoff )
+            if (zd > maxcutoff )
               break;
 
             d2  = SQUARE(c[idx1*3]   - c[idx2*3]);


### PR DESCRIPTION
Z-ordering let's you terminate early if the z dimension is beyond
a cutoff.  However, the code was using the radii of the two current
atoms to determine when to terminate.  The caused problems when
one or more of the atoms were a hydrogen with a small radii.
In this case, the search terminated to early and bonds were missed.

Here's an example that fails:

ATOM    559  N   MET    38       4.134  38.514 132.609  1.00  0.00           N
ATOM    560  CA  MET    38       5.261  38.734 131.692  1.00  0.00           C
ATOM    561  C   MET    38       4.788  38.782 130.238  1.00  0.00           C
ATOM    562  O   MET    38       5.354  39.502 129.410  1.00  0.00           O
ATOM    563  CB  MET    38       6.357  37.679 131.847  1.00  0.00           C
ATOM    564  CG  MET    38       7.317  37.906 133.028  1.00  0.00           C
ATOM    565  SD  MET    38       8.106  39.531 133.230  1.00  0.00           S
ATOM    566  CE  MET    38       9.031  39.718 131.703  1.00  0.00           C
ATOM    567  H   MET    38       4.165  37.714 133.224  1.00  0.00           H
ATOM    568  HA  MET    38       5.691  39.715 131.894  1.00  0.00           H
ATOM    569  HB2 MET    38       5.853  36.720 131.969  1.00  0.00           H
ATOM    570  HB3 MET    38       6.921  37.675 130.915  1.00  0.00           H
ATOM    571  HG2 MET    38       6.724  37.684 133.915  1.00  0.00           H
ATOM    572  HG3 MET    38       8.089  37.146 132.908  1.00  0.00           H
ATOM    573  HE1 MET    38       8.346  39.686 130.856  1.00  0.00           H
ATOM    574  HE2 MET    38       9.555  40.674 131.710  1.00  0.00           H
ATOM    575  HE3 MET    38       9.755  38.908 131.614  1.00  0.00           H