### PR TITLE
Python setup.py fixes for 2.4.0 release

### DIFF
--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup, Extension
 
 __author__ = 'Noel O\'Boyle'
 __email__ = 'openbabel-discuss@lists.sourceforge.net'
-__version__ = '1.8.3'
+__version__ = '2.4.0'
 __license__ = 'GPL'
 
 
@@ -76,7 +76,7 @@ class CustomInstall(install):
     """Ensure build_ext runs first in install command."""
     def run(self):
         self.run_command('build_ext')
-        self.do_egg_install()
+        install.run(self)
 
 
 class CustomSdist(sdist):
@@ -124,7 +124,7 @@ setup(name='openbabel',
       url='http://openbabel.org/',
       description='Python interface to the Open Babel chemistry library',
       long_description=long_description,
-      zip_safe=True,
+      zip_safe=False,
       cmdclass={'build': CustomBuild, 'build_ext': CustomBuildExt, 'install': CustomInstall, 'sdist': CustomSdist},
       py_modules=['openbabel', 'pybel'],
       ext_modules=[obextension],


### PR DESCRIPTION
This commit contains a few minor changes to the Python setup.py file that is used for independent installation of the Python bindings.

- Version bumped to 2.4.0 to match the main Open Babel version.
- The custom install command subclass was fixed to just call the superclass install method after the extra build_ext command. This resolved an issue with running bdist_wheel.
- `zip_safe` changed to `False`, so running `python setup.py install` behaviour is more like `pip install openbabel`.