### PR TITLE
Convert tabs to spaces in testpdbformat.py

### DIFF
--- a/test/testpdbformat.py
+++ b/test/testpdbformat.py
@@ -24,12 +24,12 @@ class TestPDBFormat(BaseTest):
 
     def testInsertionCodes(self):
         """
-	Testing a PDB entry with insertion codes to distinguish residues
-	upon conversion to FASTA.
+        Testing a PDB entry with insertion codes to distinguish residues
+        upon conversion to FASTA.
         """
         self.canFindExecutable("babel")
 
-	self.entryPDBwithInsertioncodes="""ATOM    406  N   VAL L  29      58.041  17.797  48.254  1.00  0.00           N  
+        self.entryPDBwithInsertioncodes="""ATOM    406  N   VAL L  29      58.041  17.797  48.254  1.00  0.00           N  
 ATOM    407  CA  VAL L  29      57.124  18.088  47.170  1.00  0.00           C  
 ATOM    408  C   VAL L  29      55.739  17.571  47.538  1.00  0.00           C  
 ATOM    409  O   VAL L  29      55.535  16.362  47.550  1.00  0.00           O  
@@ -100,9 +100,9 @@ ATOM    473  HE1 TYR L  32      48.512  15.775  42.066  1.00  0.00           H
 ATOM    474  HE2 TYR L  32      48.145  19.172  44.648  1.00  0.00           H  
 ATOM    475  HH  TYR L  32      46.462  17.658  44.280  1.00  0.00           H  
 """
-	output, error = run_exec(self.entryPDBwithInsertioncodes,
-				     "babel -ipdb -ofasta")
-	self.assertEqual(output.rstrip().rsplit("\n",1)[1], "VSSSY")
+        output, error = run_exec(self.entryPDBwithInsertioncodes,
+                                     "babel -ipdb -ofasta")
+        self.assertEqual(output.rstrip().rsplit("\n",1)[1], "VSSSY")
 
 if __name__ == "__main__":
     testsuite = []


### PR DESCRIPTION
I'm trying to write a package for Open Babel for the Spack package manager (see https://github.com/LLNL/spack/pull/4256). The installation seems to work, but one of the unit tests crashes:
```
        Start 157: pytest_pdbformat
157/160 Test #157: pytest_pdbformat .................***Failed    0.04 sec
/blues/gpfs/home/software/spack-0.10.0/var/spack/stage/openbabel-2.4.1-g7kl4coxcxba2x2ugjpqbeipuembkpk7/openbabel-2.4.1/scripts/python:/scratch/ajstewart/spack-stage/spack-stage-z0O89Y/openbabel-2.4.1/spack-build/lib
  File "/blues/gpfs/home/software/spack-0.10.0/var/spack/stage/openbabel-2.4.1-g7kl4coxcxba2x2ugjpqbeipuembkpk7/openbabel-2.4.1/test/testpdbformat.py", line 32
    self.entryPDBwithInsertioncodes="""ATOM    406  N   VAL L  29      58.041  17.797  48.254  1.00  0.00           N  
                                                                                                                      ^
TabError: inconsistent use of tabs and spaces in indentation

CMake Error at pytest_pdbformat.cmake:20 (MESSAGE):
  1
```
The problem is that this file contains mixed tabs and spaces. This PR converts all tabs to spaces and allows the unit test to pass.