### PR TITLE
Don't set precision to 0 when reporting time estimate

### DIFF
--- a/src/formats/fastsearchformat.cpp
+++ b/src/formats/fastsearchformat.cpp
@@ -481,12 +481,10 @@ virtual const char* Description() //required
       {
         clog << " Estimated completion time ";
         double secs = sw.Elapsed() * nmols / 400; //
-        streamsize op = clog.precision(0);
         if(secs>150)
           clog << secs/60 << " minutes" << endl;
     else
           clog << secs << " seconds" << endl;
-        clog.precision(op);
       }
     }
     else


### PR DESCRIPTION
Changing the stream precision to 0 seems like a bad idea.

I'd rather see a reported time of 90.5956 minutes and
mentally round it to the number of sig figs I think is
appropriate, than see 1e+02 minutes and be left to wonder
where between 50.1 and 149.9 that might mean.