### PR TITLE
Fix regression + minor cppcheck report

### DIFF
--- a/src/forcefields/forcefieldmmff94.cpp
+++ b/src/forcefields/forcefieldmmff94.cpp
@@ -3801,7 +3801,7 @@ namespace OpenBabel
             }
           }
 
-          if (type == 77)
+          if (atoi(nbr->GetType()) == 77)
             atom->SetPartialCharge(-0.25); // O4CL
         }
       } else if (type == 61) {

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -45,7 +45,7 @@ namespace OpenBabel
         "Read Options e.g. -ac\n"
         "  c               Read UCSF Dock scores saved in comments preceeding molecules\n\n"
         "Write Options e.g. -xl\n"
-        "  l               Output ignores residue information (only ligands)\n\n";
+        "  l               Output ignores residue information (only ligands)\n\n"
         "  c               Write UCSF Dock scores saved in comments preceeding molecules\n\n";
     };
 


### PR DESCRIPTION
regression from 624abd353f8ea2c889edb663adf84e50ee81e8d2 (2008-03-06)
- if (atoi(nbr->GetType()) == 77)
+ if (type == 77)
whereas:
+ int type = atoi(atom->GetType());

cppcheck:
[src/formats/mol2format.cpp:49]: (style) Statements following return, break, continue, goto or throw will never be executed