### PR TITLE
do not reset conformer in addH

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -2284,7 +2284,6 @@ namespace OpenBabel
       }
 
     DecrementMod();
-    SetConformer(0);
 
     //reset atom type and partial charge flags
     _flags &= (~(OB_PCHARGE_MOL|OB_ATOMTYPES_MOL|OB_SSSR_MOL|OB_AROMATIC_MOL));


### PR DESCRIPTION
previously all but the currently set conformers were blown away; now that they are kept around, SetConformer(0) is having an effect which is unexpected and breaks backwards compatibility

This change removes the call to SetConformer(0) so that addHydrogens no longer has the side effect of changing the currently selected conformer.