### PR TITLE
Added further checks for zlib availability in OBConversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,20 +161,11 @@ else()
 endif()
 
 # configure checks
-find_package(LibXml2)
-if(NOT LIBXML2_FOUND)
-  message(WARNING "libxml2 not found - disabling CML support!")
-endif()
+SET(LIBXML2_FOUND FALSE)
+set(LIBXML2_LIBRARIES "")
 
-find_package(ZLIB)
-if(ZLIB_FOUND)
-  add_definitions(-DHAVE_LIBZ)
-  include_directories(${ZLIB_INCLUDE_DIR})
-  # Longstanding unsolved problem with compression under Windows
-  if(WIN32)
-    add_definitions(-DDISABLE_WRITE_COMPRESSION)
-  endif()
-endif()
+SET(ZLIB_FOUND FALSE)
+set(ZLIB_LIBRARY "")
 
 # wxWidgets instructions based on http://wiki.wxwidgets.org/CMake
 #find_package(wxWidgets COMPONENTS base core REQUIRED)
@@ -438,18 +429,8 @@ include_directories(${openbabel_BINARY_DIR}/include
 )
 
 #cjh
-find_package(Eigen3)
-if(EIGEN3_FOUND)
-  add_definitions(-DHAVE_EIGEN -DHAVE_EIGEN3)
-  include_directories(${EIGEN3_INCLUDE_DIR})
-else()
-  find_package(Eigen2) # find and setup Eigen2
-  if(EIGEN2_FOUND)
-    add_definitions (-DHAVE_EIGEN)
-    include_directories(${EIGEN2_INCLUDE_DIR})
-  endif()
-endif()
-#cjh
+SET(EIGEN3_FOUND FALSE)
+SET(EIGEN2_FOUND FALSE)
 
 find_package(Cairo)
 if(CAIRO_FOUND)

--- a/src/obconversion.cpp
+++ b/src/obconversion.cpp
@@ -461,10 +461,12 @@ namespace OpenBabel {
     StreamState savedIn, savedOut;
     if (is)
     {
+#ifdef HAVE_LIBZ
       if(!inFormatGzip && pInFormat && zlib_stream::isGZip(*is))
       {
         inFormatGzip = true;
       }
+#endif
       savedIn.pushInput(*this);
       SetInStream(is, false);
     }
@@ -828,10 +830,12 @@ namespace OpenBabel {
   {
     if(pin) {
       //for backwards compatibility, attempt to detect a gzip file
-      if(!inFormatGzip && pInFormat && zlib_stream::isGZip(*pin))
+#ifdef HAVE_LIBZ
+		if(!inFormatGzip && pInFormat && zlib_stream::isGZip(*pin))
       {
         inFormatGzip = true;
       }
+#endif
       SetInStream(pin, false);
     }
 
@@ -1066,12 +1070,13 @@ namespace OpenBabel {
         obErrorLog.ThrowError(__FUNCTION__,"Cannot read from " + filePath, obError);
         return false;
     }
-
+#ifdef HAVE_LIBZ
     if(!inFormatGzip && pInFormat && zlib_stream::isGZip(*ifs))
     {
       //for backwards compat, attempt to autodetect gzip
       inFormatGzip = true;
     }
+#endif
 
     SetInStream(ifs, true);
     return Read(pOb);
@@ -1434,12 +1439,13 @@ namespace OpenBabel {
                     //Output is put in a temporary stream and written to a file
                     //with an augmenting name only when it contains a valid object.
                     int Indx=1;
-
+#ifdef HAVE_LIBZ
                     if(pInFormat && zlib_stream::isGZip(*pIs))
                     {
                       //for backwards compat, attempt to autodetect gzip
                       inFormatGzip = true;
                     }
+#endif
                     SetInStream(pIs, false);
 
 


### PR DESCRIPTION
More checks were necessary to make all occurrences
of zlib-dependent code build conditional.