### PR TITLE
The findFiles member should return 0 for error

### DIFF
--- a/src/dlhandler_unix.cpp
+++ b/src/dlhandler_unix.cpp
@@ -129,7 +129,7 @@ int DLHandler::findFiles (std::vector <std::string>& file_list,
     }
 
   if (file_list.empty())
-    return(-1); // error, didn't find any files at all
+    return 0; // error, didn't find any files at all
   return file_list.size();
 }
 


### PR DESCRIPTION
The Windows equivalent returns 0 for error/no files, this variant should
do the same. This member is used to load all plugins, and can result in
an infinite loop when -1 is returned.