### PR TITLE
Patch QM code input generator

### DIFF
--- a/include/openbabel/plugin.h
+++ b/include/openbabel/plugin.h
@@ -421,6 +421,8 @@ public:
   OB_STATIC_PLUGIN(GaussianOutputFormat, theGaussianOutputFormat)
   OB_STATIC_PLUGIN(GaussianInputFormat, theGaussianInputFormat)
   OB_STATIC_PLUGIN(GaussianZMatrixInputFormat, theGaussianZMatrixInputFormat)
+  OB_STATIC_PLUGIN(GaussianGQMInputFormat, theGaussianGenericQMInputFormat)
+  OB_STATIC_PLUGIN(PSI4GQMInputFormat, thePSI4GenericQMInputFormat)
   OB_STATIC_PLUGIN(GenBankFormat, theGenBankFormat)
   OB_STATIC_PLUGIN(GhemicalFormat, theGhemicalFormat)
   OB_STATIC_PLUGIN(GROFormat, theGROFormat)

--- a/src/formats/formats.cmake
+++ b/src/formats/formats.cmake
@@ -29,6 +29,9 @@ set(formats_compchem
       gaussformat
       gausscubeformat
       gausszmatformat
+      genericqminputformat
+      gaussiangenericqminputformat
+      psi4genericqminputformat
       gulpformat
       hinformat
       jaguarformat

--- a/src/formats/gaussiangenericqminputformat.cpp
+++ b/src/formats/gaussiangenericqminputformat.cpp
@@ -99,26 +99,38 @@ namespace OpenBabel
 		os << "# " << theory << "/" << basis  << endl; 
 		switch( opt ) {
 			case OPT_NONE:
+				if( frozen.size() ) {
+					os << "# opt(modredundant)" << endl;
+				}
 				break;
 			case OPT_NORMAL: 
-				os << "# opt"  <<endl; 
+				os << "# opt" ; 
+				if( frozen.size() ) {
+					os << "(modredundant)";
+				}
+				os << endl;
 				break;
 			case OPT_LOOSE:  
-				os << "# opt=loose" <<endl ; 
+				os << "# opt(loose" ; 
+				if( frozen.size() ) {
+					os << ",modredundant";
+				}
+				os << ")" << endl;
 				break;
 			case OPT_TIGHT:  
-				os << "# opt=tight" <<endl ; 
+				os << "# opt(tight" ; 
+				if( frozen.size() ) {
+					os << ",modredundant";
+				}
+				os << ")" << endl;
 				break;
 			default:
 				return false;
 		}
-
+		
 
 		os << "# symmetry=None" << endl ;
 
-		if( frozen.size() ) {
-			os << "# modredundant" << endl;
-		}
 
 		if( espgrid ) {
 			os << "# prop=(read,field)"  << endl;
@@ -155,7 +167,7 @@ namespace OpenBabel
 
 			for( std::vector< std::vector<int> >::iterator i = frozen.begin(); i!=frozen.end(); i++ ) {
 
-				if( i->size() == 3 ) {
+				if( i->size() == 4 ) {
 					os << "D " << (*i)[0] << " " << (*i)[1] << " " <<  (*i)[2] << " " << (*i)[3] << " F" << endl ;
 				}
 			}

--- a/src/formats/gaussiangenericqminputformat.cpp
+++ b/src/formats/gaussiangenericqminputformat.cpp
@@ -1,0 +1,177 @@
+//
+// GaussianGQMInput Input file writer for Open Babel
+// Copyright (C) 2015 M J Harvey, 
+// Acellera Ltd 
+// m.j.harvey ( at ) acellera.com
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+// MA  02110-1301, USA.
+//
+// $Author$
+// $Date$
+// $Revision$
+//
+
+
+#include <openbabel/mol.h>
+#include <openbabel/obconversion.h>
+#include <openbabel/obmolecformat.h>
+
+#include <openbabel/obiter.h>
+#include <openbabel/data.h>
+
+#include "genericqminputformat.h"
+
+#include <iostream>
+#include <iomanip>
+
+#include <stdlib.h>
+#include <math.h>
+
+using namespace std;
+
+namespace OpenBabel
+{
+
+
+	class GaussianGQMInputFormat : public GenericQMInputFormat
+	{
+		public:
+			GaussianGQMInputFormat() : GenericQMInputFormat( "Gaussian", "gaussianin" ) {
+			}
+
+			virtual const char* SpecificationURL() {
+
+				return "http://www.gaussian.com/g_tech/g09ur.htm";
+			}
+
+			virtual bool WriteMolecule( OpenBabel::OBBase* , OpenBabel::OBConversion* );
+	};
+
+
+	// Global variable used to register GaussianGQMInput format.
+	GaussianGQMInputFormat theGaussianGenericQMInputFormat;
+
+
+
+	//------------------------------------------------------------------------------
+	bool GaussianGQMInputFormat::WriteMolecule( OBBase* pOb, OBConversion* pConv )
+	{
+		char line[80];
+		if( ! ParseOptions( pOb, pConv ) ) {
+			return false;
+		}
+
+		OBMol* mol = dynamic_cast< OBMol* >(pOb);
+		if( mol == 0 ) return false;
+
+		ostream& os = *pConv->GetOutStream();
+
+		double q = 0.;
+
+		FOR_ATOMS_OF_MOL(atom, mol) {
+			q += atom->GetPartialCharge();
+		}
+
+		int qi = (int) round(q);
+
+		os << std::setprecision(10);
+		os << "%nprocshared="  << ncpus << endl;
+		os << "%mem="  << mem << "GB" << endl;
+		os << "%chk = chk" << endl;
+		os << "%nosave" << endl;
+		os << endl;
+
+		// the route
+
+		os << "# " << theory << "/" << basis  << endl; 
+		switch( opt ) {
+			case OPT_NONE:
+				break;
+			case OPT_NORMAL: 
+				os << "# opt"  <<endl; 
+				break;
+			case OPT_LOOSE:  
+				os << "# opt=loose" <<endl ; 
+				break;
+			case OPT_TIGHT:  
+				os << "# opt=tight" <<endl ; 
+				break;
+			default:
+				return false;
+		}
+
+
+		os << "# symmetry=None" << endl ;
+
+		if( frozen.size() ) {
+			os << "# modredundant" << endl;
+		}
+
+		if( espgrid ) {
+			os << "# prop=(read,field)"  << endl;
+		}
+
+
+		os << endl;
+		os << "MOL" << endl;
+		os << endl;
+
+		os << qi << " " << mult << endl;
+
+		FOR_ATOMS_OF_MOL(a, mol) {
+			double *c = a->GetCoordinate();
+			sprintf( line, "%s %f %f %f", etab.GetSymbol(a->GetAtomicNum()), c[0], c[1], c[2] ); 
+			os <<  line << endl;
+		}
+
+
+		os << endl;
+
+		if( frozen.size() ) {
+			for( std::vector< std::vector<int> >::iterator i = frozen.begin(); i!=frozen.end(); i++ ) {
+				if( i->size() == 2 ) {
+					os << "B " << (*i)[0] << " " << (*i)[1] << " F" << endl ;
+				}
+			}
+
+			for( std::vector< std::vector<int> >::iterator i = frozen.begin(); i!=frozen.end(); i++ ) {
+				if( i->size() == 3 ) {
+					os << "A " << (*i)[0] << " " << (*i)[1] << " " <<  (*i)[2] <<" F" << endl ;
+				}
+			}
+
+			for( std::vector< std::vector<int> >::iterator i = frozen.begin(); i!=frozen.end(); i++ ) {
+
+				if( i->size() == 3 ) {
+					os << "D " << (*i)[0] << " " << (*i)[1] << " " <<  (*i)[2] << " " << (*i)[3] << " F" << endl ;
+				}
+			}
+
+		}
+		else {
+			os << endl;
+		}
+
+		if( espgrid ) {
+			os << "@grid.dat /N" << endl;
+			os << endl;
+		}
+
+		os.flush();
+
+		return true;
+	}
+}

--- a/src/formats/genericqminputformat.cpp
+++ b/src/formats/genericqminputformat.cpp
@@ -1,0 +1,238 @@
+//
+// Generic QM Input file writer for Open Babel
+// Copyright (C) 2015 M J Harvey, 
+// Acellera Ltd 
+// m.j.harvey ( at ) acellera.com
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+// MA  02110-1301, USA.
+//
+// $Author$
+// $Date$
+// $Revision$
+//
+
+
+#include <openbabel/mol.h>
+#include <openbabel/obconversion.h>
+#include <openbabel/obmolecformat.h>
+
+#include <openbabel/obiter.h>
+#include <openbabel/data.h>
+
+#include <iostream>
+#include <iomanip>
+
+#include <stdlib.h>
+#include <math.h>
+
+#include "genericqminputformat.h"
+
+using namespace std;
+
+
+namespace OpenBabel {
+
+	GenericQMInputFormat::GenericQMInputFormat( const char *format_name, const char *type )
+	{
+		format_type = strdup( format_name );
+		OpenBabel::OBConversion::RegisterFormat( type, this );
+		OBConversion::RegisterOptionParam("B"      , this, 1, OBConversion::OUTOPTIONS);
+		OBConversion::RegisterOptionParam("T"      , this, 1, OBConversion::OUTOPTIONS);
+		OBConversion::RegisterOptionParam("E"      , this, 0, OBConversion::OUTOPTIONS);
+		OBConversion::RegisterOptionParam("M"      , this, 1, OBConversion::OUTOPTIONS);
+		OBConversion::RegisterOptionParam("O"      , this, 1, OBConversion::OUTOPTIONS);
+		OBConversion::RegisterOptionParam("F"      , this, 1, OBConversion::OUTOPTIONS);
+		OBConversion::RegisterOptionParam("m"      , this, 1, OBConversion::OUTOPTIONS);
+		OBConversion::RegisterOptionParam("p"      , this, 1, OBConversion::OUTOPTIONS);
+
+		basis_default = string("6-31g*");
+		theory_default= string("rhf");
+
+		basis_sets.insert( std::pair<string,string>(string(basis_default) , string(basis_default )) );
+		basis_sets.insert( std::pair<string,string>(string("cc-pvdz"), string ("cc-pvdz" )) );
+
+		theory_sets.insert( std::pair<string,string>(string(theory_default), string (theory_default) ) );
+		theory_sets.insert( std::pair<string,string>(string("rohf"), string ("rohf" ) ) );
+		theory_sets.insert( std::pair<string,string>(string("uhf"), string ("uhf" ) ) );
+		theory_sets.insert( std::pair<string,string>(string("b3lyp"), string ("b3lyp" ) ) );
+
+		mult  = 1;
+		espgrid = false;
+		mem   = 2;
+		ncpus = 1;
+		basis = basis_default;
+		theory= theory_default;
+		opt   = OPT_NONE;
+	}
+
+	/// Return description.
+	const char* GenericQMInputFormat::Description() 
+	{
+		stringstream o; 
+		o << "Generate a " << format_type << " Input file. \n"
+			<< "Write Options:\n"
+			<<	 "  T<theory>            Theory level for calculation. Options:   (" << theory_default << ")\n";
+
+		for( std::map<string,string>::iterator i = theory_sets.begin(); i != theory_sets.end(); i++ ) {
+			o << "                         " << i->first << "\n";
+		}
+
+		o	<<	 "  B<basis-set>         Basis set for calculation. Options:   (" << basis_default << ")\n";
+
+		for( std::map<string,string>::iterator i = basis_sets.begin(); i != basis_sets.end(); i++ ) {
+			o << "                         " << i->first << "\n";
+		}
+
+		o <<  "  M#                   Multiplicity of the molecule          (default 1)\n"
+			<<  "  E                    Calculate field and potential on points from grid.dat\n"
+			<<  "  O<type>              Optimise geometry. Options:           (default none)\n"
+			<<  "                         none  loose  normal  tight\n"
+			<<  "  F<...>               List of bonds, angles and dihedrals to freeze\n"
+			<<  "                       Atoms indexed from 1, comma-separated.\n"
+			<<  "                       Each term colon-separated.\n"
+			<<  "                       Eg freezing one angle, one dihedral: \n"
+			<<  "                          -xF 1,2,3:3,5,6,7\n"
+			<<  "  m#                   Amount of memory to allocate (GB)     (default 2.0)\n"
+			<<  "  n#                   Number of CPUs/threads to allocate    (default 1)\n\n";
+		return strdup( o.str().c_str() );
+	}
+
+	/// Return read/write flag: read only.
+	unsigned int GenericQMInputFormat::Flags()
+	{
+		return WRITEONEONLY | NOTREADABLE;
+	};
+
+	/// Skip to object: used for multi-object file formats.
+	int GenericQMInputFormat::SkipObjects( int n, OpenBabel::OBConversion* pConv ) { return 0; }
+
+	/// Read: always return false.
+	bool GenericQMInputFormat::ReadMolecule( OpenBabel::OBBase*, OpenBabel::OBConversion* )
+	{
+		return false;
+	}
+
+	//==============================================================================
+
+	static bool parse_freeze( const char *args_x, int natoms, std::vector< std::vector<int> > &frozen ) {
+		char *args = strdup( args_x );
+		char *tmp1;
+		char *tmp2;
+		char *entry;
+		bool retval = false;
+
+		entry = strtok_r( args, ":", &tmp1 );
+		while( entry != NULL ) {
+			char *field = strtok_r( entry, ",", &tmp2 );
+			std::vector<int> idx;
+			int cnt=0;
+			while( cnt<4 && ( field!=NULL ) ) {
+				idx.push_back( atoi( field ) );
+				if( idx[cnt]<1 || idx[cnt]>natoms ) { goto err; } // invalid index
+				cnt++;
+				field = strtok_r( NULL, ",", &tmp2 );
+			} 
+			frozen.push_back( idx );
+			if( strtok_r( NULL, ",", &tmp2 ) ) { 
+				// one of the entries was too long
+				goto err;
+			}
+			if( idx[0] < 1 ) {
+				// one of the entries was too short or invalid index (<1)
+				goto err;
+			}
+			entry = strtok_r( NULL, ":", &tmp1 );
+		}
+
+		retval = true;
+err:
+		free( args );
+		return retval;
+	}
+
+	//------------------------------------------------------------------------------
+
+	bool GenericQMInputFormat::ParseOptions( OBBase *pOb, OBConversion *pConv ) {
+		OBMol* mol = dynamic_cast< OBMol* >(pOb);
+		if( mol == 0 ) return false;
+
+		if( pConv->IsOption( "M" , OBConversion::OUTOPTIONS ) ) {
+			mult = atoi( pConv->IsOption( "M", OBConversion::OUTOPTIONS) );
+			if( mult < 1 ) {
+				obErrorLog.ThrowError(__FUNCTION__, "Invalid value for argument 'M'", obError );
+				return false;
+			}
+		}
+		if( pConv->IsOption( "E" , OBConversion::OUTOPTIONS ) ) {
+			espgrid = true;
+		}
+		if( pConv->IsOption( "O" , OBConversion::OUTOPTIONS ) ) {
+			const char *o = pConv->IsOption("O", OBConversion::OUTOPTIONS);
+			if     ( !strcmp( o, "none"  ) ) { opt = OPT_NONE  ; }
+			else if( !strcmp( o, "loose" ) ) { opt = OPT_LOOSE ; }
+			else if( !strcmp( o, "normal") ) { opt = OPT_NORMAL; }
+			else if( !strcmp( o, "tight" ) ) { opt = OPT_TIGHT ; }
+			else if( !strlen( o ) ) { opt = OPT_NORMAL; }
+			else {
+				obErrorLog.ThrowError(__FUNCTION__, "Invalid value for argument 'O'", obError );
+				return false;
+			}
+		}
+
+
+		if( pConv->IsOption( "m" , OBConversion::OUTOPTIONS ) ) {
+			mem = atoi( pConv->IsOption( "m", OBConversion::OUTOPTIONS) );
+			if( mem < 1 ) {
+				obErrorLog.ThrowError(__FUNCTION__, "Invalid value for argument 'm'", obError );
+				return false;
+			}
+		} 
+		if( pConv->IsOption( "p" , OBConversion::OUTOPTIONS ) ) {
+			ncpus = atoi( pConv->IsOption( "p", OBConversion::OUTOPTIONS) );
+			if( ncpus < 1 ) {
+				obErrorLog.ThrowError(__FUNCTION__, "Invalid value for argument 'p'", obError );
+				return false;
+			}
+		} 
+
+		if( pConv->IsOption( "T" , OBConversion::OUTOPTIONS ) ) {
+			theory = string( pConv->IsOption("T" , OBConversion::OUTOPTIONS ) );
+			if( ! theory_sets.count( theory ) ) {
+				obErrorLog.ThrowError(__FUNCTION__, "Invalid value for argument 'T'", obError );
+				return false;
+			}
+		}
+
+
+		if( pConv->IsOption( "B" , OBConversion::OUTOPTIONS ) ) {
+			basis = string( pConv->IsOption("B" , OBConversion::OUTOPTIONS ) );
+			if( ! basis_sets.count( basis ) ) {
+				obErrorLog.ThrowError(__FUNCTION__, "Invalid value for argument 'B'", obError );
+				return false;
+			}
+		}
+
+		if( pConv->IsOption( "F" , OBConversion::OUTOPTIONS ) ) {
+			if( ! parse_freeze( pConv->IsOption( "F" , OBConversion::OUTOPTIONS ), mol->NumAtoms(), frozen ) ) {
+				obErrorLog.ThrowError(__FUNCTION__, "Invalid value for argument 'F'", obError );
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+}

--- a/src/formats/genericqminputformat.h
+++ b/src/formats/genericqminputformat.h
@@ -1,0 +1,99 @@
+//
+// Generic QM Input file writer for Open Babel
+// Copyright (C) 2015 M J Harvey, 
+// Acellera Ltd 
+// m.j.harvey ( at ) acellera.com
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+// MA  02110-1301, USA.
+//
+// $Author$
+// $Date$
+// $Revision$
+//
+
+
+#ifndef __GENERICQMINPUT_H 
+#define __GENERICQMINPUT_H 1
+
+#include <openbabel/mol.h>
+#include <openbabel/obconversion.h>
+#include <openbabel/obmolecformat.h>
+
+#include <openbabel/obiter.h>
+#include <openbabel/data.h>
+
+#include <iostream>
+#include <iomanip>
+
+#include <stdlib.h>
+#include <math.h>
+
+using namespace std;
+
+namespace OpenBabel
+{
+
+
+	//==============================================================================
+	/// Class to output a point cloud on a surface around a molecule
+
+	enum OPT_t  { OPT_NONE, OPT_LOOSE, OPT_NORMAL, OPT_TIGHT  };
+
+	class GenericQMInputFormat : public OpenBabel::OBMoleculeFormat
+	{
+		protected:
+
+
+			std::map<string, string> basis_sets;
+			std::map<string, string> theory_sets;
+			string basis_default;
+			string theory_default;
+			const char *format_type;
+
+
+			// the parsed arguments are stored in these
+			int  mult     ; //= 1;
+			bool espgrid  ; //= false;
+			int  mem      ; //= 2;
+			int  ncpus    ; //= 1;
+			std::vector<std::vector<int> > frozen;
+			string  basis ; // =  basis_default;
+			string  theory;
+			int  opt      ; //= OPT_NONE;
+
+
+		public:
+			GenericQMInputFormat( const char *format_name, const char *type );
+			/// Return description.
+			virtual const char* Description() ;
+
+			/// Return read/write flag: read only.
+			virtual unsigned int Flags();
+
+			/// Skip to object: used for multi-object file formats.
+			virtual int SkipObjects( int n, OpenBabel::OBConversion* pConv );
+
+			/// Read: always return false.
+			virtual bool ReadMolecule( OpenBabel::OBBase*, OpenBabel::OBConversion* );
+
+			/// Write.
+			//	virtual bool WriteMolecule( OpenBabel::OBBase* , OpenBabel::OBConversion* );
+
+			bool ParseOptions( OBBase *pOb, OBConversion *pConv ) ;
+	};
+
+}
+#endif

--- a/src/formats/psi4genericqminputformat.cpp
+++ b/src/formats/psi4genericqminputformat.cpp
@@ -1,0 +1,193 @@
+//
+// PSI4GQMInput Input file writer for Open Babel
+// Copyright (C) 2015 M J Harvey, 
+// Acellera Ltd 
+// m.j.harvey ( at ) acellera.com
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+// MA  02110-1301, USA.
+//
+// $Author$
+// $Date$
+// $Revision$
+//
+
+
+#include <openbabel/mol.h>
+#include <openbabel/obconversion.h>
+#include <openbabel/obmolecformat.h>
+
+#include <openbabel/obiter.h>
+#include <openbabel/data.h>
+
+#include "genericqminputformat.h"
+
+#include <iostream>
+#include <iomanip>
+
+#include <stdlib.h>
+#include <math.h>
+
+using namespace std;
+
+namespace OpenBabel
+{
+
+
+	class PSI4GQMInputFormat : public GenericQMInputFormat
+	{
+		public:
+			PSI4GQMInputFormat() : GenericQMInputFormat( "PSI4", "psi4in" ) {
+			}
+
+			virtual const char* SpecificationURL() {
+
+				return "http://sirius.chem.vt.edu/psi4manual/latest/index.html";
+			}
+
+			virtual bool WriteMolecule( OpenBabel::OBBase* , OpenBabel::OBConversion* );
+	};
+
+
+	// Global variable used to register PSI4GQMInput format.
+	PSI4GQMInputFormat thePSI4GenericQMInputFormat;
+
+
+
+	//------------------------------------------------------------------------------
+	bool PSI4GQMInputFormat::WriteMolecule( OBBase* pOb, OBConversion* pConv )
+	{
+		char line[100];
+		if( ! ParseOptions( pOb, pConv ) ) {
+			return false;
+		}
+
+		OBMol* mol = dynamic_cast< OBMol* >(pOb);
+		if( mol == 0 ) return false;
+
+		ostream& os = *pConv->GetOutStream();
+
+		bool is_hf = ( theory.find("hf") != string::npos );
+
+		double q = 0.;
+
+		FOR_ATOMS_OF_MOL(atom, mol) {
+			q += atom->GetPartialCharge();
+		}
+
+		int qi = (int) round(q);
+
+		os << std::setprecision(10);
+
+		if( is_hf ) {
+			os << "set reference "<<theory << endl;
+		}
+		os << "set basis " << basis << endl << endl;
+
+
+
+		os << "try:" <<endl;
+		os << "\tmem = int(os.getenv(\"MEM\") ) * 1.e9" << endl;
+		os << "except:" << endl;
+		os << "\tmemory "<< mem << " gb" << endl << endl;
+
+		os << "try:" <<endl;
+		os << "\tset_num_threads( int(os.getenv(\"NCPUS\") ) )" << endl ;
+		os << "except:" << endl;
+		os << "\tset_num_threads(" << ncpus << ")" << endl << endl;
+
+		os << "molecule MOL {" << endl; 
+		os << "\t" << qi <<" " << mult << endl;
+
+
+		FOR_ATOMS_OF_MOL(a, mol) {
+			double *c = a->GetCoordinate();
+			sprintf( line, "\t%s\t%f\t%f\t%f", etab.GetSymbol(a->GetAtomicNum()) , c[0], c[1], c[2] );
+			os << line << endl;
+		}
+		os << "\tsymmetry c1" << endl;
+		os << "}" << endl;
+
+		switch( opt ) {
+			case OPT_LOOSE:
+				os << "set optking { g_convergence = \"GAU_LOOSE\" }" << endl;
+				break;
+			case OPT_TIGHT:
+				os << "set optking { g_convergence = \"GAU_TIGHT\" }" << endl;
+				break;
+		}
+
+		if( frozen.size() ) {
+			bool first= true;
+			os << "set optking { frozen_distance = \" ";
+			for( std::vector< std::vector<int> >::iterator i = frozen.begin(); i!=frozen.end(); i++ ) {
+				if( i->size() == 2 ) {
+					if( !first ) { os << " , "; }
+					os << (*i)[0] << " " << (*i)[1] ;
+					first = false;
+				}
+			}
+			os << " \" }" << endl;
+
+			first=true;
+			os << "set optking { frozen_bend = \" ";
+			for( std::vector< std::vector<int> >::iterator i = frozen.begin(); i!=frozen.end(); i++ ) {
+				if( i->size() == 3 ) {
+					if( !first ) { os << " , "; }
+					os << (*i)[0] << " " << (*i)[1]  << " " << (*i)[2];
+					first = false;
+				}
+			}
+			os << " \" }" << endl;
+
+			first=true;
+			os << "set optking { frozen_dihedral = \" ";
+			for( std::vector< std::vector<int> >::iterator i = frozen.begin(); i!=frozen.end(); i++ ) {
+				if( i->size() == 4 ) {
+					if( !first ) { os << " , "; }
+					os << (*i)[0] << " " << (*i)[1] << " " << (*i)[2] << " " << (*i)[3];
+					first = false;
+				}
+			}
+			os << " \" }" << endl;
+		}
+
+
+		string type = "scf";
+		if( !is_hf ) {
+			type = theory;
+		}
+		if( opt == OPT_NONE ) {
+			os << "ee = energy('" << type << "')" << endl;
+		}
+		else {
+			os << "ee = optimize('" << type <<"')" << endl;
+		}
+
+		// Output coords in XYZ
+		os <<  endl << "f = open( 'psi4.xyz', 'w' ) " << endl;
+		os << "f.write( \"" << mol->NumAtoms() << " \" )" << endl;
+		// nonstandard -- smuggle the QM energy on the first line
+		os << "f.write( str(ee) )" << endl;
+		os << "f.write( \"\\n\" )" << endl;
+		os << "f.write( MOL.save_string_xyz() )" << endl << endl;
+		os << "f.close()" << endl << endl;
+
+		if( espgrid ) {
+			os << "oeprop( \"GRID_ESP\", \"GRID_FIELD\" )" << endl;
+		}
+		return true;
+	}
+}

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -270,6 +270,8 @@ std::vector<std::string> EnableStaticPlugins()
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGaussianOutputFormat)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGaussianInputFormat)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGaussianZMatrixInputFormat)->GetID());
+  plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGaussianGenericQMInputFormat)->GetID());
+  plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&thePSI4GenericQMInputFormat)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGenBankFormat)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGhemicalFormat)->GetID());
   plugin_ids.push_back(reinterpret_cast<OBPlugin*>(&theGROFormat)->GetID());


### PR DESCRIPTION
Submitted for comment -

Intended to facilitate interchangeability of QM codes, this patch adds code for generating Gaussian and PSI4 input files. Inputs are constructed them from a common set of configuration options:

```
psi4in -- Generate a PSI4 Input file.  [Write-only]
Write Options:
  T<theory>            Theory level for calculation. Options:   (rhf)
                         b3lyp
                         rhf
                         rohf
                         uhf
  B<basis-set>         Basis set for calculation. Options:   (6-31g*)
                         6-31g*
                         cc-pvdz
  M#                   Multiplicity of the molecule          (default 1)
  E                    Calculate field and potential on points from grid.dat
  O<type>              Optimise geometry. Options:           (default none)
                         none  loose  normal  tight
  F<...>               List of bonds, angles and dihedrals to freeze
                       Atoms indexed from 1, comma-separated.
                       Each term colon-separated.
                       Eg freezing one angle, one dihedral: 
                          -xF 1,2,3:3,5,6,7
  m#                   Amount of memory to allocate (GB)     (default 2.0)
  n#                   Number of CPUs/threads to allocate    (default 1)


```

This is a derivative of something we use in-house; I've another few formats I can add in the same model