### PR TITLE
Fix for failure to build JSON formats with MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,13 @@ if(ENABLE_TESTS)
   add_subdirectory(test)
 endif()
 
+# To build the JSON formats, you need to provide an import library for MSVC
+if(MSVC)
+  if (NOT JSON_LIBRARY)
+    message(STATUS "JSON formats will NOT be built. To build, specify the location of the jsoncpp library with -DJSON_LIBRARY")
+  endif()
+endif()
+
 # Should the language bindings be regenereted?
 option(RUN_SWIG "Generate language bindings with SWIG" OFF)
 

--- a/src/formats/CMakeLists.txt
+++ b/src/formats/CMakeLists.txt
@@ -77,7 +77,7 @@ if(NOT MSVC OR JSON_LIBRARY)
   )
   set(json_additional_sources json/customwriter.cpp)
   if(NOT MSVC) # With MSVC, we link to the .dll rather than compiling it in
-    set(json_additional_sources json/jsoncpp.cpp ${json_additional_source})
+    set(json_additional_sources json/jsoncpp.cpp ${json_additional_sources})
   endif()
 endif()
 

--- a/src/formats/CMakeLists.txt
+++ b/src/formats/CMakeLists.txt
@@ -69,11 +69,17 @@ if(MSVC OR HAVE_REGEX_H)
   )
 endif(MSVC OR HAVE_REGEX_H)
 
-set(formats_json
-  chemdoodlejsonformat
-  pubchemjsonformat
-)
-set(json_additional_sources json/jsoncpp.cpp json/customwriter.cpp)
+# Support JSON format with MSVC only if JSON_LIBRARY is specified
+if(NOT MSVC OR JSON_LIBRARY)
+  set(formats_json
+    chemdoodlejsonformat
+    pubchemjsonformat
+  )
+  set(json_additional_sources json/customwriter.cpp)
+  if(NOT MSVC) # With MSVC, we link to the .dll rather than compiling it in
+    set(json_additional_sources json/jsoncpp.cpp ${json_additional_source})
+  endif()
+endif()
 
 set(formats_misc
       APIInterface
@@ -302,21 +308,23 @@ if(MSVC)
                   PREFIX ""
                   SUFFIX ${MODULE_EXTENSION})
                   
-  set(jsonsources "")
-  foreach(format ${formats_json})
-    set(jsonsources ${jsonsources} json/${format}.cpp)
-  endforeach(format)
-  add_library(formats_json ${PLUGIN_TYPE} ${jsonsources} ${json_additional_sources}
-              "${openbabel_BINARY_DIR}/include/openbabel/babelconfig.h")
-  target_link_libraries(formats_json ${libs} ${XDR_LIBRARY} openbabel)
-  install(TARGETS formats_json
-          RUNTIME DESTINATION ${BIN_INSTALL_DIR}
-          LIBRARY DESTINATION ${OB_PLUGIN_INSTALL_DIR}
-          ARCHIVE DESTINATION ${OB_PLUGIN_INSTALL_DIR})
-  set_target_properties(formats_json PROPERTIES
-                        OUTPUT_NAME formats_json
-                        PREFIX ""
-                        SUFFIX ${MODULE_EXTENSION})  
+  if(JSON_LIBRARY)
+    set(jsonsources "")
+    foreach(format ${formats_json})
+      set(jsonsources ${jsonsources} json/${format}.cpp)
+    endforeach(format)
+    add_library(formats_json ${PLUGIN_TYPE} ${jsonsources} ${json_additional_sources}
+                "${openbabel_BINARY_DIR}/include/openbabel/babelconfig.h")
+    target_link_libraries(formats_json ${libs} ${JSON_LIBRARY} openbabel)
+    install(TARGETS formats_json
+            RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+            LIBRARY DESTINATION ${OB_PLUGIN_INSTALL_DIR}
+            ARCHIVE DESTINATION ${OB_PLUGIN_INSTALL_DIR})
+    set_target_properties(formats_json PROPERTIES
+                          OUTPUT_NAME formats_json
+                          PREFIX ""
+                          SUFFIX ${MODULE_EXTENSION})
+  endif(JSON_LIBRARY)
                                 
 else(MSVC)
 foreach(format ${formats_xml})


### PR DESCRIPTION
For MSVC, link against a DLL rather than compiling it in. The latter was
causing a link error which I could not resolve. Fixes #151 