### PR TITLE
Include original when there are zero rotatable bonds in confab

### DIFF
--- a/src/ops/opconfab.cpp
+++ b/src/ops/opconfab.cpp
@@ -152,10 +152,12 @@ namespace OpenBabel
 
     pff->GetConformers(mol);
     int nconfs = include_original ? mol.NumConformers() : mol.NumConformers() - 1;
+    nconfs = mol.NumRotors() == 0 ? 1 : nconfs;
 
     cout << "..generated " << nconfs << " conformers" << endl;
 
     unsigned int c = include_original ? 0 : 1;
+    c = mol.NumRotors() == 0 ? 0 : c;
 
     for (; c < mol.NumConformers(); ++c) {
       mol.SetConformer(c);

--- a/src/ops/opconfab.cpp
+++ b/src/ops/opconfab.cpp
@@ -152,12 +152,16 @@ namespace OpenBabel
 
     pff->GetConformers(mol);
     int nconfs = include_original ? mol.NumConformers() : mol.NumConformers() - 1;
-    nconfs = mol.NumRotors() == 0 ? 1 : nconfs;
+    unsigned int c = include_original ? 0 : 1;
+
+    // If mol.NumRotors is 0 and originals have not been included, then nconfs
+    // may be 0. Here, if nconfs is 0, we include the original input conformer
+    if (nconfs == 0) {
+      nconfs = mol.NumConformers();
+      c = 0;
+    }
 
     cout << "..generated " << nconfs << " conformers" << endl;
-
-    unsigned int c = include_original ? 0 : 1;
-    c = mol.NumRotors() == 0 ? 0 : c;
 
     for (; c < mol.NumConformers(); ++c) {
       mol.SetConformer(c);


### PR DESCRIPTION
If you don't include the original coordinates, confab currently will give you no conformers for molecule with zero rotatable bonds, so the molecule disappears from the output file. This makes confab return the original coordinates if there are zero rotatable bonds.