### PR TITLE
Fixed an error with the allExplicit option

### DIFF
--- a/src/depict/depict.cpp
+++ b/src/depict/depict.cpp
@@ -544,7 +544,7 @@ namespace OpenBabel
         unsigned int hCount = atom->ImplicitHydrogenCount();
         // LPW: The allExplicit option will omit the drawing of extra hydrogens
         // to fill the valence.
-        if(!(d->options & allExplicit))
+        if((d->options & allExplicit))
             hCount = 0;
         // rightAligned:
         //   false  CH3


### PR DESCRIPTION
Fixed an error with the allExplicit option where the function was opposite to what was stated. Fixed by removing the negation in test.
See line note in  https://github.com/openbabel/openbabel/commit/ba397aa5a01cd3753072fadf9535d0092dfcf784#diff-2a365bc04bfc2f8bea760bcade7466a0