### PR TITLE
cppcheck: Condition '1==0' is always false

### DIFF
--- a/src/math/spacegroup.cpp
+++ b/src/math/spacegroup.cpp
@@ -431,7 +431,7 @@ namespace OpenBabel
             if (stripped_HM.length() > 0 && _SpaceGroups.sgbn[nm] == NULL)
               _SpaceGroups.sgbn[nm] = this;
 		  }
-        if ((m_OriginAlternative & (1 == 0)) && (_SpaceGroups.sgbn[m_HM] == NULL))
+        if (((m_OriginAlternative & 1) == 0) && (_SpaceGroups.sgbn[m_HM] == NULL))
           _SpaceGroups.sgbn[m_HM] = this;
 	  }
     // Also use the HM symbol stripped from whitespaces as key


### PR DESCRIPTION
[src/math/spacegroup.cpp:434]: (style) Condition '1==0' is always false
commit 6d448d8a6967b5edca34ef0d7cef6466985b817c was:
math/spacegroup.cpp: Fix -Wparentheses
-        if ((m_OriginAlternative & 1 == 0) && (_SpaceGroups.sgbn[m_HM] == NULL))
+        if ((m_OriginAlternative & (1 == 0)) && (_SpaceGroups.sgbn[m_HM] == NULL))
but (1 == 0) doesn't mean anything.
the initial warning meant since "==" has more priority than "&" so there was a pb here
(see http://en.cppreference.com/w/cpp/language/operator_precedence)