### PR TITLE
Added further checks for zlib availability in OBConversion

### DIFF
--- a/src/obconversion.cpp
+++ b/src/obconversion.cpp
@@ -461,10 +461,12 @@ namespace OpenBabel {
     StreamState savedIn, savedOut;
     if (is)
     {
+#ifdef HAVE_LIBZ
       if(!inFormatGzip && pInFormat && zlib_stream::isGZip(*is))
       {
         inFormatGzip = true;
       }
+#endif
       savedIn.pushInput(*this);
       SetInStream(is, false);
     }
@@ -828,10 +830,12 @@ namespace OpenBabel {
   {
     if(pin) {
       //for backwards compatibility, attempt to detect a gzip file
-      if(!inFormatGzip && pInFormat && zlib_stream::isGZip(*pin))
+#ifdef HAVE_LIBZ
+		if(!inFormatGzip && pInFormat && zlib_stream::isGZip(*pin))
       {
         inFormatGzip = true;
       }
+#endif
       SetInStream(pin, false);
     }
 
@@ -1066,12 +1070,13 @@ namespace OpenBabel {
         obErrorLog.ThrowError(__FUNCTION__,"Cannot read from " + filePath, obError);
         return false;
     }
-
+#ifdef HAVE_LIBZ
     if(!inFormatGzip && pInFormat && zlib_stream::isGZip(*ifs))
     {
       //for backwards compat, attempt to autodetect gzip
       inFormatGzip = true;
     }
+#endif
 
     SetInStream(ifs, true);
     return Read(pOb);
@@ -1434,12 +1439,13 @@ namespace OpenBabel {
                     //Output is put in a temporary stream and written to a file
                     //with an augmenting name only when it contains a valid object.
                     int Indx=1;
-
+#ifdef HAVE_LIBZ
                     if(pInFormat && zlib_stream::isGZip(*pIs))
                     {
                       //for backwards compat, attempt to autodetect gzip
                       inFormatGzip = true;
                     }
+#endif
                     SetInStream(pIs, false);
 
 


### PR DESCRIPTION
More checks were necessary to make all occurrences
of zlib-dependent code build conditional.