### PR TITLE
Fix the OBStopwatch

### DIFF
--- a/include/openbabel/obutil.h
+++ b/include/openbabel/obutil.h
@@ -71,7 +71,7 @@ namespace OpenBabel
     double Lap()
     {
       stop= clock();
-      return((stop - start) / CLOCKS_PER_SEC);
+      return((stop - start) / (double) CLOCKS_PER_SEC);
     }
 #else
     //! Mark the start of "stopwatch" timing


### PR DESCRIPTION
OBStopwatch was using integer division to arrive at a double,
and so would report only integer seconds.