### PR TITLE
Reintroduce the 'charges none' method

### DIFF
--- a/include/openbabel/plugin.h
+++ b/include/openbabel/plugin.h
@@ -566,6 +566,7 @@ public:
   // charges
   OB_STATIC_PLUGIN(GasteigerCharges, theGasteigerCharges)
   OB_STATIC_PLUGIN(MMFF94Charges, theMMFF94Charges)
+  OB_STATIC_PLUGIN(NoCharges, theNoCharges)
 #ifdef HAVE_EIGEN
   OB_STATIC_PLUGIN(QEqCharges, theQEqCharges)
   OB_STATIC_PLUGIN(QTPIECharges, theQTPIECharges)

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -413,6 +413,7 @@ std::vector<std::string> EnableStaticPlugins()
   // charges
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGasteigerCharges)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theMMFF94Charges)->GetID());
+  plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theNoCharges)->GetID());
 #ifdef HAVE_EIGEN
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theQEqCharges)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theQTPIECharges)->GetID());


### PR DESCRIPTION
Hi,

The "charges none" method seems to have been removed at some point.
I'd like to re-introduce it, as we have a dependency on it.

Matt