### PR TITLE
add support for customizations of filter and rotors used during conformer search and small bugfixes

### DIFF
--- a/include/openbabel/conformersearch.h
+++ b/include/openbabel/conformersearch.h
@@ -3,6 +3,7 @@ conformersearch.h - Conformer searching using genetic algorithm.
 
 Copyright (C) 2010 Tim Vandermeersch
 Some portions Copyright (C) 2012 Materials Design, Inc.
+Some portions Copyright (C) 2016 Torsten Sachse
 
 This file is part of the Open Babel project.
 For more information, see <http://openbabel.org/>
@@ -336,6 +337,11 @@ namespace OpenBabel {
       }
 
       /**
+      * Set whether or not you want rotors to be printed prior to the conformer search.
+      */
+      void PrintRotors(bool printrotors) { m_printrotors = printrotors; }
+
+      /**
        * Perform conformer search using a genetic algorithm.
        */
       void Search();
@@ -452,6 +458,7 @@ namespace OpenBabel {
       OBMol         m_mol; //!< The molecule with starting coordinates
       OBRotorList   m_rotorList; //!< The OBRotorList for the molecule
       RotorKeys     m_rotorKeys; //!< The current population
+      bool          m_printrotors; //!< Wheter or not to print all rotors that are found instead of performing the conformer search
 
       OBConformerFilter *m_filter;
       OBConformerScore  *m_score;

--- a/src/conformersearch.cpp
+++ b/src/conformersearch.cpp
@@ -2,6 +2,7 @@
 conformersearch.cpp - Conformer searching using genetic algorithm.
 
 Copyright (C) 2010 Tim Vandermeersch
+Some portions Copyright (C) 2016 Torsten Sachse
 
 This file is part of the Open Babel project.
 For more information, see <http://openbabel.org/>
@@ -302,6 +303,8 @@ namespace OpenBabel {
     unique_generator.TimeSeed();
     m_logstream = &cout; 	// Default logging send to standard output
     // m_logstream = NULL;
+    m_printrotors = false;  // By default, do not print rotors but perform the conformer search
+
   }
 
   OBConformerSearch::~OBConformerSearch()
@@ -327,6 +330,46 @@ namespace OpenBabel {
     // Initialize the OBRotorList
     m_rotorList.SetFixedBonds(m_fixedBonds);
     m_rotorList.Setup(m_mol);
+
+    // Print all available rotors if so desired
+    if (m_printrotors){
+      OBRotorIterator it;
+      OBRotorIterator end_it = m_rotorList.EndRotors();
+      OBRotor* r = m_rotorList.BeginRotor(it);
+      int rotcount = 1;
+      std::cout << "Rotors:" << std::endl;
+      while(r){
+        OBBond* b = r->GetBond();
+        int at1,at2;
+        at1 = b->GetBeginAtomIdx();
+        at2 = b->GetEndAtomIdx();
+        std::cout << at1 << "-" << at2 << "  ";
+        r = m_rotorList.NextRotor(it);
+        if (rotcount%4==0 && r){std::cout << std::endl;}
+        ++rotcount;
+      }
+      std::cout << std::endl;
+      return false;
+    }
+    // Print those that are fixed
+    if (!m_fixedBonds.IsEmpty()){
+      std::cout << "Fixed Rotors: " << std::endl;
+      int end_it = m_fixedBonds.EndBit();
+      int it = m_fixedBonds.FirstBit();
+      int rotcount = 1;
+      while(it!=end_it){
+        OBBond* b = m_mol.GetBond(it);
+        int at1,at2;
+        at1 = b->GetBeginAtomIdx();
+        at2 = b->GetEndAtomIdx();
+        std::cout << at1 << "-" << at2 << "  ";
+        it = m_fixedBonds.NextBit(it);
+        if (rotcount%4==0 && it!=end_it){std::cout << std::endl;}
+        ++rotcount;
+      }
+      std::cout << std::endl;
+    }
+
     nb_rotors = m_rotorList.Size();
     if (!nb_rotors) { // only one conformer
       return false;
@@ -577,6 +620,10 @@ namespace OpenBabel {
           // make the selection
           score = MakeSelection();
         }
+      if (std::isnan(score)) {
+          (*m_logstream) << "The current score is not a number, will not continue."  << endl  << endl;
+          return;
+      }
       if (i == 0)
         last_score = score;
 

--- a/src/ops/conformer.cpp
+++ b/src/ops/conformer.cpp
@@ -3,6 +3,7 @@ conformer.cpp - A OBOp to calculate and minimize the energy using a
                  forcefield (re-wrap of obminimize and obenergy)
 
 Copyright (C) 2010 by Tim Vandermeersch
+Some portions Copyright (C) 2016 Torsten Sachse
 
 This file is part of the Open Babel project.
 For more information, see <http://openbabel.org/>
@@ -26,6 +27,8 @@ Compile with tools/obabel.cpp rather than tools/babel.cpp
 
 #include <openbabel/babelconfig.h>
 #include <iostream>
+#include <vector>
+#include <stdio.h>
 #include <openbabel/op.h>
 #include <openbabel/mol.h>
 #include <openbabel/forcefield.h>
@@ -61,11 +64,20 @@ namespace OpenBabel
           " --weighted       weighted rotor search for lowest energy conformer\n"
           " --ff #           select a forcefield (default = MMFF94)\n"
           " --rings          sample ring torsions\n"
-          " genetic algorithm based methods (default):\n"
+          " genetic algorithm (GA) based methods (default):\n"
           " --children #     number of children to generate for each parent (default = 5)\n"
           " --mutability #   mutation frequency (default = 5)\n"
-          " --converge #     number of identical generations before convergence is reached\n"
+          " --convergence #  number of identical generations before convergence is reached\n"
           " --score #        scoring function [rmsd|energy|minrmsd|minenergy] (default = rmsd)\n"
+          " customize the filter used to sort out wrong conformers\n"
+          " --csfilter #     the filtering algorithm [steric] (default=steric)\n"
+          " --cutoff #       absolute distance in Anstroms below which atoms are considered to clash\n"
+          " --vdw-factor #   apply this factor to all van-der-Waals radii before detecting clashes\n"
+          " --ignore-H       do not detect clashes with hydrogen atoms\n"
+          " customize rotors for GA based method (a rotor is given as a-b where a and b are indices)\n"
+          " --printrot       print all possible rotors and do not perform a conformer search\n"
+          " --onlyrot        declare a comma-separated list of rotors, all but these will be disregarded\n"
+          " --norot          declare a comma-separated list of rotors that shall be disregarded\n"
           ;
       }
 
@@ -79,10 +91,12 @@ namespace OpenBabel
   //////////////////////////////////////////////////////////
   OpConformer theOpConformer("conformer"); //Global instance
 
-  void getInteger(const std::string &str, int &value)
+  template<typename T>
+  bool getValue(const std::string &str, T &value)
   {
     std::istringstream iss(str);
-    iss >> value;
+    bool ret = (iss >> value);
+    return ret;
   }
 
   //////////////////////////////////////////////////////////
@@ -108,7 +122,7 @@ namespace OpenBabel
 
     iter = pmap->find("nconf");
     if(iter!=pmap->end())
-      getInteger(iter->second, numConformers);
+      getValue<int>(iter->second, numConformers);
 
     iter = pmap->find("systematic");
     if(iter!=pmap->end())
@@ -170,22 +184,31 @@ namespace OpenBabel
       pFF->GetConformers(*pmol);
 
     } else { // GA-based searching
+      //default values for score
       int numChildren = 5;
       int mutability = 5;
       int convergence = 5;
       std::string score = "rmsd";
+      //default values for filter
+      double cutoff = 0.8 ;
+      double vdw_factor = 0.5 ;
+      bool check_hydrogens = true ;
+      std::string filter = "steric";
+      bool rotchange = false;
+      bool rotorsoff = false;
+      OBBitVec extrotors;
 
       iter = pmap->find("children");
       if(iter!=pmap->end())
-        getInteger(iter->second, numChildren);
+        getValue<int>(iter->second, numChildren);
 
       iter = pmap->find("mutability");
       if(iter!=pmap->end())
-        getInteger(iter->second, mutability);
+        getValue<int>(iter->second, mutability);
 
       iter = pmap->find("convergence");
       if(iter!=pmap->end())
-        getInteger(iter->second, convergence);
+        getValue<int>(iter->second, convergence);
 
       iter = pmap->find("score");
       if(iter!=pmap->end())
@@ -198,6 +221,95 @@ namespace OpenBabel
         cs.SetScore(new OBMinimizingEnergyConformerScore);
       else if (score == "minr" || score == "minrmsd")
         cs.SetScore(new OBMinimizingRMSDConformerScore);
+
+      iter = pmap->find("csfilter");
+      if(iter!=pmap->end())
+        filter = iter->second;
+ 
+      iter = pmap->find("vdw-factor");
+      if(iter!=pmap->end())
+        getValue<double>(iter->second, vdw_factor);
+ 
+      iter = pmap->find("cutoff");
+      if(iter!=pmap->end())
+        getValue<double>(iter->second, cutoff);
+      
+      iter = pmap->find("ignore-H");
+      if(iter!=pmap->end())
+        check_hydrogens = false;
+ 
+      if (filter == "steric")
+        cs.SetFilter(new OBStericConformerFilter(cutoff, vdw_factor, check_hydrogens));
+
+      iter = pmap->find("printrot");
+      if(iter!=pmap->end())
+        cs.PrintRotors(true);
+
+      iter = pmap->find("onlyrot");
+      if(iter!=pmap->end()){
+        rotchange = true;
+        rotorsoff = false;
+      }
+      iter = pmap->find("norot");
+      if(iter!=pmap->end()){
+        rotchange = true;
+        rotorsoff = true;
+      }
+      if (rotchange){
+        if (rotorsoff){
+          iter = pmap->find("norot");
+        }else{
+          iter = pmap->find("onlyrot");
+        }
+        OBBitVec fixbonds;
+        if (rotorsoff){
+          fixbonds.SetRangeOff(0,pmol->NumBonds()-1);
+        }else{
+          fixbonds.SetRangeOn( 0,pmol->NumBonds()-1);
+          int end_it = fixbonds.EndBit();
+          int it = fixbonds.FirstBit();
+          while(it!=end_it){
+            OBBond* b = pmol->GetBond(it);
+            if (!(b->IsRotor())){
+              fixbonds.SetBitOff(it);
+            }
+            it = fixbonds.NextBit(it);
+          }
+        }
+        std::stringstream input(iter->second);
+        std::string segment;
+        while (std::getline(input, segment, ',')){
+          int p1, p2;
+          char additional;
+          int converted = sscanf(segment.c_str(), "%d-%d%c", &p1, &p2, &additional);
+          if (converted==2 && p1>0 && p2>0){
+            if (p1>pmol->NumAtoms() || p2>pmol->NumAtoms()){
+              std::cerr << "ERROR at least one of the atom indices " << p1 << " or " << p2 
+                        << " is greater than the number of atoms " << pmol->NumAtoms() << "." << std::endl << std::flush;
+              return false;
+            }
+            OBBond* b = pmol->GetBond(p1,p2);
+            if (!b){
+              std::cerr << "ERROR atoms " << p1 << " and " << p2 << " form no bond." << std::endl << std::flush;
+              return false;
+            }
+            if (!(b->IsRotor())){
+                std::cerr << "ERROR bond formed by atoms " << p1 << " and " << p2 << " is not rotable." << std::endl << std::flush;
+                return false;
+            }
+            int idx = b->GetIdx();
+            if (rotorsoff){
+              fixbonds.SetBitOn(idx);
+            }else{
+              fixbonds.SetBitOff(idx);
+            }
+          }else{
+              std::cerr << "ERROR parsing '" << segment << "' as rotor (must be i-j where i and j are indices >0)" << std::endl << std::flush;
+              return false;
+          }
+        }
+        cs.SetFixedBonds(fixbonds);
+      }
 
       if (cs.Setup(*pmol, numConformers, numChildren, mutability, convergence)) {
         cs.Search();

--- a/src/ops/conformer.cpp
+++ b/src/ops/conformer.cpp
@@ -95,7 +95,7 @@ namespace OpenBabel
   bool getValue(const std::string &str, T &value)
   {
     std::istringstream iss(str);
-    bool ret = (iss >> value);
+    bool ret = static_cast<bool>(iss >> value);
     return ret;
   }
 


### PR DESCRIPTION
When performing conformer searches on large molecules, it might be beneficial to a) fix certain rotors so that they are not changed and b) make the steric overlap filter less stringent. I made both changes available to the command-line interface.

I also noticed that the help message said a switch were called "--converge" but the code actually expects "--convergence". It also sometimes happens that none of the initial conformers pass the filter and the programme would then run indefinitely. Those bugs are also fixed.
