### PR TITLE
Change silicon to correct MM3 atom type

### DIFF
--- a/src/formats/tinkerformat.cpp
+++ b/src/formats/tinkerformat.cpp
@@ -354,7 +354,7 @@ namespace OpenBabel
     case 12: // Mg
       return 59; break;
     case 14: // Si
-      return 59; break;
+      return 19; break;
 
     case 15: // P
       if (atom->CountFreeOxygens() > 0)


### PR DESCRIPTION
Silicon is incorrectly assigned as Magnesium. 

It should be replaced with the only silicon type in the mm3 parameter list - #19 silane
https://dasher.wustl.edu/tinker/distribution/params/mm3.prm