### PR TITLE
Fixed the (HM: 63 m c) to (HM: P 63 m c) in space group data file.

### DIFF
--- a/data/space-groups.txt
+++ b/data/space-groups.txt
@@ -6272,7 +6272,7 @@ x-y,-y,z
 
 186
 P 6c -2c
- 63 m c
+P 63 m c
 x,y,z
 -y,x-y,z
 y-x,-x,z


### PR DESCRIPTION
This was causing a problem with one of the cif file we ran. So I had to fix this to get the right space group. Otherwise the pdb file converted from cif get default to P1.