### PR TITLE
Fix comment symbol in swig interfaces

### DIFF
--- a/scripts/openbabel-R.i
+++ b/scripts/openbabel-R.i
@@ -268,7 +268,7 @@ CAST_GENERICDATA_TO(VirtualBond)
 %warnfilter(516) OpenBabel::SpaceGroup; // Ignoring std::string methods in favour of char* ones
 %include <openbabel/math/spacegroup.h>
 
-# CloneData should be used instead of the following method
+// CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
 %ignore OpenBabel::OBBase::GetData(char const *);
 %ignore OpenBabel::OBBase::HasData(char const *);
@@ -351,7 +351,7 @@ IGNORE_ITER(OBMol, Residue)
 
 %warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
 %include <openbabel/bitvec.h>
-# Ignore shadowed method
+// Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>
 %ignore OpenBabel::Swab;
@@ -359,7 +359,7 @@ IGNORE_ITER(OBMol, Residue)
 %include <openbabel/spectrophore.h>
 #ifdef HAVE_EIGEN
 
-# Ignore shadowed methods
+// Ignore shadowed methods
 %ignore OpenBabel::OBForceField::VectorSubtract(const double *const, const double *const, double *);
 %ignore OpenBabel::OBForceField::VectorMultiply(const double *const, const double, double *);
 %warnfilter(516) OpenBabel::OBForceField; // Ignoring std::string methods in favour of char* ones
@@ -370,13 +370,13 @@ IGNORE_ITER(OBMol, Residue)
 %include <openbabel/math/align.h>
 #endif
 
-# The following %ignores avoid warning messages due to shadowed classes.
-# This does not imply a loss of functionality as (in this case)
-# the shadowed class is identical (from the point of view of SWIG) to
-# the shadowing class.
-# This is because C++ references (&) are transformed by SWIG back into
-# pointers, so that OBAtomIter(OBMol &) would be treated the same as
-# OBAtomIter(OBMol *).
+// The following %ignores avoid warning messages due to shadowed classes.
+// This does not imply a loss of functionality as (in this case)
+// the shadowed class is identical (from the point of view of SWIG) to
+// the shadowing class.
+// This is because C++ references (&) are transformed by SWIG back into
+// pointers, so that OBAtomIter(OBMol &) would be treated the same as
+// OBAtomIter(OBMol *).
 
 %ignore OBAtomAtomIter(OBAtom &);
 %ignore OBAtomBondIter(OBAtom &);

--- a/scripts/openbabel-java.i
+++ b/scripts/openbabel-java.i
@@ -233,7 +233,7 @@ CAST_GENERICDATA_TO(VirtualBond)
 %warnfilter(516) OpenBabel::SpaceGroup; // Ignoring std::string methods in favour of char* ones
 %include <openbabel/math/spacegroup.h>
 
-# CloneData should be used instead of the following method
+// CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
 %ignore OpenBabel::OBBase::GetData(char const *);
 %ignore OpenBabel::OBBase::HasData(char const *);
@@ -313,7 +313,7 @@ IGNORE_ITER(OBMol, Residue)
 %ignore OpenBabel::OBForceField::DiverseConfGen;
 #endif
 
-# Ignore shadowed methods
+// Ignore shadowed methods
 %ignore OpenBabel::OBForceField::VectorSubtract(const double *const, const double *const, double *);
 %ignore OpenBabel::OBForceField::VectorMultiply(const double *const, const double, double *);
 %warnfilter(516) OpenBabel::OBForceField; // Ignoring std::string methods in favour of char* ones
@@ -331,20 +331,20 @@ IGNORE_ITER(OBMol, Residue)
 
 %warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
 %include <openbabel/bitvec.h>
-# Ignore shadowed method
+// Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>
 %ignore OpenBabel::Swab;
 %include <openbabel/rotamer.h>
 %include <openbabel/spectrophore.h>
 
-# The following %ignores avoid warning messages due to shadowed classes.
-# This does not imply a loss of functionality as (in this case)
-# the shadowed class is identical (from the point of view of SWIG) to
-# the shadowing class.
-# This is because C++ references (&) are transformed by SWIG back into
-# pointers, so that OBAtomIter(OBMol &) would be treated the same as
-# OBAtomIter(OBMol *).
+// The following %ignores avoid warning messages due to shadowed classes.
+// This does not imply a loss of functionality as (in this case)
+// the shadowed class is identical (from the point of view of SWIG) to
+// the shadowing class.
+// This is because C++ references (&) are transformed by SWIG back into
+// pointers, so that OBAtomIter(OBMol &) would be treated the same as
+// OBAtomIter(OBMol *).
 
 %ignore OBAtomAtomIter(OBAtom &);
 %ignore OBAtomBondIter(OBAtom &);

--- a/scripts/openbabel-mono.i
+++ b/scripts/openbabel-mono.i
@@ -315,13 +315,13 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %include <openbabel/bitvec.h>
 
-# The following %ignores avoid warning messages due to shadowed classes.
-# This does not imply a loss of functionality as (in this case)
-# the shadowed class is identical (from the point of view of SWIG) to
-# the shadowing class.
-# This is because C++ references (&) are transformed by SWIG back into
-# pointers, so that OBAtomIter(OBMol &) would be treated the same as
-# OBAtomIter(OBMol *).
+// The following %ignores avoid warning messages due to shadowed classes.
+// This does not imply a loss of functionality as (in this case)
+// the shadowed class is identical (from the point of view of SWIG) to
+// the shadowing class.
+// This is because C++ references (&) are transformed by SWIG back into
+// pointers, so that OBAtomIter(OBMol &) would be treated the same as
+// OBAtomIter(OBMol *).
 
 %ignore OBAtomAtomIter(OBAtom &);
 %ignore OBAtomBondIter(OBAtom &);

--- a/scripts/openbabel-perl.i
+++ b/scripts/openbabel-perl.i
@@ -179,7 +179,7 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %import <openbabel/math/spacegroup.h>
 
-%# CloneData should be used instead of the following method
+// CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
 %rename(_local) OpenBabel::local;
 %include <openbabel/base.h>
@@ -224,7 +224,7 @@ namespace std { class stringbuf {}; }
 %ignore OpenBabel::OBForceField::DiverseConfGen;
 #endif
 
-%# Ignore shadowed methods
+// Ignore shadowed methods
 %ignore OpenBabel::OBForceField::VectorSubtract(const double *const, const double *const, double *);
 %ignore OpenBabel::OBForceField::VectorMultiply(const double *const, const double, double *);
 %include <openbabel/forcefield.h>
@@ -234,20 +234,20 @@ namespace std { class stringbuf {}; }
 
 %warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
 %include <openbabel/bitvec.h>
-%# Ignore shadowed method
+// Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %warnfilter(314); // 'next' is a Perl keyword
 %include <openbabel/rotor.h>
 %ignore OpenBabel::Swab;
 %include <openbabel/rotamer.h>
 
-%# The following %ignores avoid warning messages due to shadowed classes.
-%# This does not imply a loss of functionality as (in this case)
-%# the shadowed class is identical (from the point of view of SWIG) to
-%# the shadowing class.
-%# This is because C++ references (&) are transformed by SWIG back into
-%# pointers, so that OBAtomIter(OBMol &) would be treated the same as
-%# OBAtomIter(OBMol *).
+// The following %ignores avoid warning messages due to shadowed classes.
+// This does not imply a loss of functionality as (in this case)
+// the shadowed class is identical (from the point of view of SWIG) to
+// the shadowing class.
+// This is because C++ references (&) are transformed by SWIG back into
+// pointers, so that OBAtomIter(OBMol &) would be treated the same as
+// OBAtomIter(OBMol *).
 
 %ignore OBAtomAtomIter(OBAtom &);
 %ignore OBAtomBondIter(OBAtom &);

--- a/scripts/openbabel-php.i
+++ b/scripts/openbabel-php.i
@@ -214,7 +214,7 @@ CAST_GENERICDATA_TO(VirtualBond)
 %include <openbabel/math/transform3d.h>
 %include <openbabel/math/spacegroup.h>
 
-# CloneData should be used instead of the following method
+// CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
 %include <openbabel/base.h>
 
@@ -264,7 +264,7 @@ IGNORE_ITER(OBMol, Residue)
 %ignore OpenBabel::OBDescriptor::LessThan;
 %include <openbabel/descriptor.h>
 
-# Ignore shadowed methods
+// Ignore shadowed methods
 %ignore OpenBabel::OBForceField::VectorSubtract(const double *const, const double *const, double *);
 %ignore OpenBabel::OBForceField::VectorMultiply(const double *const, const double, double *);
 %include <openbabel/forcefield.h>
@@ -281,7 +281,7 @@ IGNORE_ITER(OBMol, Residue)
 
 %warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
 %include <openbabel/bitvec.h>
-# Ignore shadowed method
+// Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>
 %ignore OpenBabel::Swab;
@@ -293,13 +293,13 @@ IGNORE_ITER(OBMol, Residue)
 %include <openbabel/math/align.h>
 #endif
 
-# The following %ignores avoid warning messages due to shadowed classes.
-# This does not imply a loss of functionality as (in this case)
-# the shadowed class is identical (from the point of view of SWIG) to
-# the shadowing class.
-# This is because C++ references (&) are transformed by SWIG back into
-# pointers, so that OBAtomIter(OBMol &) would be treated the same as
-# OBAtomIter(OBMol *).
+// The following %ignores avoid warning messages due to shadowed classes.
+// This does not imply a loss of functionality as (in this case)
+// the shadowed class is identical (from the point of view of SWIG) to
+// the shadowing class.
+// This is because C++ references (&) are transformed by SWIG back into
+// pointers, so that OBAtomIter(OBMol &) would be treated the same as
+// OBAtomIter(OBMol *).
 
 %ignore OBAtomAtomIter(OBAtom &);
 %ignore OBAtomBondIter(OBAtom &);
@@ -320,7 +320,7 @@ IGNORE_ITER(OBMol, Residue)
 
 %include <openbabel/obiter.h>
 
-# Functions to set the log file to std::cout and std::cerr
+// Functions to set the log file to std::cout and std::cerr
        
 %ignore OBForceField::SetLogFile(std::ostream *pos);
 %extend OpenBabel::OBForceField {

--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -229,7 +229,7 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 %include <openbabel/math/transform3d.h>
 %include <openbabel/math/spacegroup.h>
 
-%# CloneData should be used instead of the following method
+// CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
 %include <openbabel/base.h>
 
@@ -291,7 +291,7 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 %ignore OpenBabel::OBDescriptor::LessThan;
 %include <openbabel/descriptor.h>
 
-%# Ignore shadowed methods
+// Ignore shadowed methods
 %ignore OpenBabel::OBForceField::VectorSubtract(const double *const, const double *const, double *);
 %ignore OpenBabel::OBForceField::VectorMultiply(const double *const, const double, double *);
 %include <openbabel/forcefield.h>
@@ -312,7 +312,7 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 
 %warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
 %include <openbabel/bitvec.h>
-%# Ignore shadowed method
+// Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>
 %ignore OpenBabel::Swab;
@@ -323,13 +323,13 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 %include <openbabel/math/align.h>
 #endif
 
-%# The following %ignores avoid warning messages due to shadowed classes.
-%# This does not imply a loss of functionality as (in this case)
-%# the shadowed class is identical (from the point of view of SWIG) to
-%# the shadowing class.
-%# This is because C++ references (&) are transformed by SWIG back into
-%# pointers, so that OBAtomIter(OBMol &) would be treated the same as
-%# OBAtomIter(OBMol *).
+// The following %ignores avoid warning messages due to shadowed classes.
+// This does not imply a loss of functionality as (in this case)
+// the shadowed class is identical (from the point of view of SWIG) to
+// the shadowing class.
+// This is because C++ references (&) are transformed by SWIG back into
+// pointers, so that OBAtomIter(OBMol &) would be treated the same as
+// OBAtomIter(OBMol *).
 
 %ignore OBAtomAtomIter(OBAtom &);
 %ignore OBAtomBondIter(OBAtom &);
@@ -348,9 +348,9 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 %ignore OBResidueIter(OBMol &);
 %ignore OBResidueAtomIter(OBResidue &);
 
-%# These classes are renamed so that they can be replaced by Python
-%# classes of the same name which provide Pythonic iterators
-%# (see %pythoncode section below)
+// These classes are renamed so that they can be replaced by Python
+// classes of the same name which provide Pythonic iterators
+// (see %pythoncode section below)
 
 %rename(_OBAtomAtomIter) OpenBabel::OBAtomAtomIter;
 %rename(_OBAtomBondIter) OpenBabel::OBAtomBondIter;
@@ -369,8 +369,8 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 
 %include <openbabel/obiter.h>
 
-%# The following class, OBiter, is subclassed to provide Python iterators
-%# equivalent to the C++ iterators in obiter.h and the plugin iterators
+// The following class, OBiter, is subclassed to provide Python iterators
+// equivalent to the C++ iterators in obiter.h and the plugin iterators
 
 %pythoncode %{
 class OBIter(object):
@@ -460,7 +460,7 @@ def double_array(mylist):
     return c
 %}
 
-%# Copy some of the global variables in cvar into the openbabel namespace
+// Copy some of the global variables in cvar into the openbabel namespace
 
 %pythoncode %{
 obErrorLog = cvar.obErrorLog
@@ -471,7 +471,7 @@ atomtyper = cvar.atomtyper
 aromtyper = cvar.aromtyper
 %}
 
-%# Functions to set the log file to std::cout and std::cerr
+// Functions to set the log file to std::cout and std::cerr
        
 %ignore OBForceField::SetLogFile(std::ostream *pos);
 %extend OpenBabel::OBForceField {

--- a/scripts/openbabel-ruby.i
+++ b/scripts/openbabel-ruby.i
@@ -181,7 +181,7 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %import <openbabel/math/spacegroup.h>
 
-%# CloneData should be used instead of the following method
+// CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
 %include <openbabel/base.h>
 %include <openbabel/generic.h>
@@ -217,7 +217,7 @@ namespace std { class stringbuf {}; }
 %include <openbabel/fingerprint.h>
 %include <openbabel/descriptor.h>
 
-%# Ignore shadowed methods
+// Ignore shadowed methods
 %ignore OpenBabel::OBForceField::VectorSubtract(const double *const, const double *const, double *);
 %ignore OpenBabel::OBForceField::VectorMultiply(const double *const, const double, double *);
 #ifdef HAVE_EIGEN
@@ -241,13 +241,13 @@ namespace std { class stringbuf {}; }
 %ignore OpenBabel::Swab;
 %include <openbabel/rotamer.h>
 
-%# The following %ignores avoid warning messages due to shadowed classes.
-%# This does not imply a loss of functionality as (in this case)
-%# the shadowed class is identical (from the point of view of SWIG) to
-%# the shadowing class.
-%# This is because C++ references (&) are transformed by SWIG back into
-%# pointers, so that OBAtomIter(OBMol &) would be treated the same as
-%# OBAtomIter(OBMol *).
+// The following %ignores avoid warning messages due to shadowed classes.
+// This does not imply a loss of functionality as (in this case)
+// the shadowed class is identical (from the point of view of SWIG) to
+// the shadowing class.
+// This is because C++ references (&) are transformed by SWIG back into
+// pointers, so that OBAtomIter(OBMol &) would be treated the same as
+// OBAtomIter(OBMol *).
 
 %ignore OBAtomAtomIter(OBAtom &);
 %ignore OBAtomBondIter(OBAtom &);


### PR DESCRIPTION
Swig uses C style comments. Earlier I was using "#" sometimes which now causes a Swig error. Another dev had changed a few of these to %#. I have changed everything to //.