### PR TITLE
Allow only unique symmetry transformations

### DIFF
--- a/src/math/spacegroup.cpp
+++ b/src/math/spacegroup.cpp
@@ -279,7 +279,23 @@ namespace OpenBabel
 			v.z() += 1.;
 		else if (v.z() >= 1.)
 			v.z() -= 1.;
-    m_transforms.push_back (new transform3d (m, v));
+
+    // only push_back unique transformations
+    transform3dIterator i, iend = m_transforms.end();
+    transform3d* candidate = new transform3d (m, v);
+    bool transform_exists = false;
+
+    for (i = m_transforms.begin(); i!= iend; i++)
+    {
+      if (candidate->DescribeAsString() == (*i)->DescribeAsString())
+      {
+        transform_exists = true;
+        break;
+      }
+    }
+
+    if (!transform_exists)
+      m_transforms.push_back (candidate);
   }
 
   /*!


### PR DESCRIPTION
This should match the correct space group when the same transformation is present:

```
_symmetry_equiv_pos_as_xyz
x,y,z
x,y,z
```