### PR TITLE
For pwscfformat.cpp, fixed a few reading problems caused by newer ver…

### DIFF
--- a/src/formats/pwscfformat.cpp
+++ b/src/formats/pwscfformat.cpp
@@ -93,13 +93,23 @@ namespace OpenBabel {
 
     while (ifs.getline(buffer,BUFF_SIZE)) {
 
+      // Older version of pwscf may use this for alat
       if (strstr(buffer, "lattice parameter (a_0)")) {
         tokenize(vs, buffer);
         alat = atof(vs.at(4).c_str());
       }
 
+      // Newer versions will use this for alat instead
+      if (strstr(buffer, "lattice parameter (alat)")) {
+        tokenize(vs, buffer);
+        alat = atof(vs.at(4).c_str());
+      }
+
       // Unit cell info
-      if (strstr(buffer, "CELL_PARAMETERS")) {
+      // Newer versions will also say "CELL_PARAMETERS" to complain that no
+      // units were specified
+      if (strstr(buffer, "CELL_PARAMETERS") &&
+          !strstr(buffer, "no units specified in CELL_PARAMETERS card")) {
         // Discover units
         double conv = 1.0;
         tokenize(vs, buffer);


### PR DESCRIPTION
…sions of quantum espresso. The 'alat' term can now be read correctly, and it doesn't crash anymore from the extra 'CELL_PARAMETER' use at the beginning of the output.