### PR TITLE
Fix for compile error with MSVC 2013.

### DIFF
--- a/src/ops/conformer.cpp
+++ b/src/ops/conformer.cpp
@@ -78,11 +78,10 @@ namespace OpenBabel
   //////////////////////////////////////////////////////////
   OpConformer theOpConformer("conformer"); //Global instance
 
-  bool getInteger(const std::string &str, int &value)
+  void getInteger(const std::string &str, int &value)
   {
     std::istringstream iss(str);
-    bool ret = iss >> value;
-    return ret;
+    iss >> value;
   }
 
   //////////////////////////////////////////////////////////


### PR DESCRIPTION
The fix is for a simple string-to-integer function where it was mistakenly coercing a istringstream to a boolean, but MSVC 2013 no longer is happy with this.