### PR TITLE
Add partialcharge method "fromfile"

### DIFF
--- a/include/openbabel/chargemodel.h
+++ b/include/openbabel/chargemodel.h
@@ -38,7 +38,7 @@ class OBAPI OBChargeModel : public OBPlugin
 
     /// \return whether partial charges were successfully assigned to this molecule
     /// \note The method should fill m_partialCharges and m_formalCharges as well
-    virtual bool ComputeCharges(OBMol &) { return false; }
+    virtual bool ComputeCharges(OBMol &, const char *args=NULL) { return false; }
 
     /// \return a vector of the formal charges on each atom, indexed from 0
     /// This method returns floating point formal charges since some

--- a/include/openbabel/plugin.h
+++ b/include/openbabel/plugin.h
@@ -566,6 +566,8 @@ public:
   // charges
   OB_STATIC_PLUGIN(GasteigerCharges, theGasteigerCharges)
   OB_STATIC_PLUGIN(MMFF94Charges, theMMFF94Charges)
+  OB_STATIC_PLUGIN(NoCharges, theNoCharges)
+  OB_STATIC_PLUGIN(FromFileCharges, theFromFileCharges)
 #ifdef HAVE_EIGEN
   OB_STATIC_PLUGIN(QEqCharges, theQEqCharges)
   OB_STATIC_PLUGIN(QTPIECharges, theQTPIECharges)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(charges
   charges/gasteiger.cpp
   charges/none.cpp
   charges/mmff94.cpp
+  charges/fromfile.cpp
 )
 
 if (EIGEN2_FOUND OR EIGEN3_FOUND)

--- a/src/charges/fromfile.cpp
+++ b/src/charges/fromfile.cpp
@@ -1,0 +1,159 @@
+/**********************************************************************
+	fromfile.cpp - A OBChargeModel to apply charges specified in a file
+
+	Copyright (C) 2015 M J Harvey, Acellera Ltd
+	m.j.harvey (at) acellera.com
+
+	This file is part of the Open Babel project.
+	For more information, see <http://openbabel.org/>
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation version 2 of the License.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+ ***********************************************************************/
+
+#include <openbabel/babelconfig.h>
+#include <openbabel/chargemodel.h>
+#include <openbabel/mol.h>
+#include <openbabel/molchrg.h>
+#include <openbabel/obconversion.h>
+#include <openbabel/obmolecformat.h>
+
+#include <openbabel/obiter.h>
+#include <openbabel/data.h>
+
+
+using namespace std;
+
+namespace OpenBabel
+{
+
+	class FromFileCharges : public OBChargeModel
+	{
+		public:
+			FromFileCharges(const char* ID) : OBChargeModel(ID, false){
+			};
+
+			const char* Description(){ return "Assign charges from file containing {'atom-name', charge} pairs"; }
+
+			bool ComputeCharges(OBMol &mol, const char *arg );
+
+	};
+
+	/////////////////////////////////////////////////////////////////
+	FromFileCharges theFromFileCharges("fromfile"); //Global instance
+
+	bool read_file( const char *file, std::map< std::string, double> &q_by_name ) {
+		char name[17];
+		double q;
+
+		FILE *fin = fopen( file, "r" );
+
+		if( !fin ) {
+			stringstream msg;
+			msg << "Cannot open file " << file << endl;
+			obErrorLog.ThrowError(__FUNCTION__, msg.str(), obError);
+			return false;
+		}
+		while( 2 == fscanf( fin, "%16s %lf\n", name, &q ) ) {
+			q_by_name.insert( std::pair<std::string, double>( string(name), q) );
+		}
+		fclose( fin );
+
+		return true;
+	}
+
+	/////////////////////////////////////////////////////////////////
+
+	bool FromFileCharges::ComputeCharges(OBMol &mol, const char *arg )
+	{
+
+		if( !arg ) {
+			stringstream msg;
+			msg << "Charge file argument required:" << endl
+				<< "\tbabel --partialcharge fromfile:/path/to/file"<< endl
+				<< "File format is one 'atom-name charge' pair per line, eg:"<<endl
+				<< "\tC1\t1.0" << endl
+				<< "\tO2\t-1.5" << endl;
+			obErrorLog.ThrowError(__FUNCTION__, msg.str(), obError);
+			return false;
+		}
+
+		std::map< std::string,  double> q_by_name;
+		if( !read_file( arg, q_by_name ) ) {
+			return false;
+		}
+
+
+		mol.SetPartialChargesPerceived();
+
+
+		for ( int i = 1; i <= mol.NumAtoms(); i++)
+		{
+			OBAtom *a = mol.GetAtom(i);
+
+			OBResidue *res;
+			double q   = 0.;
+			bool found = false;
+			char *name = NULL;
+
+			// First try atom type name
+			if ( (res = a->GetResidue()) != 0 )
+			{
+				char *f = name  = (char*)res->GetAtomID( a ).c_str();
+				for( int j = strlen(f)-1; j>=0; j-- ) { if( f[j]==' ' ){ f[j]='\0'; } } // trim trailing whitespace
+				std::string ff = string(f);
+				if( q_by_name.count( ff ) ) {
+					q = q_by_name[ string(ff) ];
+					found = true;
+				}
+			}
+			// Then try the element symbol
+			if( !found ) {
+				std::string ff  = string( etab.GetSymbol(a->GetAtomicNum()) );
+				if( q_by_name.count( ff ) ) {
+					q = q_by_name[ string(ff) ];
+					found = true;
+				}
+			}
+			// Finally "*" wildcard
+			if( !found ) {
+				std::string ff  = string("*");
+				if( q_by_name.count( "*" ) ) {
+					q = q_by_name[ string(ff) ];
+					found = true;
+				}
+			}
+
+			if( !found ) {
+				stringstream msg;
+				msg << "Charge mapping for atom # " << i ;
+				if( name ) {
+					msg << " (" << name <<") ";
+				}
+				msg << "not found " <<  endl;  
+				obErrorLog.ThrowError(__FUNCTION__, msg.str(), obError);
+				return false;
+			}
+
+			a->SetPartialCharge( q );
+
+		}
+
+		OBPairData *dp = new OBPairData;
+		dp->SetAttribute("PartialCharges");
+		dp->SetValue("User Charges");
+		dp->SetOrigin(perceived);
+		mol.SetData(dp);
+
+		OBChargeModel::FillChargeVectors(mol);
+
+		return true;
+	}
+
+}//namespace

--- a/src/ops/partialcharges.cpp
+++ b/src/ops/partialcharges.cpp
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 #include<openbabel/chargemodel.h>
 #include <openbabel/obconversion.h>
 
+#include <string.h>
 namespace OpenBabel
 {
 
@@ -46,18 +47,33 @@ OpPartialCharge theOpPartialCharge("partialcharge"); //Global instance
 /////////////////////////////////////////////////////////////////
 bool OpPartialCharge::Do(OBBase* pOb, const char* OptionText, OpMap* pOptions, OBConversion* pConv)
 {
+	char *arg = NULL;
+	const char *tok1= NULL; 
+ 	const char *tok2= NULL; 
   OBMol* pmol = dynamic_cast<OBMol*>(pOb);
+
   if(!pmol)
     return false;
 
-  _pChargeModel = OBChargeModel::FindType(OptionText);
+
+	if( OptionText ) { 
+		arg = strdup( OptionText ); 
+		tok1 = strtok( arg, ":" );
+		tok2 = strtok( NULL, "\0" );
+	}
+	else {
+		tok1 = OptionText;
+	}
+	
+  _pChargeModel = OBChargeModel::FindType(tok1);
+
+	
   if(!_pChargeModel)
     {
       obErrorLog.ThrowError(__FUNCTION__,
-                            std::string("Unknown charge model ") + OptionText, obError, onceOnly);
-      return false;
+                            std::string("Unknown charge model ") + tok1, obError, onceOnly);
+			return false;
     }
-
-  return _pChargeModel->ComputeCharges(*pmol);
+  return _pChargeModel->ComputeCharges(*pmol, tok2);
 }
 }//namespace

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -413,6 +413,8 @@ std::vector<std::string> EnableStaticPlugins()
   // charges
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGasteigerCharges)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theMMFF94Charges)->GetID());
+  plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theNoCharges)->GetID());
+  plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theFromFileCharges)->GetID());
 #ifdef HAVE_EIGEN
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theQEqCharges)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theQTPIECharges)->GetID());


### PR DESCRIPTION
Applies per-atomtype/element charges specified in a file, eg:
babel --partialcharge fromfile:mapping.txt -i mol2 in.mol2 -o mol2 out.mol2

$ cat mapping.txt
C1   1.0
C2   0.5
O1  -1.0
etc