### PR TITLE
Add deprecation warning for babel

### DIFF
--- a/tools/babel.cpp
+++ b/tools/babel.cpp
@@ -413,7 +413,7 @@ void deprecation()
   cout << "WARNING: babel is deprecated and will be removed in a future release" << endl
     << "         of Open Babel. You should use obabel instead. For information" << endl
     << "         on the differences please see:"
-    << endl << "             http://openbabel.org/docs/current/Command-line_tools"
+    << endl << "             http://openbabel.org/docs/current/Command-line_tools/babel.html"
     << endl;
 }
 

--- a/tools/babel.cpp
+++ b/tools/babel.cpp
@@ -408,6 +408,15 @@ void DoOption(const char* p, OBConversion& Conv,
   }
 }
 
+void deprecation()
+{
+  cout << "WARNING: babel is deprecated and will be removed in a future release" << endl
+    << "         of Open Babel. You should use obabel instead. For information" << endl
+    << "         on the differences please see:"
+    << endl << "             http://openbabel.org/docs/current/Command-line_tools"
+    << endl;
+}
+
 void usage()
 {
   cout << "Open Babel " << BABEL_VERSION << " -- " << __DATE__ << " -- "
@@ -415,6 +424,8 @@ void usage()
   cout << "Usage: " << program_name
        << " [-i<input-type>] <name> [-o<output-type>] <name>" << endl;
   cout << "Try  -H option for more information." << endl;
+  cout << endl;
+  deprecation();
 
 #ifdef _DEBUG
   //CM keep window open
@@ -429,6 +440,10 @@ void help()
 {
   cout << "Open Babel converts chemical structures from one file format to another"<< endl << endl;
   cout << "Usage: " << program_name << " <input spec> <output spec> [Options]" << endl << endl;
+
+  deprecation();
+  cout << endl;
+
   cout << "Each spec can be a file whose extension decides the format." << endl;
   cout << "Optionally the format can be specified by preceding the file by" << endl;
   cout << "-i<format-type> e.g. -icml, for input and -o<format-type> for output" << endl << endl;


### PR DESCRIPTION
For "babel -H", the warning is added near the top of the help text
For "babel" just on its own, the warning is added at the end of the short usage information.
For other uses, no warning is given.

The text is:
<pre>
WARNING: babel is deprecated and will be removed in a future release
         of Open Babel. You should use obabel instead. For information
         on the differences please see:
             http://openbabel.org/docs/current/Command-line_tools
</pre>