### PR TITLE
Fix for missing ZLIB on win32

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,7 +209,9 @@ set(openbabel_library_srcs
   )
 
 if(WIN32)
-  set(libs ${libs} ${ZLIB_LIBRARY})
+  if(ZLIB_FOUND)
+    set(libs ${libs} ${ZLIB_LIBRARY})
+  endif(ZLIB_FOUND)
 else(WIN32)
   # the C math library
   if(BUILD_MIXED)


### PR DESCRIPTION
I'm not entirely sure, but I suppose this check for ZLIB availability is necessary.
Otherwise, CMake throws an error due to missing variable 'ZLIB_LIBRARY'. 