### PR TITLE
Fixed bug related to charges from cdx file

### DIFF
--- a/src/formats/chemdrawcdx.cpp
+++ b/src/formats/chemdrawcdx.cpp
@@ -686,7 +686,7 @@ puts("found name");
 
   int getCharge(istream *ifs, UINT32 size)
   {
-    int charge - 0;
+    int charge = 0;
     char tmp_charge;
 
     if(size == 4)		// Bug in ChemDraw 8.0, see http://www.cambridgesoft.com/services/documentation/sdk/chemdraw/cdx/properties/Atom_Charge.htm

--- a/src/formats/chemdrawcdx.cpp
+++ b/src/formats/chemdrawcdx.cpp
@@ -686,7 +686,8 @@ puts("found name");
 
   int getCharge(istream *ifs, UINT32 size)
   {
-    int charge;
+    int charge - 0;
+    char tmp_charge;
 
     if(size == 4)		// Bug in ChemDraw 8.0, see http://www.cambridgesoft.com/services/documentation/sdk/chemdraw/cdx/properties/Atom_Charge.htm
       {
@@ -695,10 +696,9 @@ puts("found name");
     else
       if(size == 1)
         {
-          ifs->read((char *)&charge, size);
-#if __BYTE_ORDER == __BIG_ENDIAN
-          charge = charge >> 24;
-#endif
+          ifs->read(&tmp_charge, size);
+          charge = int(tmp_charge);
+         
         }
       else
         return 0;

--- a/src/formats/chemdrawcdx.cpp
+++ b/src/formats/chemdrawcdx.cpp
@@ -698,7 +698,9 @@ puts("found name");
         {
           ifs->read(&tmp_charge, size);
           charge = int(tmp_charge);
-         
+#if __BYTE_ORDER == __BIG_ENDIAN
+          charge = charge >> 24;
+#endif
         }
       else
         return 0;


### PR DESCRIPTION
Problem reading the charges from the CDX file (e.g. M  CHG  2   432513   832767  instead of M  CHG  2   4   1   8  -1;  value of 32767 instead of -1).
