### PR TITLE
Swig fix for python package

### DIFF
--- a/scripts/python/openbabel-python.i
+++ b/scripts/python/openbabel-python.i
@@ -229,7 +229,7 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 %include <openbabel/math/transform3d.h>
 %include <openbabel/math/spacegroup.h>
 
-# CloneData should be used instead of the following method
+%# CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
 %include <openbabel/base.h>
 
@@ -291,7 +291,7 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 %ignore OpenBabel::OBDescriptor::LessThan;
 %include <openbabel/descriptor.h>
 
-# Ignore shadowed methods
+%# Ignore shadowed methods
 %ignore OpenBabel::OBForceField::VectorSubtract(const double *const, const double *const, double *);
 %ignore OpenBabel::OBForceField::VectorMultiply(const double *const, const double, double *);
 %include <openbabel/forcefield.h>
@@ -312,7 +312,7 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 
 %warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
 %include <openbabel/bitvec.h>
-# Ignore shadowed method
+%# Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>
 %ignore OpenBabel::Swab;
@@ -323,13 +323,13 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 %include <openbabel/math/align.h>
 #endif
 
-# The following %ignores avoid warning messages due to shadowed classes.
-# This does not imply a loss of functionality as (in this case)
-# the shadowed class is identical (from the point of view of SWIG) to
-# the shadowing class.
-# This is because C++ references (&) are transformed by SWIG back into
-# pointers, so that OBAtomIter(OBMol &) would be treated the same as
-# OBAtomIter(OBMol *).
+%# The following %ignores avoid warning messages due to shadowed classes.
+%# This does not imply a loss of functionality as (in this case)
+%# the shadowed class is identical (from the point of view of SWIG) to
+%# the shadowing class.
+%# This is because C++ references (&) are transformed by SWIG back into
+%# pointers, so that OBAtomIter(OBMol &) would be treated the same as
+%# OBAtomIter(OBMol *).
 
 %ignore OBAtomAtomIter(OBAtom &);
 %ignore OBAtomBondIter(OBAtom &);
@@ -348,9 +348,9 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 %ignore OBResidueIter(OBMol &);
 %ignore OBResidueAtomIter(OBResidue &);
 
-# These classes are renamed so that they can be replaced by Python
-# classes of the same name which provide Pythonic iterators
-# (see %pythoncode section below)
+%# These classes are renamed so that they can be replaced by Python
+%# classes of the same name which provide Pythonic iterators
+%# (see %pythoncode section below)
 
 %rename(_OBAtomAtomIter) OpenBabel::OBAtomAtomIter;
 %rename(_OBAtomBondIter) OpenBabel::OBAtomBondIter;
@@ -369,8 +369,8 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 
 %include <openbabel/obiter.h>
 
-# The following class, OBiter, is subclassed to provide Python iterators
-# equivalent to the C++ iterators in obiter.h and the plugin iterators
+%# The following class, OBiter, is subclassed to provide Python iterators
+%# equivalent to the C++ iterators in obiter.h and the plugin iterators
 
 %pythoncode %{
 class OBIter(object):
@@ -460,7 +460,7 @@ def double_array(mylist):
     return c
 %}
 
-# Copy some of the global variables in cvar into the openbabel namespace
+%# Copy some of the global variables in cvar into the openbabel namespace
 
 %pythoncode %{
 obErrorLog = cvar.obErrorLog
@@ -471,7 +471,7 @@ atomtyper = cvar.atomtyper
 aromtyper = cvar.aromtyper
 %}
 
-# Functions to set the log file to std::cout and std::cerr
+%# Functions to set the log file to std::cout and std::cerr
        
 %ignore OBForceField::SetLogFile(std::ostream *pos);
 %extend OpenBabel::OBForceField {

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup, Extension
 
 __author__ = 'Noel O\'Boyle'
 __email__ = 'openbabel-discuss@lists.sourceforge.net'
-__version__ = '1.8.1'
+__version__ = '1.8.2'
 __license__ = 'GPL'
 
 


### PR DESCRIPTION
This commit updates `scripts/python/openbabel-python.i` to match recent fixes to `scripts/openbabel-python.i`. It also bumps the version number in `scripts/python/setup.py` to prepare for uploading the fixes to PyPI to fix installing the python bindings through `pip install openbabel`.