### PR TITLE
Fixed a problem with reading POSCARs.

### DIFF
--- a/src/formats/vaspformat.cpp
+++ b/src/formats/vaspformat.cpp
@@ -309,6 +309,8 @@ namespace OpenBabel {
       vector3 coords (x,y,z);
       if (!cartesian)
         coords = cell->FractionalToCartesian( coords );
+      // If we have Cartesian coordinates, we need to apply the scaling factor
+      else coords *= scale;
       atom->SetVector(coords);
       //if the selective dynamics info is present then read it into OBPairData
       //this needs to be kept somehow to be able to write out the same as input


### PR DESCRIPTION
According to the POSCAR file description at http://cms.mpi.univie.ac.at/vasp/vasp/POSCAR_file.html: "The second line provides a universal scaling factor ('lattice constant'), which is used to scale all lattice vectors and all atomic coordinates." When using Cartesian coordinates, we need to scale the coordinates of the atoms with the scaling factor.