### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -105,7 +105,7 @@ namespace OpenBabel
 
     if (buffer[0] != '#') // skip comment line (at the top)
       {
-        sscanf(buffer,"%d %4s %lf %lf %*f %lf %d %lf %lf %lf %lf %lf %lf %lf %255s",
+        sscanf(buffer,"%d %3s %lf %lf %*f %lf %d %lf %lf %lf %lf %lf %lf %lf %255s",
                &num,
                symbol,
                &ARENeg,

--- a/src/forcefields/forcefieldmm2.cpp
+++ b/src/forcefields/forcefieldmm2.cpp
@@ -351,7 +351,6 @@ namespace OpenBabel
     OBAtom *a, *b;
     vector3 va, vb, ab, vf;
     double e, energy, ra, rb, rab, rr, rrab, rrab2, rrab4, rrab6, rrab7, abrr, eps, epsa, epsb, f;
-    int idx;
 
     //sprintf(errbuf, "a_expterm=%f  b_expterm=%f c_expter=%fm\n", a_expterm, b_expterm, c_expterm); // DEBUG
 
@@ -495,9 +494,12 @@ namespace OpenBabel
 
   OBForceFieldMM2 &OBForceFieldMM2::operator=(OBForceFieldMM2 &src)
   {
-    _mol = src._mol;
-    _init = src._init;
-    return src;
+    if (this != &src)
+    {
+      _mol = src._mol;
+      _init = src._init;
+      return *this;
+    }
   }
 
   bool OBForceFieldMM2::Setup(OBMol &mol)
@@ -516,8 +518,6 @@ namespace OpenBabel
   {
     vector<string> vs;
     char buffer[80];
-    char filename[80];
-    int currently_parsing;
 
     OBFFParameter parameter;
 

--- a/src/formats/libinchi/ichi_bns.c
+++ b/src/formats/libinchi/ichi_bns.c
@@ -6015,7 +6015,7 @@ int bRestoreBnsAfterCheckAltPath( BN_STRUCT *pBNS, ALT_PATH_CHANGES *apc, int bC
                     pBNS->num_edges --;
                 }
                 /* clear the new vertex */
-                memset( pNewVert, 0, sizeof( pNewVert ) );
+                memset( pNewVert, 0, sizeof(BNS_VERTEX) );
                 /* and decrement the total number of vertices (new vertice ids are contiguous */
                 pBNS->num_vertices --;
                 ret ++;
@@ -6068,7 +6068,7 @@ int bRestoreBnsAfterCheckAltPath( BN_STRUCT *pBNS, ALT_PATH_CHANGES *apc, int bC
                     pBNS->num_edges --;
                 }
                 /* clear the new vertex */
-                memset( pNewVert, 0, sizeof( pNewVert ) );
+                memset( pNewVert, 0, sizeof(BNS_VERTEX) );
                 /* and decrement the total number of vertices (new vertice ids are contiguous */
                 pBNS->num_vertices --;
                 ret ++;
@@ -9611,8 +9611,8 @@ int ReInitBnStructForAltBns( BN_STRUCT *pBNS, inp_ATOM *at, int num_atoms, int b
                     break;
 
                 }
-                pBond->nBondNonStereoAltBns =
-                pBond->nBlockNumberAltBns   =
+                pBond->nBondNonStereoAltBns = 0;
+                pBond->nBlockNumberAltBns   = 0;
                 pBond->nNumAtInBlockAltBns  = 0;
 
 #if ( RESET_EDGE_FORBIDDEN_MASK == 1 )

--- a/src/formats/libinchi/ichimake.c
+++ b/src/formats/libinchi/ichimake.c
@@ -2085,7 +2085,7 @@ int CompareReversedStereoINChI2( INChI_Stereo *s1/* InChI from reversed struct *
     int nNumSb1 = s1? s1->nNumberOfStereoBonds   : 0;
     int nNumSb2 = s2? s2->nNumberOfStereoBonds   : 0;
     
-    if ( (nNumSc1 || nNumSc1) &&
+    if ( (nNumSc1 || nNumSc2) &&
          ( nNumSc1 != nNumSc2 ||
            memcmp( s1->nNumber,  s2->nNumber,  nNumSc1*sizeof(s1->nNumber[0] ) ) ||
            memcmp( s1->t_parity, s2->t_parity, nNumSc1*sizeof(s1->t_parity[0]) ) ) ) {

--- a/src/formats/mdffformat.cpp
+++ b/src/formats/mdffformat.cpp
@@ -230,7 +230,7 @@ namespace OpenBabel {
         ifs_ions.getline(buffer, BUFF_SIZE); 
         tokenize(vs, buffer);
         vs.erase(find(vs.begin(), vs.end(), "!") ,vs.end());
-        remove(vs.begin(), vs.end(), "=");        
+        vs.erase(remove(vs.begin(), vs.end(), "="));
                 
         if(vs.size() == 0)
           continue;

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -43,7 +43,7 @@ namespace OpenBabel
       return
         "Sybyl Mol2 format\n"
         "Read Options e.g. -ac\n"
-        "  c               Read UCSF Dock scores saved in comments preceeding molecules\n\n";
+        "  c               Read UCSF Dock scores saved in comments preceeding molecules\n\n"
         "Write Options e.g. -xl\n"
         "  l               Output ignores residue information (only ligands)\n\n";
         "  c               Write UCSF Dock scores saved in comments preceeding molecules\n\n";


### PR DESCRIPTION
[src/data.cpp:108]: (error) Width 4 given in format string (no. 2) is larger than destination buffer 'symbol[4]', use %3s to prevent overflowing it.
[src/forcefields/forcefieldmm2.cpp:496]: (style) 'operator=' should return reference to 'this' instance.
[src/forcefields/forcefieldmm2.cpp:354]: (style) Unused variable: idx
[src/forcefields/forcefieldmm2.cpp:519]: (style) Unused variable: filename
[src/forcefields/forcefieldmm2.cpp:520]: (style) Unused variable: currently_parsing
[src/formats/libinchi/ichi_bns.c:6018]: (warning) Size of pointer 'pNewVert' used instead of size of its data.
[src/formats/libinchi/ichi_bns.c:6071]: (warning) Size of pointer 'pNewVert' used instead of size of its data.
[src/formats/libinchi/ichi_bns.c:9614]: (error) Expression 'pBond.cap=pBond.flow=pBond.cap=0' depends on order of evaluation of side effects
[src/formats/libinchi/ichimake.c:2088] -> [src/formats/libinchi/ichimake.c:2088]: (style) Same expression on both sides of '||'
[src/formats/mdffformat.cpp:233]: (warning) Return value of std::remove() ignored. Elements remain in container
[src/formats/mol2format.cpp:47]: (style) Statements following return, break, continue, goto or throw will never be executed