### PR TITLE
Remove the change in resonance structure from the vinylogous carboxylic acid pH model

### DIFF
--- a/data/phmodel.txt
+++ b/data/phmodel.txt
@@ -22,7 +22,7 @@
 TRANSFORM O=C[OD1-0:1] >> O=C[O-:1]					4.0 # pKa from acid (AH)
 
 #uncomment for vinylogous carboxylic acids (e.g. ascorbic acid)
-TRANSFORM [O:1]=[C:2][C:3]=[C:4][O:5] >> [O-:1][C:2]=[C:3][C:4]=[O:5]	4.0 # pKa from acid (AH)
+TRANSFORM [O:1]=[C:2][C:3]=[C:4][O:5] >> [O:1]=[C:2][C:3]=[C:4][O-:5]   4.0 # pKa from acid (AH)
 
 #charged amine
 TRANSFORM [N^3;!$(N~[!#6;!#1]):1] >> [N+:1]				10.0 # pKa from conjugated acid (BH+)


### PR DESCRIPTION
This pull request changes the vinylogous carboxylic acid pH model. Originally, the pH model changed the resonance structure and put the charge at the O1 position (changing the bond order of the related atoms in the process). Due to the way openbabel applies the pH model, the model can be applied more than once resulting in an invalid structure. For example, if you add hydrogens to the [SDF file](http://www.rcsb.org/pdb/download/downloadLigandFiles.do?ligandIdList=CZA&structIdList=3FPB&instanceType=all&excludeUnobserved=false&includeHydrogens=false) for cyclopiazonic acid from the PDB 3fpb: `obabel -isdf CZA.sdf -omol2 -p 7.4` you can see that atom 3 has 5 bonds to it and oxygens 1 and 5 are both assigned negative charges. Additionally, in the output mol2 file the bond order for the bonds 1-2, 3-24 and 4-5 are set to 0, which is invalid. 

You don't actually need to change the resonance structure for this pH model to work, so my suggested model just gives the vinyl hydroxyl in the input structure the negative charge.

Input SDF:
![original_sdf](https://cloud.githubusercontent.com/assets/29077949/26610515/cfe512e4-455c-11e7-9622-1f5bbc818412.png)
Output Mol2:
![output_mol2](https://cloud.githubusercontent.com/assets/29077949/26610522/d6f8f28a-455c-11e7-902d-74a8aeb1ca7e.png)
