### PR TITLE
Remove OBBond::IsAmidine and IsImide from public API

### DIFF
--- a/include/openbabel/bond.h
+++ b/include/openbabel/bond.h
@@ -269,16 +269,10 @@ namespace OpenBabel
       //! \return Is the bond a teriary amide (i.e., between a carbonyl C and a NH0)?
       //!  \since version 2.3.
       bool IsTertiaryAmide();
-      //! \return Is the bond an amidine link (i.e., between an imide C and a N)?
-      //! \since version 2.4
-      bool IsAmidine();
       //! \return Is the bond an ester link (i.e., between a carbonyl C and an O)?
       bool IsEster();
       //! \return Is the bond a carbonyl C=O?
       bool IsCarbonyl();
-      //! \return Is the bond an imide C=N?
-      //! \since version 2.4
-      bool IsImide();
       //! \return Is the bond a single bond?
       bool IsSingle();
       //! \return Is the bond is a double bond?

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -329,38 +329,6 @@ namespace OpenBabel
       return(false);
    }
 
-   bool OBBond::IsAmidine()
-   {
-      OBAtom *c,*n;
-      c = n = NULL;
-
-      // Look for C-N bond
-      if (_bgn->GetAtomicNum() == 6 && _end->GetAtomicNum() == 7)
-      {
-         c = (OBAtom*)_bgn;
-         n = (OBAtom*)_end;
-      }
-      if (_bgn->GetAtomicNum() == 7 && _end->GetAtomicNum() == 6)
-      {
-         c = (OBAtom*)_end;
-         n = (OBAtom*)_bgn;
-      }
-      if (!c || !n) return(false);
-      if (GetBondOrder() != 1) return(false);
-      if (n->GetImplicitValence() != 3) return(false);
-
-      // Make sure C is attached to =N
-      OBBond *bond;
-      vector<OBBond*>::iterator i;
-      for (bond = c->BeginBond(i); bond; bond = c->NextBond(i))
-      {
-         if (bond->IsImide()) return(true);
-      }
-
-      // Return
-      return(false);
-   }
-
 /*
   bool OBBond::IsAmide()
   {
@@ -496,18 +464,6 @@ namespace OpenBabel
 
     if ((_bgn->GetAtomicNum() == 6 && _end->GetAtomicNum() == 8) ||
         (_bgn->GetAtomicNum() == 8 && _end->GetAtomicNum() == 6))
-      return(true);
-
-    return(false);
-  }
-
-  bool OBBond::IsImide()
-  {
-    if (GetBO() != 2)
-      return(false);
-
-    if ((_bgn->GetAtomicNum() == 6 && _end->GetAtomicNum() == 7) ||
-        (_bgn->GetAtomicNum() == 7 && _end->GetAtomicNum() == 6))
       return(true);
 
     return(false);

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -676,13 +676,61 @@ namespace OpenBabel
     return count;
   }
 
+  static bool IsImide(OBBond* querybond)
+  {
+    if (querybond->GetBO() != 2)
+      return(false);
+
+    OBAtom* bgn = querybond->GetBeginAtom();
+    OBAtom* end = querybond->GetEndAtom();
+    if ((bgn->GetAtomicNum() == 6 && end->GetAtomicNum() == 7) ||
+      (bgn->GetAtomicNum() == 7 && end->GetAtomicNum() == 6))
+      return(true);
+
+    return(false);
+  }
+
+  static bool IsAmidine(OBBond* querybond)
+  {
+    OBAtom *c, *n;
+    c = n = NULL;
+
+    // Look for C-N bond
+    OBAtom* bgn = querybond->GetBeginAtom();
+    OBAtom* end = querybond->GetEndAtom();
+    if (bgn->GetAtomicNum() == 6 && end->GetAtomicNum() == 7)
+    {
+      c = bgn;
+      n = end;
+    }
+    if (bgn->GetAtomicNum() == 7 && end->GetAtomicNum() == 6)
+    {
+      c = end;
+      n =bgn;
+    }
+    if (!c || !n) return(false);
+    if (querybond->GetBondOrder() != 1) return(false);
+    if (n->GetImplicitValence() != 3) return(false);
+
+    // Make sure C is attached to =N
+    OBBond *bond;
+    vector<OBBond*>::iterator i;
+    for (bond = c->BeginBond(i); bond; bond = c->NextBond(i))
+    {
+      if (IsImide(bond)) return(true);
+    }
+
+    // Return
+    return(false);
+  }
+
 
   /////////////////////////////////////////////////////////////////////////
   bool IsRotBond_PDBQT(OBBond * the_bond)
   //identifies a bond as rotatable if it is a single bond, not amide, not in a ring,
   //and if both atoms it connects have at least one other atom bounded to them
   {
-    if ( !the_bond->IsSingle() || the_bond->IsAmide() || the_bond->IsAmidine() || the_bond->IsInRing() ) {return false;}
+    if ( !the_bond->IsSingle() || the_bond->IsAmide() || IsAmidine(the_bond) || the_bond->IsInRing() ) {return false;}
     if ( ((the_bond->GetBeginAtom())->GetValence() == 1) || ((the_bond->GetEndAtom())->GetValence() == 1) ) {return false;}
     return true;
   }


### PR DESCRIPTION
These functions are used by pdbqtformat.cpp in the context of determining whether a bond is rotatable.
