### PR TITLE
Builder fixes

### DIFF
--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -230,11 +230,8 @@ namespace OpenBabel
           }
           // there is no a-2 atom
           v1 = cross(bond1, vrand); // so find a perpendicular, given the random vector (this doesn't matter here)
-          v2 = cross(bond1, v1);
-        } else {
-          v1 = cross(bond1, bond2);
-          v2 = cross(bond1, v1);
         }
+        v2 = cross(bond1, v1);
         v2 = v2.normalize();
 
         // check to see if atom is a square planar in disguise

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -209,10 +209,12 @@ namespace OpenBabel
             continue;
 
           FOR_NBORS_OF_ATOM (nbr2, &*nbr) {
-            if (&*nbr2 != atom)
+            if (&*nbr2 != atom) {
               bond2 = nbr->GetVector() - nbr2->GetVector();
-            if (isCarboxylateO && nbr2->IsOxygen())
-              break; // make sure that the hydrogen is trans to the C=O
+
+              if (isCarboxylateO && nbr2->IsOxygen())
+                break; // make sure that the hydrogen is trans to the C=O
+            }
           }
         }
 


### PR DESCRIPTION
This fixes a logic error in OBBuilder which led to nondeterministic behavior for some groups (e.g. carboxylate).