### PR TITLE
fix for segfaulting similarity search with fastsearch index

### DIFF
--- a/include/openbabel/plugin.h
+++ b/include/openbabel/plugin.h
@@ -124,6 +124,9 @@ public:
   ///Returns the map of the subtypes
   virtual PluginMapType& GetMap() const =0;
 
+  ///Load all plugins (formats, fingerprints, forcefields etc.)
+  static void LoadAllPlugins();
+
 protected:
   ///\brief Returns a reference to the map of the plugin types.
   /// Is a function rather than a static member variable to avoid initialization problems.
@@ -135,9 +138,6 @@ protected:
 
   ///Keep a record if all plugins have been loaded
   static int AllPluginsLoaded;
-
-  ///Load all plugins (formats, fingerprints, forcefields etc.)
-  static void LoadAllPlugins();
 
   ///Returns the map of a particular plugin type, e.g. GetMapType("fingerprints")
   static PluginMapType& GetTypeMap(const char* PluginID);

--- a/src/formats/fastsearchformat.cpp
+++ b/src/formats/fastsearchformat.cpp
@@ -541,6 +541,13 @@ virtual const char* Description() //required
       vector<string> vec;
       tokenize(vec, p);
 
+      if(vec.size() == 0)
+      {
+    	  obErrorLog.ThrowError(__FUNCTION__,
+    			  "Missing argument for -s/-S", obError);
+          return false;
+      }
+
       //ignore leading ~ (not relevant to fastsearch)
       if(vec[0][0]=='~')
         vec[0].erase(0,1);

--- a/tools/babel.cpp
+++ b/tools/babel.cpp
@@ -73,6 +73,9 @@ int main(int argc,char *argv[])
   char *oext = NULL;
   char *iext = NULL;
 
+  //load plugs to fully initialize option parameters
+  OBPlugin::LoadAllPlugins();
+
   //Save name of program without its path (and .exe)
   string pn(argv[0]);
   string::size_type pos;


### PR DESCRIPTION
This fixes a segfault when trying to use a fastsearch index
    babel mymols.fs -ifs -sN#Cc1ccccc1C#N results.smi
would segfault since the fastsearch plugin assumed that the -s argument was set and was indexing into an empty vector.  If it encounters this situation it will now generate a message instead.

More importantly, the reason the argument was missing is because plugin parameter options were getting registered *after* the parameters were parsed in babel.cpp.  Specifically, in DoOption in babel.cpp `nParams` for -s was zero since its number of arguments hadn't been registered yet. This is due to the commit 3cb13fb2155740ad632c0cd49fcbf9686c78f2ee.  This made plugin loading something that happens greedily when the first plugin is retrieved, whereas before it happened in the OBConversion constructor.

The provided fix makes LoadAllPlugins a public function and calls it explicitly in babel.cpp before parsing commandline arguments.