### PR TITLE
Clean space group name before anything

### DIFF
--- a/src/math/spacegroup.cpp
+++ b/src/math/spacegroup.cpp
@@ -342,12 +342,13 @@ namespace OpenBabel
 
   /*!
    */
-  const SpaceGroup * SpaceGroup::GetSpaceGroup (const string &name)
+  const SpaceGroup * SpaceGroup::GetSpaceGroup (const string &name_in)
   {
     if (!_SpaceGroups.Inited())
       _SpaceGroups.Init();
 
     // This needs to be more forgiving
+    string name = RemoveWhiteSpaceUnderscore(name_in);
     const SpaceGroup *match = (_SpaceGroups.sgbn.find(name)!=_SpaceGroups.sgbn.end())? _SpaceGroups.sgbn[name]: NULL;
     if (!match) {
       // Try another search, e.g. Fm-3m instead of Fm3m


### PR DESCRIPTION
This fixes the issue with reading space groups from PDB (and maybe other formats).