### PR TITLE
track the number of electrons cored by an electron core potential and read that information from Molden-files

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -101,6 +101,7 @@ namespace OpenBabel
       OBResidue                    *_residue;   //!< parent residue (if applicable)
 
       unsigned long                 _id;        //!< unique id
+      unsigned int                  _ecp;       //!< number of electrons cored by ecp
 
       //! \return All flags
       int  GetFlag() const    {  return(_flags);  }
@@ -199,6 +200,8 @@ namespace OpenBabel
       void SetChiral()         { SetFlag(OB_CHIRAL_ATOM); }
       //! Clear the internal coordinate pointer
       void ClearCoordPtr()     { _c = NULL; _cidx=0; }
+      //! Sets the number of electrons cored by an ecp
+      void SetEcp(int ecp){_ecp = ecp;}
       //@}
 
       //! \name Methods to retrieve atomic information
@@ -296,6 +299,8 @@ namespace OpenBabel
       //! \deprecated Use any of the other iterator methods. This
       //!    method will be removed in the future.
       OBAtom    *GetNextAtom();
+      //! \return the number of electrons cored by an ecp
+      int       GetEcp(){return _ecp;}
       //@}
 
       //! \name Iterator methods

--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -101,7 +101,6 @@ namespace OpenBabel
       OBResidue                    *_residue;   //!< parent residue (if applicable)
 
       unsigned long                 _id;        //!< unique id
-      unsigned int                  _ecp;       //!< number of electrons cored by ecp
 
       //! \return All flags
       int  GetFlag() const    {  return(_flags);  }
@@ -200,8 +199,6 @@ namespace OpenBabel
       void SetChiral()         { SetFlag(OB_CHIRAL_ATOM); }
       //! Clear the internal coordinate pointer
       void ClearCoordPtr()     { _c = NULL; _cidx=0; }
-      //! Sets the number of electrons cored by an ecp
-      void SetEcp(int ecp){_ecp = ecp;}
       //@}
 
       //! \name Methods to retrieve atomic information
@@ -299,8 +296,6 @@ namespace OpenBabel
       //! \deprecated Use any of the other iterator methods. This
       //!    method will be removed in the future.
       OBAtom    *GetNextAtom();
-      //! \return the number of electrons cored by an ecp
-      int       GetEcp(){return _ecp;}
       //@}
 
       //! \name Iterator methods

--- a/src/formats/moldenformat.cpp
+++ b/src/formats/moldenformat.cpp
@@ -125,6 +125,7 @@ bool OBMoldenFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
       {
         if( lineBuffer.find( "[Atoms]" ) != string::npos ||
             lineBuffer.find( "[ATOMS]" ) != string::npos ) {
+          unsigned int ecpLines = 0;
           double factor = 1.; // Angstrom
           if( lineBuffer.find( "AU" ) != string::npos ) factor = BOHR_TO_ANGSTROM; // Bohr
           while( getline( ifs, lineBuffer ) )
@@ -141,10 +142,22 @@ bool OBMoldenFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
               OBAtom* atom = pmol->NewAtom();
               if( !atom ) break;
               atomicNumber = etab.GetAtomicNum(atomName.c_str());
-              atom->SetEcp( atomicNumber-valenceCharge );
               atom->SetAtomicNum( atomicNumber );
               atom->SetVector( x * factor, y * factor, z * factor );
+              if (atomicNumber-valenceCharge!=0){
+                OBPairData* ecpData = new OBPairData();
+                ecpData->SetAttribute("ecp");
+                std::ostringstream os;
+                os << atomicNumber-valenceCharge;
+                ecpData->SetValue(os.str());
+                atom->SetData(ecpData);
+                ++ecpLines;
+              }
             }
+          if (ecpLines!=0){
+              cerr << "WARNING: element number given in 3rd column does not agree with element name on " << ecpLines << " lines." << endl
+                   << "         Difference between expected nuclear charge and given element number saved to atom property 'ecp'." << endl;
+          }
         } // "[Atoms]" || "[ATOMS]"
         if ( lineBuffer.find( "[GEOMETRIES] (XYZ)" ) != string::npos ) {
           while( getline( ifs, lineBuffer ) ) {

--- a/src/formats/moldenformat.cpp
+++ b/src/formats/moldenformat.cpp
@@ -135,10 +135,13 @@ bool OBMoldenFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
               string atomName;
               int atomId;
               int atomicNumber;
+              int valenceCharge;
               double x, y, z;
-              is >> atomName >> atomId >> atomicNumber >> x >> y >> z;
+              is >> atomName >> atomId >> valenceCharge >> x >> y >> z;
               OBAtom* atom = pmol->NewAtom();
               if( !atom ) break;
+              atomicNumber = etab.GetAtomicNum(atomName.c_str());
+              atom->SetEcp( atomicNumber-valenceCharge );
               atom->SetAtomicNum( atomicNumber );
               atom->SetVector( x * factor, y * factor, z * factor );
             }


### PR DESCRIPTION
Added methods to get and set the number of electrons cored by an electron core potential.

Molden files store an element via both the element symbol and the element number. If the element number is replaced by the actual charge (that not cored by an ECP), the number of cored electrons can be inferred directly from the file.
