### PR TITLE
Add regression test for fast tanimoto search

### DIFF
--- a/test/testfastsearch.py
+++ b/test/testfastsearch.py
@@ -50,6 +50,9 @@ c12[C]3([C@H]4([N@@](CCc1c1ccccc1[nH]2)C[C@H](C=C4CC)C3))C(=O)OC"""
         query = "Nc2nc(c1ccccc1)nc3ccccc23"
         output, error = run_exec("babel ten.fs -ifs -s %s -osmi" % query)
         self.assertConverted(error, 1)
+
+        output, error = run_exec("babel ten.fs -ifs -s %s -at 0.5 -aa -osmi" % query)
+        self.assertConverted(error, 1)
         
 
 


### PR DESCRIPTION
I break the -at option in a local build, and make test failed to detect
the breakage.  Add a regression test for it.