### PR TITLE
Fix bug in the fingerprint algorithm.

### DIFF
--- a/src/fingerprints/finger2.cpp
+++ b/src/fingerprints/finger2.cpp
@@ -175,6 +175,7 @@ void fingerprint2::getFragments(vector<int> levels, vector<int> curfrag,
 				//and save in ringset
 				curfrag[0] = bo;
 				ringset.insert(curfrag);
+ 				curfrag[0] = 0;
 			}
 		}
 		else //no ring


### PR DESCRIPTION
If the atom currently being visited in a path through the atoms can
both close a ring back to the first atom, and can also proceed
to a different atom, and the bond enumerator returns the closing
bond first, then the other path was omitted.  That is because after
the path was marked as closed and the ring added to the fingerprint
bit set, the closure is not cleared.  When the next bond is visited,
the path is not added because it still appears to be closed.

In order for the bit to be missed altogether, this problem must
occur in both directions along the path, so the situation is somewhat
rare.

See bug #206