### PR TITLE
restore NumRotors behavior and add rotor count output to obprop

### DIFF
--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -279,8 +279,8 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     unsigned int NumHvyAtoms();
     //! \return the number of residues (i.e. OBResidue substituents)
     unsigned int NumResidues() const      { return(static_cast<unsigned int> (_residue.size())); }
-    //! \return the number of rotatable bonds. See OBBond::IsRotor() for details
-    unsigned int NumRotors();
+    //! \return the number of rotatable bonds. If sampleRingBonds is true, will include rotors within rings (see OBBond::IsRotor() for details)
+    unsigned int NumRotors(bool sampleRingBonds=false);
 
     //! \return the atom at index @p idx or NULL if it does not exist.
     //! \warning Atom indexing will change. Use iterator methods instead.

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -792,17 +792,11 @@ namespace OpenBabel
     return(count);
   }
 
-  unsigned int OBMol::NumRotors()
+  unsigned int OBMol::NumRotors(bool sampleRingBonds)
   {
-    OBBond *bond;
-    vector<OBBond*>::iterator i;
-
-    unsigned int count = 0;
-    for (bond = BeginBond(i);bond;bond = NextBond(i))
-      if (bond->IsRotor())
-        count++;
-
-    return(count);
+    OBRotorList rl;
+    rl.FindRotors(*this, sampleRingBonds);
+    return rl.Size();
   }
 
   //! Returns a pointer to the atom after a safety check

--- a/tools/obprop.cpp
+++ b/tools/obprop.cpp
@@ -157,6 +157,7 @@ int main(int argc,char **argv)
       cout << "num_atoms        " << mol.NumAtoms() << endl;
       cout << "num_bonds        " << mol.NumBonds() << endl;
       cout << "num_residues     " << mol.NumResidues() << endl;
+      cout << "num_rotors       " << mol.NumRotors() << endl;
       if (mol.NumResidues() > 0)
         cout << "sequence         " << sequence(mol) << endl;
       else

--- a/tools/obprop.cpp
+++ b/tools/obprop.cpp
@@ -65,6 +65,7 @@ int main(int argc,char **argv)
         "num_atoms  NUM\n"
         "num_bonds  NUM\n"
         "num_residues  NUM\n"
+	"num_rotors NUM\n"
         "sequence RESIDUE_SEQUENCE\n"
         "num_rings NUMBER_OF_RING_(SSSR)\n"
         "logP   NUM\n"


### PR DESCRIPTION
For assessing ligand flexibility, counting rotors within rings is highly undesirable.  This patch restores the old behavior of NumRotors and makes the new behavior available with a boolean argument.

Internally, there don't appear to be any dependences in NumRotors, so restoring the old behavior will probably keep the most people happy.