### PR TITLE
SF #909 - Fix segfault when ReadMolecule() called with PubChem document but...

### DIFF
--- a/src/formats/xml/xmlformat.cpp
+++ b/src/formats/xml/xmlformat.cpp
@@ -81,7 +81,7 @@ public:
   bool ReadMolecule(OBBase* pOb, OBConversion* pConv)
   {
     XMLBaseFormat* pDefault = XMLConversion::GetDefaultXMLClass();
-    if(pConv->GetOutFormat()->GetType() == pDefault->GetType())
+    if(pConv->GetOutFormat() != NULL && pConv->GetOutFormat()->GetType() == pDefault->GetType())
     {
       XMLConversion* pxmlConv = XMLConversion::GetDerived(pConv);
       pxmlConv->LookForNamespace();


### PR DESCRIPTION
file extension was generic .xml (bug #909)

This fix addresses https://sourceforge.net/p/openbabel/bugs/909/ where Allan was passing PubChem documents directly to **obprop** with an `.xml` file extension, but instead of the property listing he expected (or a meaningful error message), **obprop** caused a segmentation fault due to the output format being `NULL` when `ReadMolecule()` gets called.  The fix will generate a more meaningful error message (which had already existed).

Allan noted that if he renamed the PubChem document with a `.pc` file extension, then **obprop** worked as expected.

This was originally reported in a Debian build of OpenBabel 2.3.2, although I was able to reproduce in CentOS builds of both 2.3.2 and the latest development code.