### PR TITLE
Set default coordinates before doing bond perception.

### DIFF
--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -1229,6 +1229,10 @@ namespace OpenBabel
       mol.SetData(etd);
     }
 
+    // set some default coordinates
+    // ConnectTheDots will remove conformers, so we add those later
+    mol.SetCoordinates(vconf[vconf.size() - 1]);
+
     if (!pConv->IsOption("b",OBConversion::INOPTIONS))
       mol.ConnectTheDots();
     if (!pConv->IsOption("s",OBConversion::INOPTIONS) && !pConv->IsOption("b",OBConversion::INOPTIONS))


### PR DESCRIPTION
Fixes bug in previous commit - bonds were not perceived because no atom coordinates existed.