### PR TITLE
Bugfix for multi-model PDB writing

### DIFF
--- a/src/formats/pdbformat.cpp
+++ b/src/formats/pdbformat.cpp
@@ -734,10 +734,15 @@ namespace OpenBabel
     snprintf(buffer, BUFF_SIZE, "%4d    0 %4d    0\n",mol.NumAtoms(),mol.NumAtoms());
     ofs << buffer;
 
-    ofs << "END\n";
     if (model_num) {
       ofs << "ENDMDL" << endl;
+	  if (pConv->IsLast()) {
+	    ofs << "END\n";
+	  }
     }
+	else {
+	  ofs << "END\n";
+	}
 
     return(true);
   }


### PR DESCRIPTION
Bugfix for multi-model PDB writing. Previous versions inserted an
'END' tag before the 'ENDMDL' tag after each model. This violates
the PDB spec, which says 'END' marks the end of file, and also
trips up some programs/APIs (e.g. rdkit) that follow the spec and
stop reading the resulting PDB files after the first model.
Minimally invasive fix. I can make a test if desired. 