### PR TITLE
Fixes #135

### DIFF
--- a/include/openbabel/inchiformat.h
+++ b/include/openbabel/inchiformat.h
@@ -104,7 +104,7 @@ public:
     "/formula   formula only\n"
     "/connect   formula and connectivity only\n"
     "/nostereo  ignore E/Z and sp3 stereochemistry\n"
-    "/sp3       ignore sp3 stereochemistry\n"
+    "/nosp3       ignore sp3 stereochemistry\n"
     "/noEZ      ignore E/Z steroeochemistry\n"
     "/nochg     ignore charge and protonation\n"
     "/noiso     ignore isotopes\n\n"

--- a/src/formats/inchiformat.cpp
+++ b/src/formats/inchiformat.cpp
@@ -277,7 +277,11 @@ bool InChIFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
 
   //Use any existing InChI, probably from an InChIformat input,
   //in preference to determining it from the structure.
-  if(!pConv->IsOption("r") && pmol->HasData("inchi"))
+  //but only if no InChI output option has been specified that would
+  //modify a standard InChI
+  if (pmol->HasData("inchi") && pConv->IsOption("r")==NULL && pConv->IsOption("a")==NULL &&
+    pConv->IsOption("s")==NULL && pConv->IsOption("X")==NULL && pConv->IsOption("F")==NULL &&
+    pConv->IsOption("M")==NULL)
   {
     //All origins for the data are currently acceptable.
     //Possibly this may need to be restricted to data with a local origin.

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -4282,6 +4282,7 @@ namespace OpenBabel {
     tokenize(vs, inchi);
     MolConv.SetInFormat(pInChIFormat);
     success = MolConv.ReadString(mol, vs.at(0));
+    mol->DeleteData("inchi"); // Tidy up this side-effect
     return success;
   }
 

--- a/src/ops/unique.cpp
+++ b/src/ops/unique.cpp
@@ -64,7 +64,7 @@ public:
     "/formula  formula only\n"
     "/connect  formula and connectivity only\n"
     "/nostereo ignore E/Z and sp3 stereochemistry\n"
-    "/sp3      ignore sp3 stereochemistry\n"
+    "/nosp3    ignore sp3 stereochemistry\n"
     "/noEZ     ignore E/Z steroeochemistry\n"
     "/nochg    ignore charge and protonation\n"
     "/noiso    ignore isotopes\n\n"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ add_definitions(-DFORMATDIR="\\"${FORMATDIR}/\\"")
 set (cpptests
      automorphism builder canonconsistent canonstable carspacegroup
      cistrans graphsym
-     implicitH lssr isomorphism rotor shuffle smiles spectrophore
+     implicitH lssr isomorphism regressions rotor shuffle smiles spectrophore
      squareplanar stereo stereoperception tetrahedral
      tetranonplanar tetraplanar uniqueid
     )
@@ -31,6 +31,7 @@ set (graphsym_parts 1 2 3 4 5)
 set (implicitH_parts 1)
 set (lssr_parts 1 2 3 4 5)
 set (isomorphism_parts 1 2 3 4 5 6 7 8)
+set (regressions_parts 1)
 set (rotor_parts 1 2 3 4)
 set (shuffle_parts 1 2 3 4 5)
 set (smiles_parts 1 2 3)

--- a/test/regressionstest.cpp
+++ b/test/regressionstest.cpp
@@ -1,0 +1,68 @@
+#include "obtest.h"
+#include <openbabel/mol.h>
+#include <openbabel/obconversion.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+using namespace OpenBabel;
+
+
+// A segfault was occuring when a Universal SMILES was output after an InChIfied SMILES.
+// This was due to short-circuit caching of InChIs on reading. The fix was to limit
+// the situations when the cached value was used, but also to delete the cached value
+// in this particular instance.
+void test_Issue135_UniversalSmiles()
+{
+  // Test writing U smiles after I smiles
+  OBConversion conv;
+  conv.SetInFormat("smi");
+  OBMol mol;
+  conv.ReadString(&mol, "C(=O)([O-])C(=O)O");
+  conv.SetOutFormat("smi");
+  conv.SetOptions("I", OBConversion::OUTOPTIONS);
+  std::string res = conv.WriteString(&mol, true);
+  OB_COMPARE(res, "C(=O)(C(=O)O)[O-]");
+  conv.SetOptions("U", OBConversion::OUTOPTIONS);
+  res = conv.WriteString(&mol, true);
+  OB_COMPARE(res, "C(=O)(C(=O)[O-])O");
+}
+
+int regressionstest(int argc, char* argv[])
+{
+  int defaultchoice = 1;
+  
+  int choice = defaultchoice;
+
+  if (argc > 1) {
+    if(sscanf(argv[1], "%d", &choice) != 1) {
+      printf("Couldn't parse that input as a number\n");
+      return -1;
+    }
+  }
+  // Define location of file formats for testing
+  #ifdef FORMATDIR
+    char env[BUFF_SIZE];
+    snprintf(env, BUFF_SIZE, "BABEL_LIBDIR=%s", FORMATDIR);
+    putenv(env);
+  #endif  
+
+  switch(choice) {
+  case 1:
+    test_Issue135_UniversalSmiles();
+    break;
+  //case N:
+  //  YOUR_TEST_HERE();
+  //  Remember to update CMakeLists.txt with the number of your test
+  //  break;
+  default:
+    cout << "Test number " << choice << " does not exist!\n";
+    return -1;
+  }
+
+  return 0;
+}
+


### PR DESCRIPTION
(1) Don't cache inchi when generating inchifield smiles
(2) Don't use cached inchi if the user specifies one of several InChI output options
(3) Add a new test file for caching (and debugging) regressions: regressionstest.cpp
(4) Drive-by fix for typo in docstrings for 'unique' op and inchiformat ("/sp3" -> "/nosp3")
(5) Add test for regression to regressionstest.cpp