### PR TITLE
Fix in OBForceField::WeightedRotorSearch.

### DIFF
--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -1825,7 +1825,7 @@ namespace OpenBabel
       }
     }
 
-    _current_conformer = best_conformer + 1; // Initial coords are stored in _vconf[0]
+    _current_conformer = best_conformer; // Initial coords are stored in _vconf[0]
     _mol.SetConformer(_current_conformer);
     SetupPointers(); // update pointers to atom positions in the OBFFCalculation objects
   }


### PR DESCRIPTION
The WeightedRotorSearch method of the OBForceField class returned wrong
index to the conformer of the lowest energy.  Although the method worked
correctly, it returned incorrect result. I think this must be somehow
related to a change in indexing conformers which did not propagate fully
to dependent classes. The change is minimal.