### PR TITLE
Default OPTIMIZE_NATIVE to OFF, fixes #279

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,13 +467,13 @@ else(CAIRO_FOUND)
   message(STATUS "Could NOT find Cairo. PNG output will NOT be supported.")
 endif(CAIRO_FOUND)
 
-# Should we enable optimizations for the native architecture?
+# Should we enable optimizations for the native CPU architecture?
 # (this will speed up similarity calculations and maybe those involving Eigen)
 if(NOT MSVC)
-  option(OPTIMIZE_NATIVE "Optimize for native architecture. Turn off if cross-compiling." ON)
+  option(OPTIMIZE_NATIVE "Optimize for native CPU architecture. Turn off if compiling for distribution/reuse on other machines." OFF)
   if(OPTIMIZE_NATIVE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-    message(STATUS "Optimizing code for this machine's architecture. Use -DOPTIMIZE_NATIVE=OFF if cross-compiling.")
+    message(STATUS "Optimizing code for this machine's CPU architecture. Use -DOPTIMIZE_NATIVE=OFF if compiling for distribution/reuse on other machines.")
   endif()
 endif()
 


### PR DESCRIPTION
Default the OPTIMIZE_NATIVE option to OFF, and update the documentation
to more accurately reflect the optimization for the machines CPU
architecture. This isn't related to cross-compiling, so replaced
references to it.