### PR TITLE
3D ipython rendering moved to pip-installable library

### DIFF
--- a/scripts/python/pybel.py
+++ b/scripts/python/pybel.py
@@ -21,8 +21,6 @@ Global variables:
 import sys
 import os.path
 import tempfile
-import json
-import uuid
 
 if sys.platform[:4] == "java":
     import org.openbabel as ob
@@ -417,78 +415,12 @@ class Molecule(object):
         if not ipython_3d:
             return None
 
-        # If the javascript files have not yet been loaded, do so
-        # IPython >=2.0 does this by copying into ~/.ipython/nbextensions
-        filename = "imolecule.min.js"
-        local_path = os.path.join("nbextensions", filename)
-        remote_path = ("https://rawgit.com/openbabel/contributed/master/web/"
-                       "imolecule/build/imolecule.min.js")
-
-        # Try using IPython >=2.0 to install js locally from website
         try:
-            from IPython.html.nbextensions import (install_nbextension,
-                                                   check_nbextension)
-            if not check_nbextension(local_path):
-                install_nbextension(remote_path, verbose=0)
-        except:
-            pass
-
-        # Some exposed parameters. Leaving this unfunctionalized for now.
-        size = (400, 300)
-        drawing_type = "ball and stick"
-        camera_type = "perspective"
-
-        # Clone molecule
-        mol = self.clone
-
-        # Infer structure in cases where the input format has no specification
-        if not mol.OBMol.HasNonZeroCoords():
-            mol.make3D()
-        mol.OBMol.Center()
-
-        # Convert the relevant parts of `self` into JSON for rendering
-        table = ob.OBElementTable()
-        atoms = [{"element": table.GetSymbol(atom.atomicnum),
-                  "location": atom.coords}
-                 for atom in mol.atoms]
-        bonds = [{"atoms": [bond.GetBeginAtom().GetIndex(),
-                            bond.GetEndAtom().GetIndex()],
-                  "order": bond.GetBondOrder()}
-                 for bond in ob.OBMolBondIter(mol.OBMol)]
-        mol = {"atoms": atoms, "bonds": bonds}
-        if hasattr(mol, "unitcell"):
-            uc = mol.unitcell
-            mol["unitcell"] = [[v.GetX(), v.GetY(), v.GetZ()]
-                               for v in uc.GetCellVectors()]
-            # Support for previous naming scheme
-            mol["periodic_connections"] = mol["unitcell"]
-        json_mol = json.dumps(mol, separators=(",", ":"))
-
-        # Try using local copy. If that fails, use remote copy.
-        div_id = uuid.uuid4()
-        return """<div id="molecule_%s"></div>
-               <script type="text/javascript">
-               requirejs.config({baseUrl: "/",
-                                 paths: {imolecule: ['%s', '%s']}});
-               require(['imolecule'], function () {
-                   var $d = $('#molecule_%s');
-                   $d.width(%d); $d.height(%d);
-                   $d.imolecule = jQuery.extend({}, imolecule);
-                   $d.imolecule.create($d, {drawingType: '%s',
-                                            cameraType: '%s'});
-                   $d.imolecule.draw(%s);
-
-                   $d.resizable({
-                       aspectRatio: %d / %d,
-                       resize: function (evt, ui) {
-                           $d.imolecule.renderer.setSize(ui.size.width,
-                                                         ui.size.height);
-                       }
-                   });
-               });
-               </script>""" % (div_id, local_path[:-3], remote_path[:-3],
-                               div_id, size[0], size[1], drawing_type,
-                               camera_type, json_mol, size[0], size[1])
+            import imolecule
+        except ImportError:
+            raise ImportError("Cannot import 3D rendering. Please install "
+                              "with `pip install imolecule`.")
+        return imolecule.draw(self.clone, format="pybel", display_html=False)
 
     def calcdesc(self, descnames=[]):
         """Calculate descriptor values.


### PR DESCRIPTION
I've had imolecule on pypi for a while, and it makes more sense to maintain that and require users to `pip install imolecule` when they want the integration. Switching moves this rendering to the most recent version, which includes things like:

 * Fallback to canvas rendering for users without webgl
 * Only renders on change
 * High-DPI screen bugfixes
 * Highlight support ([info](https://github.com/patrickfuller/imolecule/pull/7))
 * Now uses lambert renderer instead of toon

Most of these updates come from @bjonnh, so kudos go to him.