### PR TITLE
Remove OBAtom::IsThiocarboxylSulfur from the public API

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -461,9 +461,6 @@ namespace OpenBabel
       bool IsOneFour(OBAtom*);
       //! \return Is this atom an oxygen in a carboxyl (-CO2 or CO2H) group?
       bool IsCarboxylOxygen();
-      //! \return Is this atom a sulfur in a (di)thiocarboxyl (-CS2, -COS, CS2H or COSH) group?
-      //! \since version 2.4
-      bool IsThiocarboxylSulfur();
       //! \return Is this atom an oxygen in a phosphate (R-PO3) group?
       bool IsPhosphateOxygen();
       //! \return Is this atom an oxygen in a sulfate (-SO3) group?

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -655,35 +655,6 @@ namespace OpenBabel
     return(true);
   }
 
-  bool OBAtom::IsThiocarboxylSulfur()
-  {
-    if (!IsSulfur())
-      return(false);
-    if (GetHvyValence() != 1)
-      return(false);
-
-    OBAtom *atom;
-    OBBond *bond;
-    OBBondIterator i;
-
-    atom = NULL;
-    for (bond = BeginBond(i);bond;bond = NextBond(i))
-      if ((bond->GetNbrAtom(this))->IsCarbon())
-        {
-          atom = bond->GetNbrAtom(this);
-          break;
-        }
-    if (!atom)
-      return(false);
-    if (!(atom->CountFreeSulfurs() == 2)
-      && !(atom->CountFreeOxygens() == 1 && atom->CountFreeSulfurs() == 1))
-      return(false);
-
-    //atom is connected to a carbon that has a total
-    //of 2 attached free sulfurs or 1 free oxygen and 1 free sulfur
-    return(true);
-  }
-
   bool OBAtom::IsPhosphateOxygen()
   {
     if (!IsOxygen())

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -72,7 +72,6 @@ namespace OpenBabel
   
   // Helper function for ReadMolecule
   // \return Is this atom a sulfur in a (di)thiocarboxyl (-CS2, -COS, CS2H or COSH) group?
-  bool IsThiocarboxylSulfur();
   static bool IsThiocarboxylSulfur(OBAtom* queryatom)
   {
     if (!queryatom->IsSulfur())


### PR DESCRIPTION
I've moved OBAtom::IsThiocarboxylSulfur to being a helper function in MOL2