### PR TITLE
Remove delete statement.

### DIFF
--- a/src/formats/nwchemformat.cpp
+++ b/src/formats/nwchemformat.cpp
@@ -232,11 +232,14 @@ static const char* OPTIMIZATION_END_PATTERN = "  Optimization converged";
           break;
         tokenize(vs,buffer);
     }
-    if ((from_scratch)||(i != natoms))
-      {
+    if (from_scratch) 
+    {
+        return;
+    }
+    if (i != natoms) {
         delete[] coordinates;
         return;
-      }
+    }
     molecule->AddConformer(coordinates);
   }
 


### PR DESCRIPTION
This may or may not fix issue #1555, but I noticed it results in an unallocated pointer being freed, crashing the program.

Details:
When from_scratch is true, coordinates is not allocated. A separate if
statement was added to handle the case when from_scratch is true that
does not try to free coordinates.