### PR TITLE
Fix pubchem JSON handling of enum types as ints

### DIFF
--- a/src/formats/json/pubchemjsonformat.cpp
+++ b/src/formats/json/pubchemjsonformat.cpp
@@ -166,15 +166,14 @@ class PubChemJSONFormat : public OBMoleculeFormat
     Json::Value elements = molRoot["atoms"]["element"];
     pmol->ReserveAtoms(eAids.size());
     for(Json::ArrayIndex i = 0; i < eAids.size(); i++) {
-      if (eAids[i].isInt() && elements[i].isString()) {
-        string elementstring = elements[i].asString();
+      if (eAids[i].isInt() && elements[i].isInt()) {
+        int atomicNum = elements[i].asInt();
         OBAtom* patom = pmol->NewAtom((unsigned long)eAids[i].asInt());
-        if (elementstring == "a" || elementstring == "d" || elementstring == "r" || elementstring == "lp") {
+        if (atomicNum == 255 || atomicNum == 254 || atomicNum == 253 || atomicNum == 252) {
           patom->SetAtomicNum(0);
         } else {
-          patom->SetAtomicNum(OBElements::GetAtomicNum(elements[i].asCString()));
+          patom->SetAtomicNum(atomicNum);
         }
-        
       } else {
         obErrorLog.ThrowError("PubChemJSONFormat", "Invalid atom", obWarning);
       }
@@ -558,11 +557,9 @@ class PubChemJSONFormat : public OBMoleculeFormat
       doc["atoms"]["aid"].append(id);
       // Element
       if (patom->GetAtomicNum()) {
-        string el = OBElements::GetSymbol(patom->GetAtomicNum());
-        std::transform(el.begin(), el.end(), el.begin(), ::tolower);
-        doc["atoms"]["element"].append(el);
+        doc["atoms"]["element"].append(patom->GetAtomicNum());
       } else {
-        doc["atoms"]["element"].append("a");
+        doc["atoms"]["element"].append(255);
       }
       // Charge
       int c = patom->GetFormalCharge();

--- a/src/formats/json/pubchemjsonformat.cpp
+++ b/src/formats/json/pubchemjsonformat.cpp
@@ -199,31 +199,14 @@ class PubChemJSONFormat : public OBMoleculeFormat
     Json::Value radicals = molRoot["atoms"]["radical"];
     for(Json::ArrayIndex i = 0; i < radicals.size(); i++) {
       Json::Value radical = radicals[i];
-      if (radical["aid"].isInt() && radical["type"].isString()) {
+      if (radical["aid"].isInt() && radical["type"].isInt()) {
         OBAtom* patom = pmol->GetAtomById(radical["aid"].asInt());
         if (patom) {
-          string radicalstring = radical["type"].asString();
-          if (radicalstring == "singlet") {
-            patom->SetSpinMultiplicity(1);
-          } else if (radicalstring == "doublet") {
-            patom->SetSpinMultiplicity(2); 
-          } else if (radicalstring == "triplet") {
-            patom->SetSpinMultiplicity(3);
-          } else if (radicalstring == "quartet") {
-            patom->SetSpinMultiplicity(4);
-          } else if (radicalstring == "quintet") {
-            patom->SetSpinMultiplicity(5);
-          } else if (radicalstring == "hextet") {
-            patom->SetSpinMultiplicity(6);
-          } else if (radicalstring == "heptet") {
-            patom->SetSpinMultiplicity(7);
-          } else if (radicalstring == "octet") {
-            patom->SetSpinMultiplicity(8);
-          } else if (radicalstring == "none") {
-            patom->SetSpinMultiplicity(0);
-          } else {
-            obErrorLog.ThrowError("PubChemJSONFormat", "Invalid atom radical", obWarning);
+          int sm = radical["type"].asInt();
+          if (sm == 255) {
+            sm = 0;
           }
+          patom->SetSpinMultiplicity(sm);
         } else {
           obErrorLog.ThrowError("PubChemJSONFormat", "Invalid atom radical", obWarning);
         }
@@ -598,23 +581,7 @@ class PubChemJSONFormat : public OBMoleculeFormat
       if (sm > 0 && sm < 9) {
         Json::Value radical;
         radical["aid"] = id;
-        if (sm == 1) {
-          radical["type"] = "singlet";
-        } else if (sm == 2) {
-          radical["type"] = "doublet";
-        } else if (sm == 3) {
-          radical["type"] = "triplet";
-        } else if (sm == 4) {
-          radical["type"] = "quartet";
-        } else if (sm == 5) {
-          radical["type"] = "quintet";
-        } else if (sm == 6) {
-          radical["type"] = "hextet";
-        } else if (sm == 7) {
-          radical["type"] = "heptet";
-        } else if (sm == 8) {
-          radical["type"] = "octet";
-        }
+        radical["type"] = sm;
         doc["atoms"]["radical"].append(radical);
       }
       // Coordinates

--- a/src/formats/json/pubchemjsonformat.cpp
+++ b/src/formats/json/pubchemjsonformat.cpp
@@ -81,7 +81,7 @@ class PubChemJSONFormat : public OBMoleculeFormat
     if (pmol == NULL) return false;
     istream& ifs = *pConv->GetInStream();
     
-    if ( !ifs.good() || ifs.peek() == EOF )
+    if (!ifs.good())
       return false;
       
     map<OBBond*, OBStereo::BondDirection> updown;
@@ -90,14 +90,15 @@ class PubChemJSONFormat : public OBMoleculeFormat
     
     // Parse entire file into memory once, then reuse inRoot for subsequent molecules
     // (It's really tricky to stream json)
-    if (inRoot.empty()) {
+    if (!(ifs.peek() == EOF)) {
       Json::Reader reader;
       if (!reader.parse(ifs, inRoot)) {
         obErrorLog.ThrowError("PubChemJSONFormat", reader.getFormattedErrorMessages(), obError);
         return false;
       }
+      // Clear ifs flags so it is "good" and any subsequent mols are read, but leave it at EOF position.
+      // Therefore, when not at EOF position we know to parse next file and reset currentMolIndex 
       ifs.clear();
-      ifs.seekg(0, ios::beg);
       currentMolIndex = 0;
     }
     

--- a/src/formats/json/pubchemjsonformat.cpp
+++ b/src/formats/json/pubchemjsonformat.cpp
@@ -411,12 +411,12 @@ class PubChemJSONFormat : public OBMoleculeFormat
           config.center = tet["center"].asInt();
           config.from = (tet["top"].asInt() == -1) ? OBStereo::ImplicitRef : tet["top"].asInt();
           config.refs.push_back((tet["below"].asInt() == -1) ? OBStereo::ImplicitRef : tet["below"].asInt());
-          if (tet["parity"].asString() == "clockwise") {
+          if (tet["parity"].asInt() == 1) {  // "clockwise"
             config.specified = true;
             config.winding = OBStereo::Clockwise;
             config.refs.push_back((tet["bottom"].asInt() == -1) ? OBStereo::ImplicitRef : tet["bottom"].asInt());
             config.refs.push_back((tet["above"].asInt() == -1) ? OBStereo::ImplicitRef : tet["above"].asInt());
-          } else if (tet["parity"].asString() == "counterclockwise") {
+          } else if (tet["parity"].asInt() == 2) {  // "counterclockwise"
             config.specified = true;
             config.winding = OBStereo::AntiClockwise;
             config.refs.push_back((tet["above"].asInt() == -1) ? OBStereo::ImplicitRef : tet["above"].asInt());
@@ -439,7 +439,7 @@ class PubChemJSONFormat : public OBMoleculeFormat
           config.refs.push_back((pl["rtop"].asInt() == -1) ? OBStereo::ImplicitRef : pl["rtop"].asInt());
           config.refs.push_back((pl["rbottom"].asInt() == -1) ? OBStereo::ImplicitRef : pl["rbottom"].asInt());
           config.refs.push_back((pl["lbottom"].asInt() == -1) ? OBStereo::ImplicitRef : pl["lbottom"].asInt());
-          if (pl["parity"].asString() == "any" || pl["parity"].asString() == "unknown") {
+          if (pl["parity"].asInt() == 3 || pl["parity"].asInt() == 255) {  // "any" or "unknown"
             config.specified = false;
           } else {
             config.specified = true;
@@ -456,7 +456,7 @@ class PubChemJSONFormat : public OBMoleculeFormat
           config.refs.push_back((sq["rbelow"].asInt() == -1) ? OBStereo::ImplicitRef : sq["rbelow"].asInt());
           config.refs.push_back((sq["rabove"].asInt()) ? OBStereo::ImplicitRef : sq["rabove"].asInt());
           config.refs.push_back((sq["labove"].asInt() == -1) ? OBStereo::ImplicitRef : sq["labove"].asInt());
-          if (sq["parity"].asString() == "any" || sq["parity"].asString() == "unknown") {
+          if (sq["parity"].asInt() == 4 || sq["parity"].asInt() == 255) {  // "any" or "unknown"
             config.specified = false;
           } else {
             config.specified = true;
@@ -694,18 +694,18 @@ class PubChemJSONFormat : public OBMoleculeFormat
       if (facade.HasTetrahedralStereo(patom->GetId())) {
         OBTetrahedralStereo::Config config = facade.GetTetrahedralStereo(patom->GetId())->GetConfig();
         Json::Value tet;
-        tet["tetrahedral"]["type"] = "tetrahedral";
+        tet["tetrahedral"]["type"] = 1;  // "tetrahedral"
         tet["tetrahedral"]["center"] = (int)config.center;
         tet["tetrahedral"]["top"] = (int)config.from;
         tet["tetrahedral"]["below"] = (int)config.refs[0];
         tet["tetrahedral"]["bottom"] = (int)config.refs[1];
         tet["tetrahedral"]["above"] = (int)config.refs[2];
         if (config.winding == OBStereo::UnknownWinding || !config.specified) {
-          tet["tetrahedral"]["parity"] = "any";
+          tet["tetrahedral"]["parity"] = 3;  // "any"
         } else if (config.winding == OBStereo::Clockwise){
-          tet["tetrahedral"]["parity"] = "clockwise";
+          tet["tetrahedral"]["parity"] = 1;  // "clockwise"
         } else if (config.winding == OBStereo::AntiClockwise){
-          tet["tetrahedral"]["parity"] = "counterclockwise";
+          tet["tetrahedral"]["parity"] = 2;  // "counterclockwise"
           tet["tetrahedral"]["bottom"] = (int)config.refs[2];
           tet["tetrahedral"]["above"] = (int)config.refs[1];
         }
@@ -718,26 +718,26 @@ class PubChemJSONFormat : public OBMoleculeFormat
         sq["squareplanar"]["center"] = (int)config.center;
         if (config.specified) {
           if (config.shape == OBStereo::ShapeU) {
-            sq["squareplanar"]["parity"] = "u-shape";
+            sq["squareplanar"]["parity"] = 1;  // "u-shape"
             sq["squareplanar"]["lbelow"] = (int)config.refs[0];
             sq["squareplanar"]["rbelow"] = (int)config.refs[1];
             sq["squareplanar"]["rabove"] = (int)config.refs[2];
             sq["squareplanar"]["labove"] = (int)config.refs[3];
           } else if (config.shape == OBStereo::ShapeZ) {
-            sq["squareplanar"]["parity"] = "z-shape";
+            sq["squareplanar"]["parity"] = 2;  // "z-shape"
             sq["squareplanar"]["lbelow"] = (int)config.refs[0];
             sq["squareplanar"]["rbelow"] = (int)config.refs[1];
             sq["squareplanar"]["labove"] = (int)config.refs[2];
             sq["squareplanar"]["rabove"] = (int)config.refs[3];
           } else if (config.shape == OBStereo::Shape4) {
-            sq["squareplanar"]["parity"] = "x-shape";
+            sq["squareplanar"]["parity"] = 3;  // "x-shape"
             sq["squareplanar"]["lbelow"] = (int)config.refs[0];
             sq["squareplanar"]["rabove"] = (int)config.refs[1];
             sq["squareplanar"]["rbelow"] = (int)config.refs[2];
             sq["squareplanar"]["labove"] = (int)config.refs[3];
           }
         } else {
-          sq["squareplanar"]["parity"] = "any";
+          sq["squareplanar"]["parity"] = 4;  // "any"
           sq["squareplanar"]["lbelow"] = (int)config.refs[0];
           sq["squareplanar"]["rbelow"] = (int)config.refs[1];
           sq["squareplanar"]["rabove"] = (int)config.refs[2];
@@ -750,7 +750,7 @@ class PubChemJSONFormat : public OBMoleculeFormat
         OBCisTransStereo *cts = facade.GetCisTransStereo(pbond->GetId());
         OBCisTransStereo::Config config = cts->GetConfig();
         Json::Value ct;
-        ct["planar"]["type"] = "planar";
+        ct["planar"]["type"] = 1;  // "planar"
         ct["planar"]["ltop"] = (int)config.refs[0];
         OBAtom *begin = pmol->GetAtomById(config.begin);
         OBAtom *ltop = pmol->GetAtomById(config.refs[0]);
@@ -767,9 +767,9 @@ class PubChemJSONFormat : public OBMoleculeFormat
           ct["planar"]["rtop"] = (int)cts->GetTransRef(ct["planar"]["lbottom"].asInt());
           if (config.specified) {
             // Open babel is not capable of determining parity? (need CIP rules?)
-            ct["planar"]["parity"] = "unknown";
+            ct["planar"]["parity"] = 255;  // "unknown"
           } else {
-            ct["planar"]["parity"] = "any";
+            ct["planar"]["parity"] = 3;  // "any"
           }        
           doc["stereo"].append(ct);
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -241,7 +241,7 @@ endif(NOT MINGW AND NOT CYGWIN)
 if (PYTHON_BINDINGS)
   include(UsePythonTest)
   set(pybindtests
-      bindings _pybel example)
+      bindings _pybel example pcjsonformat)
   foreach(pybindtest ${pybindtests})
     SET_SOURCE_FILES_PROPERTIES(test${pybindtest}.py PROPERTIES
         PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}"

--- a/test/testpcjsonformat.py
+++ b/test/testpcjsonformat.py
@@ -1,0 +1,145 @@
+"""Example test that uses the OpenBabel Python bindings
+
+On Windows or Linux, you can run these tests at the commandline
+in the build folder with:
+"C:\Program Files\CMake 2.6\bin\ctest.exe" -C CTestTestfile.cmake
+                                           -R pybindtest -VV
+
+You could also "chdir" into build/test and run the test file directly:
+python ../../test/testpcjsonformat.py
+
+In both cases, the test file is run directly from the source folder,
+and so you can quickly develop the tests and try them out.
+"""
+
+import unittest
+from testbindings import PybelWrapper, pybel
+
+
+class TestPcJsonFormat(PybelWrapper):
+    """Test PubChem JSON format."""
+
+    def testRead(self):
+        """Test reading a PubChem JSON file."""
+
+        pcjson_input = """
+{
+  "PC_Compounds": [
+    {
+      "atoms": {
+        "aid": [1,2,3,4,5,6,7,8,9,10,11,12,13],
+        "element": [8,8,7,6,6,6,1,1,1,1,1,1,1]
+      },
+      "bonds": {
+        "aid1": [1,1,2,4,3,3,4,4,4,5,5,5],
+        "aid2": [6,13,6,3,11,12,5,6,7,8,9,10],
+        "order": [1,1,2,1,1,1,1,1,1,1,1,1]
+      },
+      "charge": 0,
+      "coords": [
+        {
+          "aid": [1,2,3,4,5,6,7,8,9,10,11,12,13],
+          "conformers": [
+            {
+              "style": {"aid1": [4],"aid2": [7],"annotation": [6]},
+              "x": [
+                5.1350,
+                4.2690,
+                2.53690,
+                3.4030,
+                3.4030,
+                4.2690,
+                3.4030,
+                2.7830,
+                3.4030,
+                4.0230,
+                2.0,
+                2.53690,
+                5.6720
+              ],
+              "y": [
+                -0.250,
+                1.250,
+                0.250,
+                -0.250,
+                -1.250,
+                0.250,
+                0.370,
+                -1.250,
+                -1.870,
+                -1.250,
+                -0.060,
+                0.870,
+                0.060
+              ]
+            }
+          ]
+        }
+      ],
+      "id": {"id": {"cid": 71080}},
+      "stereo": [
+        {
+          "tetrahedral": {
+            "above": 6,
+            "below": 5,
+            "bottom": 7,
+            "center": 4,
+            "parity": 1,
+            "top": 3,
+            "type": 1
+          }
+        }
+      ]
+    }
+  ]
+}
+        """
+        mol = pybel.readstring("pcjson", pcjson_input)
+        self.assertEqual(mol.OBMol.NumAtoms(), 13)
+
+    def testOldStringFormat(self):
+        """Test reading a PubChem JSON file using the old string format."""
+
+        pcjson_input2 = """
+{
+  "PC_Compounds": [
+    {
+      "atoms": {"aid": [1,2,3,4,5,6],"element": ["cl","cl","c","c","h","h"]},
+      "bonds": {"aid1": [1,2,3,3,4],"aid2": [4,3,4,5,6],"order": ["single","single","double","single","single"]},
+      "charge": 0,
+      "coords": [
+        {
+          "aid": [1,2,3,4,5,6],
+          "conformers": [
+            {
+              "x": [4.59810,2.0,2.8660,3.7320,2.8660,3.7320],
+              "y": [-0.250,0.250,-0.250,0.250,-0.870,0.870]
+            }
+          ]
+        }
+      ],
+      "id": {"id": {"cid": 638186}},
+      "stereo": [
+        {
+          "planar": {
+            "left": 3,
+            "ltop": 2,
+            "lbottom": 5,
+            "right": 4,
+            "rtop": 6,
+            "rbottom": 1,
+            "parity": "opposite",
+            "type": "planar"
+          }
+        }
+      ]
+    }
+  ]
+}
+        """
+        mol = pybel.readstring("pcjson", pcjson_input2)
+        self.assertEqual(mol.OBMol.NumAtoms(), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
At some point in the past, it seems that the PubChem JSON format returned by the PubChem REST API changed to return enum type names as integers instead of the string representation. So elements are atomic numbers instead of symbols, bond orders are integers instead of "single", "double", etc.

[Discussion on openbabel-devel mailing list](https://sourceforge.net/p/openbabel/mailman/message/35918486/)