### PR TITLE
CMakeLists.txt: Allow configuring BABEL_DATADIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,9 @@ if(EMBED_OPENBABEL)
 else()
   set(BABEL_VERSION  "${BABEL_MAJ_VER}.${BABEL_MIN_VER}.${BABEL_PATCH_VER}")
 endif()
-set(BABEL_DATADIR  "${CMAKE_INSTALL_PREFIX}/share/openbabel")
+set(BABEL_DATAROOTDIR "${CMAKE_INSTALL_PREFIX}/share"
+    CACHE PATH "Install dir for arch independent data")
+set(BABEL_DATADIR  "${BABEL_DATAROOTDIR}/openbabel")
 
 option(ENABLE_VERSIONED_FORMATS
   "Enable versioning of the format plugin directory" ON)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -52,7 +52,7 @@ set(to_install
 )
 
 if(NOT MSVC)
-  install(FILES ${to_install} DESTINATION share/openbabel/${BABEL_VERSION})
+  install(FILES ${to_install} DESTINATION "${BABEL_DATADIR}/${BABEL_VERSION}")
 else(NOT MSVC)
   install(FILES ${to_install} DESTINATION bin/data)
 endif(NOT MSVC)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB man_1 *.1)
-install(FILES ${man_1} DESTINATION share/man/man1)
-install(FILES splash.png DESTINATION share/openbabel/${BABEL_VERSION})
+install(FILES ${man_1} DESTINATION "${BABEL_DATAROOTDIR}/man/man1")
+install(FILES splash.png DESTINATION "${BABEL_DATADIR}/${BABEL_VERSION}")
 
 OPTION(BUILD_DOCS "Build Open Babel documentation" OFF)
 IF(BUILD_DOCS)


### PR DESCRIPTION
This allows installing the architecture independent data outside
the prefix, for example on a multiarch layout where the prefix
is /usr/{host-triplet}.