### PR TITLE
Fix mmcifformat.cpp to allow correctly setting atom types from the atom names containing digits

### DIFF
--- a/src/formats/mmcifformat.cpp
+++ b/src/formats/mmcifformat.cpp
@@ -631,9 +631,10 @@ namespace OpenBabel
 
                if (atom_type_tag != CIFTagID::_atom_site_label)
                  break;
-               // Else remove digits and drop through to _atom_site_type_symbol
-               token.as_text.erase(remove_if(token.as_text.begin(), token.as_text.end(), ::isdigit),
-                                   token.as_text.end());
+               // Else remove everything starting from the first digit
+               // and drop through to _atom_site_type_symbol
+               if(string::npos != token.as_text.find_first_of("0123456789"))
+                 {token.as_text.erase(token.as_text.find_first_of("0123456789"), token.as_text.size());}
              case CIFTagID::_atom_site_type_symbol:
                // Problem: posat->mSymbol is not guaranteed to actually be a 
                // symbol see http://www.iucr.org/iucr-top/cif/cifdic_html/1/cif_core.dic/Iatom_type_symbol.html


### PR DESCRIPTION
In the case of setting the atom type from the atom label, this change allows for correctly parsing atom names containing digits:

loop_
_atom_site_label
_atom_site_fract_x
_atom_site_fract_y
_atom_site_fract_z
H2A 0.4481 -0.8277 0.2649
H2B 0.6245 -0.7166 0.2599
H3A 0.4700 -0.6074 0.1979
H3B 0.3580 -0.7706 0.1862

Before that, digits were stripped ending up with the weird types: HA, HB, etc.