### PR TITLE
New OBAtom:IsHbondAcceptor() method

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -468,6 +468,8 @@ namespace OpenBabel
       bool IsPhosphateOxygen();
       //! \return Is this atom an oxygen in a sulfate (-SO3) group?
       bool IsSulfateOxygen();
+      //! \return Is this atom an oxygen in a sulfone (R1-SO2-R2) group?
+      bool IsSulfoneOxygen();
       //! \return Is this atom an oxygen in a nitro (-NO2) group?
       bool IsNitroOxygen();
       //! \return Is this atom a nitrogen in an amide (-C(=O)NR2) group?
@@ -497,9 +499,11 @@ namespace OpenBabel
       bool HasChiralitySpecified() { return(HasFlag(OB_CSTEREO_ATOM|OB_ACSTEREO_ATOM)); }
       //! \deprecated
       bool HasChiralVolume() { return(HasFlag(OB_POS_CHIRAL_ATOM|OB_NEG_CHIRAL_ATOM)); }
-      //! \return Is this atom a hydrogen-bond acceptor (receptor)?
+      //! \return Is this atom a hydrogen-bond acceptor  (considering also atom surrounding)
       bool IsHbondAcceptor();
-      //! \return Is this atom a hydrogen-bond donor?
+      //! \return Is this atom a hydrogen-bond acceptor (old function)?
+      bool IsHbondAcceptorSimple();
+            //! \return Is this atom a hydrogen-bond donor?
       bool IsHbondDonor();
       //! \return Is this a hydrogen atom attached to a hydrogen-bond donor?
       bool IsHbondDonorH();


### PR DESCRIPTION
The new OBAtom:IsHbondAcceptor() method should provide a more fine-grained detection of hydrogen bond capabilities of atoms, basing on their neighbors (i.e., different chemical moieties are recognized). The rules are based on references from Kubyni and others, and the result can differ significantly from the current 2.3.x implementation, especially for the oxygen atom. A legacy function (OBAtom:IsHBondAcceptorSimple()) has been created to provide some kind of backward compatibility. 

Accordingly to these rules, the function will return:
  aliph-O-aliph ether   -> true   [1]
  hydroxy O-sp3         -> true   [1]
  aro-O-aliph ether     -> true   [1]
  ester O-sp2           -> true   [1]
  sulfate O (R-SO3)     -> true   [2]
  sulfoxyde O (R-SO-R)  -> true   [2]
  organoboron-F (R-BF3) -> true   [3]
  ester O-sp3           -> false  [1]
  sulfone (R1-SO2-R2 )  -> false  [2]
  aro-O-aro             -> false  [1]
  aromatic O            -> false  [1]
  O-nitro               -> false  [2]
  organic F (R-F)       -> false  [4]


References
[1] Kubinyi, H. "Changing paradigms in drug discovery. "SPECIAL PUBLICATION-ROYAL SOCIETY OF CHEMISTRY 304.1 (2006): 219-232.
[2] Kingsbury, Charles A. "Why are the Nitro and Sulfone Groups Poor Hydrogen Bonders?." (2015).
[3] Per Restorp, Orion B. Berryman, Aaron C. Sather, Dariush Ajami, Julius Rebek Jr., Chem. Commun., 2009, 5692 DOI: 10.1039/b914171e
[4] Dunitz, Taylor. "Organic fluorine hardly ever accepts hydrogen bonds." Chemistry-A European Journal 3.1 (1997): 83-92.
