### PR TITLE
Charge_Radius_Error

### DIFF
--- a/src/formats/pqrformat.cpp
+++ b/src/formats/pqrformat.cpp
@@ -186,18 +186,18 @@ namespace OpenBabel
   static double parseAtomCharge(char *buffer, OBMol &mol)
   // In PQR format, either:
   // Field name, atom number, atom name, residue name, residue number
-  //    x y z charge radius
+  //    x y z charge radius element
   // OR
-  // Field, atom number, atom name, chain id, residue number, X, Y, Z, chg, rad
+  // Field, atom number, atom name, chain id, residue number, X, Y, Z, chg, rad, ele
   {
     vector<string> vs;
     tokenize(vs,buffer);
 
     OBAtom *atom = mol.GetAtom(mol.NumAtoms());
 
-    if (vs.size() == 10)
+    if (vs.size() == 11)//add element, Zhixiong Zhao
       return atof(vs[8].c_str());
-    else if (vs.size() == 11)
+    else if (vs.size() == 12)
       return atof(vs[9].c_str());
 
     return 0.0;
@@ -210,9 +210,9 @@ namespace OpenBabel
 
     OBAtom *atom = mol.GetAtom(mol.NumAtoms());
 
-    if (vs.size() == 10)
+    if (vs.size() == 11)
       return atof(vs[9].c_str());
-    else if (vs.size() == 11)
+    else if (vs.size() == 12)
       return atof(vs[10].c_str());
 
     return 0.0;

--- a/src/formats/pqrformat.cpp
+++ b/src/formats/pqrformat.cpp
@@ -548,7 +548,9 @@ namespace OpenBabel
                  atom->GetY(),
                  atom->GetZ(),
                  atom->GetPartialCharge(),
-                 etab.GetVdwRad(atom->GetAtomicNum()),
+                 atom->HasData("Radius")//use atom radius data,Zhixiong Zhao
+				 	?atof(atom->GetData("Radius")->GetValue().c_str())
+					:etab.GetVdwRad(atom->GetAtomicNum()),
                  element_name);
         ofs << buffer;
       }


### PR DESCRIPTION
The **pqr** format reader ignore the last element column...
Use the atom radius data saved in general data, not the element radius.