### PR TITLE
Remove useless line, since NAN doesn't exist on msvc

### DIFF
--- a/src/formats/mdffformat.cpp
+++ b/src/formats/mdffformat.cpp
@@ -458,9 +458,6 @@ namespace OpenBabel {
       
       if(charge_smb.find(smb) == charge_smb.end() )
         charge_smb[smb] = it->second->GetFormalCharge();
-      else
-        if(charge_smb[smb] != it->second->GetFormalCharge())
-          charge_smb[smb] = NAN;
       
       ofs << buffer << endl;
     }


### PR DESCRIPTION
This fixes a compilation error for msvc. There's not really a consistent way that I see to define NAN in a cross platform way anyway. 