### PR TITLE
Set the aspect ratio to 2.0 for ASCII depictions in SD files

### DIFF
--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -802,6 +802,7 @@ namespace OpenBabel
     if (!ok)
       return;
     obconv.AddOption("w", obconv.OUTOPTIONS, "78");
+    obconv.AddOption("a", obconv.OUTOPTIONS, "2.0");
     std::string ascii = obconv.WriteString(pmol);
 
     // Add a "." as prefix to each line as otherwise OB


### PR DESCRIPTION
The default aspect ratio of 1.5 (set selfishly to suit the Windows command prompt) is likely to produce elongated structures when viewing SD files in an editor so I'm setting the ratio to 2.0 here.