### PR TITLE
Make transformation parser case insensitive

### DIFF
--- a/src/math/spacegroup.cpp
+++ b/src/math/spacegroup.cpp
@@ -242,12 +242,15 @@ namespace OpenBabel
                   case '+':
                     neg = false;
                     break;
+                  case 'X':
                   case 'x':
                     m(i, 0) = (neg)? -1.: 1.;
                   break;
+                  case 'Y':
                   case 'y':
                     m(i, 1) = (neg)? -1.: 1.;
                   break;
+                  case 'Z':
                   case 'z':
                     m(i, 2) = (neg)? -1.: 1.;
                   break;


### PR DESCRIPTION
This needed in the cases like:

loop_
_symmetry_equiv_pos_site_id
_symmetry_equiv_pos_as_xyz
1 +X,+Y,+Z
2 -X,+Y,+Z
3 +X,1/2-Y,1/2+Z
4 -X,1/2-Y,1/2+Z
5 -X,-Y,-Z
6 +X,-Y,-Z
7 -X,1/2+Y,1/2-Z
8 +X,1/2+Y,1/2-Z