### PR TITLE
Correct MM3 carboxyl oxygen atom type definition

### DIFF
--- a/src/formats/tinkerformat.cpp
+++ b/src/formats/tinkerformat.cpp
@@ -333,7 +333,7 @@ namespace OpenBabel
       if (atom->IsPhosphateOxygen())
         return 159;
       if (atom->IsCarboxylOxygen())
-        return 47;
+        return 75;
       if (atom->IsInRingSize(3))
         return 49; // epoxy
 


### PR DESCRIPTION
MM3 has an atom type definition specifically for carboxyl oxygens. The present code defines carboxyl oxygens as carboxylate ions (which remains the best choice when using MM2).