### PR TITLE
Make orca require REGEX_H (unix like)

### DIFF
--- a/src/formats/CMakeLists.txt
+++ b/src/formats/CMakeLists.txt
@@ -47,7 +47,6 @@ set(formats_compchem
       molproformat
       mopacformat
       nwchemformat
-      orcaformat
       pwscfformat
       qchemformat
       turbomoleformat
@@ -55,6 +54,13 @@ set(formats_compchem
       xsfformat
       zindoformat
   )
+
+if(HAVE_REGEX_H)
+  set(formats_compchem
+      ${formats_compchem} orcaformat
+  )
+endif(HAVE_REGEX_H)
+
 
 if(MSVC OR HAVE_REGEX_H)
   set(formats_compchem


### PR DESCRIPTION
in gamessuk <regex> can be used for windows, but this file uses
features not present in this version.