### PR TITLE
Don't try to install aromatic.txt as it is no longer present

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Open Babel data files
 
 set(to_install
-    aromatic.txt
     atomization-energies.txt
     atomtyp.txt
     babel_povray3.inc


### PR DESCRIPTION
A fix for my merge of pull request #1545  which caused "make install" to fail as aromatic.txt was no longer present