### PR TITLE
Fix for logic when there is an existing ASCII depiction in an SD file

### DIFF
--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -824,10 +824,11 @@ namespace OpenBabel
       pd = (OBPairData*)pmol->GetData("ASCII depiction");
     else {
       pd = new OBPairData();
+      pmol->SetData(pd);
       pd->SetAttribute("ASCII depiction");
     }
     pd->SetValue(mod.substr(0, lastNonBlank+1));
-    pmol->SetData(pd);
+
   }
 
   /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The original code added the same PairData a second time if there was an existing ASCII depiction