### PR TITLE
Link libinchi with math library

### DIFF
--- a/src/formats/libinchi/CMakeLists.txt
+++ b/src/formats/libinchi/CMakeLists.txt
@@ -6,7 +6,7 @@ set(INCHI_PATCH_VER 1)
 file(GLOB inchi_srcs "*.c")
 
 if(NOT WIN32)
-  set(libs ${libs} c)
+  set(libs ${libs} c m)
 endif(NOT WIN32)
 
 include_directories(${openbabel_SOURCE_DIR}/include/inchi)


### PR DESCRIPTION
When trying to build openbabel in a Conda environment for [Bioconda](https://bioconda.github.io/), I got this error:

```
[ 11%] Linking C shared library ../../../lib/libinchi.so
cd /usr/users/ga002/soranzon/miniconda3/conda-bld/2.4.1_1494426296543/work/openbabel-openbabel-2-4-1/src/formats/libinchi && /usr/users/ga002/soranzon/miniconda3/conda-bld/2.4.1_1494426296543/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/cmake -E cmake_link_script CMakeFiles/inchi.dir/link.txt --verbose=1
/usr/users/ga002/soranzon/miniconda3/conda-bld/2.4.1_1494426296543/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/bin/cc  -fPIC -O3 -DNDEBUG -Wl,--enable-new-dtags -Wl,--fatal-warnings -Wl,--no-undefined -lc  -shared -Wl,-soname,libinchi.so.0 -o ../../../lib/libinchi.so.0.4.1 CMakeFiles/inchi.dir/ichi_bns.o CMakeFiles/inchi.dir/ichi_io.o CMakeFiles/inchi.dir/ichican2.o CMakeFiles/inchi.dir/ichicano.o CMakeFiles/inchi.dir/ichicans.o CMakeFiles/inchi.dir/ichiisot.o CMakeFiles/inchi.dir/ichilnct.o CMakeFiles/inchi.dir/ichimak2.o CMakeFiles/inchi.dir/ichimake.o CMakeFiles/inchi.dir/ichimap1.o CMakeFiles/inchi.dir/ichimap2.o CMakeFiles/inchi.dir/ichimap4.o CMakeFiles/inchi.dir/ichinorm.o CMakeFiles/inchi.dir/ichiparm.o CMakeFiles/inchi.dir/ichiprt1.o CMakeFiles/inchi.dir/ichiprt2.o CMakeFiles/inchi.dir/ichiprt3.o CMakeFiles/inchi.dir/ichiqueu.o CMakeFiles/inchi.dir/ichiread.o CMakeFiles/inchi.dir/ichiring.o CMakeFiles/inchi.dir/ichirvr1.o CMakeFiles/inchi.dir/ichirvr2.o CMakeFiles/inchi.dir/ichirvr3.o CMakeFiles/inchi.dir/ichirvr4.o CMakeFiles/inchi.dir/ichirvr5.o CMakeFiles/inchi.dir/ichirvr6.o CMakeFiles/inchi.dir/ichirvr7.o CMakeFiles/inchi.dir/ichisort.o CMakeFiles/inchi.dir/ichister.o CMakeFiles/inchi.dir/ichitaut.o CMakeFiles/inchi.dir/ikey_base26.o CMakeFiles/inchi.dir/ikey_dll.o CMakeFiles/inchi.dir/inchi_dll.o CMakeFiles/inchi.dir/inchi_dll_a.o CMakeFiles/inchi.dir/inchi_dll_a2.o CMakeFiles/inchi.dir/inchi_dll_main.o CMakeFiles/inchi.dir/runichi.o CMakeFiles/inchi.dir/sha2.o CMakeFiles/inchi.dir/strutil.o CMakeFiles/inchi.dir/util.o -ldl -lz -lcairo -lc -Wl,-rpath,/usr/users/ga002/soranzon/miniconda3/conda-bld/2.4.1_1494426296543/_b_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib: 
CMakeFiles/inchi.dir/ichister.o: In function `len3':
ichister.c:(.text+0x1f3): undefined reference to `sqrt'
CMakeFiles/inchi.dir/ichister.o: In function `half_stereo_bond_parity':
ichister.c:(.text+0x1418): undefined reference to `sqrt'
ichister.c:(.text+0x1542): undefined reference to `atan2'
ichister.c:(.text+0x155f): undefined reference to `atan2'
ichister.c:(.text+0x15dc): undefined reference to `floor'
ichister.c:(.text+0x1995): undefined reference to `floor'
ichister.c:(.text+0x19de): undefined reference to `sqrt'
ichister.c:(.text+0x19f1): undefined reference to `sqrt'
ichister.c:(.text+0x19ff): undefined reference to `sqrt'
CMakeFiles/inchi.dir/ichister.o: In function `FixSb0DParities':
ichister.c:(.text+0x1e25): undefined reference to `floor'
ichister.c:(.text+0x1e55): undefined reference to `floor'
ichister.c:(.text+0x1e85): undefined reference to `floor'
ichister.c:(.text+0x216f): undefined reference to `floor'
ichister.c:(.text+0x2197): undefined reference to `floor'
CMakeFiles/inchi.dir/ichister.o:ichister.c:(.text+0x21c7): more undefined references to `floor' follow
CMakeFiles/inchi.dir/ichister.o: In function `FixSb0DParities':
ichister.c:(.text+0x21fc): undefined reference to `sqrt'
ichister.c:(.text+0x2236): undefined reference to `sqrt'
CMakeFiles/inchi.dir/ichister.o: In function `set_stereo_atom_parity':
ichister.c:(.text+0x3bfe): undefined reference to `atan2'
ichister.c:(.text+0x3dd2): undefined reference to `sqrt'
ichister.c:(.text+0x3e27): undefined reference to `sqrt'
ichister.c:(.text+0x3e6d): undefined reference to `sqrt'
CMakeFiles/inchi.dir/ichister.o: In function `set_stereo_parity':
ichister.c:(.text+0x6d13): undefined reference to `floor'
ichister.c:(.text+0x6e36): undefined reference to `floor'
CMakeFiles/inchi.dir/strutil.o: In function `dist3D':
strutil.c:(.text+0x5ef9): undefined reference to `sqrt'
CMakeFiles/inchi.dir/strutil.o: In function `GetMinDistDistribution':
strutil.c:(.text+0x6358): undefined reference to `atan2'
strutil.c:(.text+0x6379): undefined reference to `floor'
strutil.c:(.text+0x63d9): undefined reference to `atan2'
strutil.c:(.text+0x6415): undefined reference to `atan2'
strutil.c:(.text+0x648b): undefined reference to `floor'
strutil.c:(.text+0x64ab): undefined reference to `floor'
strutil.c:(.text+0x6590): undefined reference to `atan2'
strutil.c:(.text+0x65e6): undefined reference to `cos'
strutil.c:(.text+0x6705): undefined reference to `atan2'
strutil.c:(.text+0x6778): undefined reference to `sqrt'
strutil.c:(.text+0x683c): undefined reference to `cos'
strutil.c:(.text+0x68f5): undefined reference to `atan2'
strutil.c:(.text+0x6916): undefined reference to `floor'
strutil.c:(.text+0x6995): undefined reference to `atan2'
strutil.c:(.text+0x69c4): undefined reference to `floor'
strutil.c:(.text+0x6aa5): undefined reference to `sqrt'
strutil.c:(.text+0x6b07): undefined reference to `sqrt'
strutil.c:(.text+0x6b67): undefined reference to `sqrt'
strutil.c:(.text+0x6b97): undefined reference to `sqrt'
CMakeFiles/inchi.dir/strutil.o: In function `move_explicit_Hcation':
strutil.c:(.text+0x6ec3): undefined reference to `atan2'
strutil.c:(.text+0x6f18): undefined reference to `floor'
strutil.c:(.text+0x7211): undefined reference to `sincos'
strutil.c:(.text+0x72a8): undefined reference to `sqrt'
strutil.c:(.text+0x72f7): undefined reference to `sqrt'
collect2: error: ld returned 1 exit status
make[2]: *** [lib/libinchi.so.0.4.1] Error 1
make[2]: Leaving directory `/usr/users/ga002/soranzon/miniconda3/conda-bld/2.4.1_1494426296543/work/openbabel-openbabel-2-4-1'
make[1]: *** [src/formats/libinchi/CMakeFiles/inchi.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory `/usr/users/ga002/soranzon/miniconda3/conda-bld/2.4.1_1494426296543/work/openbabel-openbabel-2-4-1'
make: *** [all] Error 2
```

which was due to a missing `-lm` in the linking command.