### PR TITLE
UFF forcefield: fix missing SetupPointers()

### DIFF
--- a/src/forcefields/forcefielduff.cpp
+++ b/src/forcefields/forcefielduff.cpp
@@ -1529,6 +1529,24 @@ namespace OpenBabel {
     return true;
   }
 
+  bool OBForceFieldUFF::SetupPointers()
+  {
+    for (unsigned int i = 0; i < _bondcalculations.size(); ++i)
+      _bondcalculations[i].SetupPointers();
+    for (unsigned int i = 0; i < _anglecalculations.size(); ++i)
+      _anglecalculations[i].SetupPointers();
+    for (unsigned int i = 0; i < _torsioncalculations.size(); ++i)
+      _torsioncalculations[i].SetupPointers();
+     for (unsigned int i = 0; i < _oopcalculations.size(); ++i)
+      _oopcalculations[i].SetupPointers();
+    for (unsigned int i = 0; i < _vdwcalculations.size(); ++i)
+      _vdwcalculations[i].SetupPointers();
+    for (unsigned int i = 0; i < _electrostaticcalculations.size(); ++i)
+      _electrostaticcalculations[i].SetupPointers();
+
+    return true;
+  }
+
   bool OBForceFieldUFF::ParseParamFile()
   {
     vector<string> vs;

--- a/src/forcefields/forcefielduff.h
+++ b/src/forcefields/forcefielduff.h
@@ -98,6 +98,8 @@ namespace OpenBabel
     bool SetTypes();
     //!  Fill OBFFXXXCalculation vectors
     bool SetupCalculations();
+    //! Setup pointers in OBFFXXXCalculation vectors
+    bool SetupPointers();
     bool SetupVDWCalculation(OBAtom *a, OBAtom *b, OBFFVDWCalculationUFF &vdwcalc);
     //!  By default, electrostatic terms are disabled
     //!  This is discouraged, since the parameterization is not designed for it


### PR DESCRIPTION
I noticed slight differences in the FF calculation results for repeated calculations of the same structure using UFF. The error stems from a missing SetupPointers() override.
gaff, ghemical, mmff94 all use OBFFCalculation objects and override the forcefield base function SetupPointers() to assure that the coordinate pointers are setup properly. The patch fixes the error, such that repeated calculations lead to the same results.
