### PR TITLE
Make obtautomer exit with status 0 on success

### DIFF
--- a/tools/obdistgen.cpp
+++ b/tools/obdistgen.cpp
@@ -120,5 +120,5 @@ int main(int argc,char **argv)
       conv.Write(&mol, &cout);
   } // end for loop
 
-  return(1);
+  return(0);
 }

--- a/tools/obenergy.cpp
+++ b/tools/obenergy.cpp
@@ -145,7 +145,7 @@ int main(int argc,char **argv)
 
   } // end for loop
 
-  return(1);
+  return(0);
 }
 
 /* obenergy man page*/

--- a/tools/obgen.cpp
+++ b/tools/obgen.cpp
@@ -148,5 +148,5 @@ int main(int argc,char **argv)
       conv.Write(&mol, &cout);
   } // end for loop
 
-  return(1);
+  return(0);
 }

--- a/tools/obgrep.cpp
+++ b/tools/obgrep.cpp
@@ -284,7 +284,7 @@ int main(int argc,char **argv)
       cout << numMatching << endl;
     }
 
-  return(1);
+  return(0);
 }
 
 

--- a/tools/obminimize.cpp
+++ b/tools/obminimize.cpp
@@ -246,7 +246,7 @@ int main(int argc,char **argv)
     cerr << "Time: " << timeElapsed << "seconds. Iterations per second: " <<  double(totalSteps) / timeElapsed << endl;
   } // end for loop
 
-  return(1);
+  return(0);
 }
 
 //

--- a/tools/obmm.cpp
+++ b/tools/obmm.cpp
@@ -379,5 +379,5 @@ int main(int argc,char **argv)
     cout << "invalid command." << endl;
   }
 
-  return(1);
+  return(0);
 }

--- a/tools/obprobe.cpp
+++ b/tools/obprobe.cpp
@@ -157,5 +157,5 @@ int main(int argc,char **argv)
 
   } // end for loop
 
-  return(1);
+  return(0);
 }

--- a/tools/obprop.cpp
+++ b/tools/obprop.cpp
@@ -184,7 +184,7 @@ int main(int argc,char **argv)
       // then with code like the above they are just ignored.
     } // end for loop
   
-  return(1);
+  return(0);
 }
 
 

--- a/tools/obsym.cpp
+++ b/tools/obsym.cpp
@@ -89,5 +89,5 @@ int main(int argc,char **argv)
 
     } // end for loop
 
-  return(1);
+  return(0);
 }

--- a/tools/obtautomer.cpp
+++ b/tools/obtautomer.cpp
@@ -112,6 +112,6 @@ int main(int argc,char **argv)
       
   } // end for loop
   
-  return(1);
+  return(0);
 }
 


### PR DESCRIPTION
Well-behaved programs are supposed to exit with status 0 upon
successful completion. Make obtautomer follow this convention.

There are other programs which exit with 1 upon successful completion,
such as obprop, obsym, obprobe and perhaps others.  But since they
have been released in that state, maybe it is better not to change
them now.