### PR TITLE
speed up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ before_script:
  - cmake -DPYTHON_BINDINGS=ON  -DRUN_SWIG=ON ..
 
 script:
- - make
+ - make -j2
  - ctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
 
 script:
  - make -j2
- - ctest
+ - ctest -j 2


### PR DESCRIPTION
Travis uses 1.5 core per build machine. Most of the time, the build is
slowed by disk access, so setting -j2 to make usually speed up things a lot.