### PR TITLE
Edit ifdef MSVC to be MSVC version specific

### DIFF
--- a/src/charges/eqeq.cpp
+++ b/src/charges/eqeq.cpp
@@ -23,8 +23,8 @@ GNU General Public License for more details.
 
 using namespace std;
 
-#ifdef _MSC_VER
-// MSVC doesn't have error function erfc, use local implementation
+#if _MSC_VER < 1800
+// Older MSVC doesn't have error function erfc, use local implementation
 #include <openbabel/math/erf.h>
 using temperf::erfc;
 #endif

--- a/src/charges/eqeq.cpp
+++ b/src/charges/eqeq.cpp
@@ -23,7 +23,7 @@ GNU General Public License for more details.
 
 using namespace std;
 
-#if _MSC_VER < 1800
+#if defined(_MSC_VER) && _MSC_VER < 1800
 // Older MSVC doesn't have error function erfc, use local implementation
 #include <openbabel/math/erf.h>
 using temperf::erfc;

--- a/src/charges/qeq.cpp
+++ b/src/charges/qeq.cpp
@@ -23,8 +23,8 @@ GNU General Public License for more details.
 
 using namespace std;
 
-#ifdef _MSC_VER
-// MSVC doesn't have error function erf, use local implementation
+#if _MSC_VER < 1800
+// Older MSVC doesn't have error function erf, use local implementation
 #include <openbabel/math/erf.h>
 using temperf::erf;
 #endif

--- a/src/charges/qeq.cpp
+++ b/src/charges/qeq.cpp
@@ -23,7 +23,7 @@ GNU General Public License for more details.
 
 using namespace std;
 
-#if _MSC_VER < 1800
+#if defined(_MSC_VER) && _MSC_VER < 1800
 // Older MSVC doesn't have error function erf, use local implementation
 #include <openbabel/math/erf.h>
 using temperf::erf;

--- a/src/charges/qtpie.cpp
+++ b/src/charges/qtpie.cpp
@@ -23,8 +23,8 @@ GNU General Public License for more details.
 
 using namespace std;
 
-#ifdef _MSC_VER
-// MSVC doesn't have error function erf use local implementation
+#if _MSC_VER < 1800
+// Older MSVC doesn't have error function erf, use local implementation
 #include <openbabel/math/erf.h>
 using temperf::erf;
 #endif

--- a/src/charges/qtpie.cpp
+++ b/src/charges/qtpie.cpp
@@ -23,7 +23,7 @@ GNU General Public License for more details.
 
 using namespace std;
 
-#if _MSC_VER < 1800
+#if defined(_MSC_VER) && _MSC_VER < 1800
 // Older MSVC doesn't have error function erf, use local implementation
 #include <openbabel/math/erf.h>
 using temperf::erf;


### PR DESCRIPTION
Fix MSVC2013 build problems as the erfc/erf are now available and this causes the compiler some confusion.