### PR TITLE
Modified phmodel.txt to fix azide transformation

### DIFF
--- a/data/phmodel.txt
+++ b/data/phmodel.txt
@@ -40,10 +40,8 @@ TRANSFORM [nD2-0]1[nD2:1]([#1:2])[nD2-0][nD2-0]c1 >> n1[n-:1]nnc1	4.89 #pKa from
 TRANSFORM [nD2-0:1]1[nD2-0][nD2-0][nD2-0]c1 >> [n-:1]1nnnc1		4.89 #pKa from acid (AH)
 
 #azide
-#TRANSFORM [ND1:1]=[ND2:2]=A >> [N-:1]=[N+:2]=A				1E+10 # always apply transformation
-#TRANSFORM [ND2:1]=[ND2:2]=A >> N=[N+:2]=A				1E+10 # always apply this transformation
 TRANSFORM [ND1:1]=[ND2:2]=N-A >> [N-:1]=[N+:2]=N-A				1E+10 # always apply transformation
-TRANSFORM [ND2:1]=[ND2:2]=N-A >> [N-1]=[N+:2]=N-A				1E+10 # always apply this transformation
+TRANSFORM [HND2:1]=[ND2:2]=N-A >> [N-1]=[N+:2]=N-A				1E+10 # always apply this transformation
 
 
 

--- a/data/phmodel.txt
+++ b/data/phmodel.txt
@@ -39,11 +39,11 @@ TRANSFORM [nD2:1]([#1:2])1[nD2-0][nD2-0][nD2-0]c1 >> [n-:1]1nnnc1	4.89 #pKa from
 TRANSFORM [nD2-0]1[nD2:1]([#1:2])[nD2-0][nD2-0]c1 >> n1[n-:1]nnc1	4.89 #pKa from acid (AH)
 TRANSFORM [nD2-0:1]1[nD2-0][nD2-0][nD2-0]c1 >> [n-:1]1nnnc1		4.89 #pKa from acid (AH)
 
-#azide
-TRANSFORM [ND1:1]=[ND2:2]=N-A >> [N-:1]=[N+:2]=N-A				1E+10 # always apply transformation
-TRANSFORM [HND2:1]=[ND2:2]=N-A >> [N-1]=[N+:2]=N-A				1E+10 # always apply this transformation
-
-
+#azide (always apply these transformations)
+TRANSFORM [ND1:1]~[ND2:2]~[ND1:3] >> [N-:1]=[N+:2]=[N-:3] 1E+10	    # azide ion
+TRANSFORM [ND1:1]~[ND2:2]~[ND1:3]~* >> [N-:1]=[N+:2]=[N:3]-* 1E+10   # azide group
+TRANSFORM [NH2:1]~[NH1:2]~[NH1:3]~* >> [N-:1]=[N+:2]=[N:3]-* 1E+10	# azide group
+TRANSFORM [NH1:1]~[ND2:2]~[NH1:3]~* >> [N-:1]=[N+:2]=[N:3]-* 1E+10	# azide group
 
 #hydroxamic acid
 #TRANSFORM O=CN[OD1-0:1][#1:2] >> O=CN[O-:1]				8.0

--- a/data/phmodel.txt
+++ b/data/phmodel.txt
@@ -40,8 +40,12 @@ TRANSFORM [nD2-0]1[nD2:1]([#1:2])[nD2-0][nD2-0]c1 >> n1[n-:1]nnc1	4.89 #pKa from
 TRANSFORM [nD2-0:1]1[nD2-0][nD2-0][nD2-0]c1 >> [n-:1]1nnnc1		4.89 #pKa from acid (AH)
 
 #azide
-TRANSFORM [ND1:1]=[ND2:2]=A >> [N-:1]=[N+:2]=A				1E+10 # always apply transformation
-TRANSFORM [ND2:1]=[ND2:2]=A >> N=[N+:2]=A				1E+10 # always apply this transformation
+#TRANSFORM [ND1:1]=[ND2:2]=A >> [N-:1]=[N+:2]=A				1E+10 # always apply transformation
+#TRANSFORM [ND2:1]=[ND2:2]=A >> N=[N+:2]=A				1E+10 # always apply this transformation
+TRANSFORM [ND1:1]=[ND2:2]=N-A >> [N-:1]=[N+:2]=N-A				1E+10 # always apply transformation
+TRANSFORM [ND2:1]=[ND2:2]=N-A >> [N-1]=[N+:2]=N-A				1E+10 # always apply this transformation
+
+
 
 #hydroxamic acid
 #TRANSFORM O=CN[OD1-0:1][#1:2] >> O=CN[O-:1]				8.0


### PR DESCRIPTION
The change fixes a bug that fragmented the molecule when processing the azide group.
The original patterns `[ND1:1]=[ND2:2]=A` used only two nitrogens, resulting probably in ambiguous matches:
   `N=NNCCN >> [N-]=[NH2+].CC[NH3+]`

The new patterns addresses the issue and prevents the fragmentation of the molecule.
   `N=NNCCN >> [N-]=[N+]=NCC[NH3+]`
Now also inorganic azide is recognized.