### PR TITLE
Fix compiling errors under Windows & Cygwin

### DIFF
--- a/include/libxml/xmlexports.h
+++ b/include/libxml/xmlexports.h
@@ -110,7 +110,7 @@
 #endif
 
 /* Cygwin platform, GNU compiler */
-#if defined(_WIN32) && defined(__CYGWIN__)
+#if defined(__CYGWIN__)
   #undef XMLPUBFUN
   #undef XMLPUBVAR
   #undef XMLCALL

--- a/src/fingerprint.cpp
+++ b/src/fingerprint.cpp
@@ -30,7 +30,7 @@ GNU General Public License for more details.
 using namespace std;
 namespace OpenBabel
 {
-#if defined(__CYGWIN32__) || defined(__MINGW32__)
+#if defined(__CYGWIN__) || defined(__MINGW32__)
   // macro to implement static OBPlugin::PluginMapType& Map()
   PLUGIN_CPP_FILE(OBFingerprint)
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -235,6 +235,7 @@ endif(NOT MINGW AND NOT CYGWIN)
 ###############################
 
 if (PYTHON_BINDINGS)
+  include(UsePythonTest)
   set(pybindtests
       bindings _pybel example)
   foreach(pybindtest ${pybindtests})


### PR DESCRIPTION
include/libxml/xmlexports.h: CMake no longer defines _WIN32 under Cygwin. 

src/fingerprint.cpp: likely a typo -- "__CYGWIN32__" is not defined.

test/CMakeLists.txt: need to include "include(UsePythonTest)" before using ADD_PYTHON_TEST.