### PR TITLE
cmake/modules/UsePythonTest.cmake: Pop policy on return

### DIFF
--- a/cmake/modules/UsePythonTest.cmake
+++ b/cmake/modules/UsePythonTest.cmake
@@ -31,6 +31,9 @@ MARK_AS_ADVANCED(PYTHON_EXECUTABLE)
 
 # Make sure we handle systems w/o python (e.g. chroot)
 if(NOT PYTHON_EXECUTABLE)
+  if(POLICY CMP0053)
+    cmake_policy(POP)
+  endif()
   return()
 endif(NOT PYTHON_EXECUTABLE)
 


### PR DESCRIPTION
Otherwise test build fails if Python interpreter is not found or is
unset.