### PR TITLE
Gaussformat multiple charge modles patch

### DIFF
--- a/include/openbabel/data_utilities.h
+++ b/include/openbabel/data_utilities.h
@@ -59,7 +59,6 @@ namespace OpenBabel {
 				    int                Nrotbonds,
 				    double             dbdt,
 				    double            *temperature,
-				    double            *ZPVE,
 				    double            *DeltaHf0,
 				    double            *DeltaHfT,
 				    double            *DeltaGfT,
@@ -67,7 +66,8 @@ namespace OpenBabel {
 				    double            *S0T,
 				    double            *CVT,
 				    double            *CPT,
-				    std::vector<double> &Scomponents);
+				    std::vector<double> &Scomponents,
+				    double            *ZPVE);
 
 }
 

--- a/include/openbabel/data_utilities.h
+++ b/include/openbabel/data_utilities.h
@@ -29,6 +29,7 @@ GNU General Public License for more details.
 namespace OpenBabel {
 
  const double HARTEE_TO_KCALPERMOL = 627.509469;
+ const double HARTREE_TO_KJPERMOL = 2625.49962;
  const double KJPERMOL_TO_KCALPERMOL = 1.0/4.184;
  const double RYDBERG_TO_KCALPERMOL = 313.755026;
  const double ELECTRONVOLT_TO_KCALPERMOL = 23.060538;
@@ -53,19 +54,20 @@ namespace OpenBabel {
  * \return true if all values were found, false otherwise.
  */
  OBAPI bool extract_thermochemistry(OpenBabel::OBMol  &mol,
-                                        bool    bVerbose,
-                                        int    *Nsymm,
-                                        int     Nrotbonds,
-                                        double  dbdt,
-                                        double *temperature,
-                                        double *DeltaHf0,
-                                        double *DeltaHfT,
-                                        double *DeltaGfT,
-                                        double *DeltaSfT,
-                                        double *S0T,
-                                        double *CVT,
-                                        double *CPT,
-                                        std::vector<double> &Scomponents);
+				    bool               bVerbose,
+				    int               *Nsymm,
+				    int                Nrotbonds,
+				    double             dbdt,
+				    double            *temperature,
+				    double            *ZPVE,
+				    double            *DeltaHf0,
+				    double            *DeltaHfT,
+				    double            *DeltaGfT,
+				    double            *DeltaSfT,
+				    double            *S0T,
+				    double            *CVT,
+				    double            *CPT,
+				    std::vector<double> &Scomponents);
 
 }
 

--- a/include/openbabel/generic.h
+++ b/include/openbabel/generic.h
@@ -1185,9 +1185,71 @@ namespace OpenBabel
 
   };
 
- //! A standard iterator over vectors of OBGenericData (e.g., inherited from OBBase)
-  typedef std::vector<OBGenericData*>::iterator OBDataIterator;
+  class OBAPI OBPcharge
+  {
+  protected:
+    int         _atomIndex;
+    double      _q;
+  public:
+    OBPcharge() {};
+    OBPcharge(int atomIndex, double q) {_atomIndex = atomIndex; _q = q ;}
+    ~OBPcharge() {};
 
+    double GetQ() {return _q;}
+    int    GetAtomIndex() {return _atomIndex;}
+    void   SetQ(double q) {_q = q;}
+    void   SetAtomIndex(int atomIndex) {_atomIndex = atomIndex;}
+    
+  };
+
+  typedef std::vector<OBPcharge*>::iterator OBPchargeIterator;
+  
+  class OBAPI OBPcharges: public OBGenericData
+  {
+  protected:
+    std::vector<OBPcharge*> _PartialCharges;
+  public:
+    OBPcharges(){};
+    ~OBPcharges(){};
+
+    int NumPartialCharges() 
+    { 
+      return _PartialCharges.size(); 
+    }
+    
+    void AddPcharge(int atomIndex, double q)
+    {
+      _PartialCharges.push_back(new OpenBabel::OBPcharge(atomIndex, q));
+    }
+
+    OBPchargeIterator BeginPartialCharges() 
+    { 
+      return _PartialCharges.begin(); 
+    }
+    
+    OBPchargeIterator EndPartialCharges() 
+    {
+      return _PartialCharges.begin() + NumPartialCharges(); 
+    }
+    
+    OBPcharge *BeginPartialCharge(OBPchargeIterator &i)
+    {
+      i = _PartialCharges.begin();
+      return((i == _PartialCharges.end()) ? (OBPcharge*)NULL : (OBPcharge*)*i);
+    }
+
+    OBPcharge *NextPartialCharge(OBPchargeIterator &i)
+    {
+      ++i;
+      return((i == _PartialCharges.end()) ? (OBPcharge*)NULL : (OBPcharge*)*i);
+    }
+
+    bool FindPcharge(int atomIndex, double *q);
+    
+  };
+
+  //! A standard iterator over vectors of OBGenericData (e.g., inherited from OBBase)
+  typedef std::vector<OBGenericData*>::iterator OBDataIterator;
 } //end namespace OpenBabel
 
 #endif // OB_GENERIC_H

--- a/include/openbabel/generic.h
+++ b/include/openbabel/generic.h
@@ -1156,6 +1156,11 @@ namespace OpenBabel
       _points.push_back(new OpenBabel::OBFreeGridPoint(x,y,z,V));
     }
 
+    void ErasePoints()
+    {
+      _points.clear();
+    }
+
     OBFreeGridPointIterator BeginPoints() 
     { 
       return _points.begin(); 

--- a/src/data_utilities.cpp
+++ b/src/data_utilities.cpp
@@ -36,6 +36,7 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
                              int     Nrotbonds,
                              double  dBdT,
                              double *temperature,
+			     double *ZPVE,
                              double *DeltaHf0,
                              double *DeltaHfT,
                              double *DeltaGfT,
@@ -45,7 +46,7 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
                              double *CPT,
                              std::vector<double> &Scomponents)
 {
-    enum kkTYPE { kkDH, kkDG, kkDS, kkS0, kkCV, kkSt, kkSr, kkSv };
+    enum kkTYPE { kkZP, kkDH, kkDG, kkDS, kkS0, kkCV, kkSt, kkSr, kkSv };
     typedef struct {
         std::string term;
         kkTYPE kk;
@@ -87,6 +88,7 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
         Sconf = Rgas*Nrotbonds*log(3.0);
     }
     energy_unit eu[] = {
+        { "zpe",        kkZP },
         { "DeltaHform", kkDH },
         { "DeltaGform", kkDG },
         { "DeltaSform", kkDS },
@@ -128,6 +130,11 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
             {
                 switch (eu[i].kk)
                 {
+		case kkZP:
+		    {
+		        *ZPVE = value;
+		    }
+		    break;
                 case kkDH:
                     if (0 == T)
                     {

--- a/src/data_utilities.cpp
+++ b/src/data_utilities.cpp
@@ -44,9 +44,9 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
                              double *CVT,
                              double *CPT,
                              std::vector<double> &Scomponents,
-			     double *ZPVE)
+                             double *ZPVE)
 {
-  enum kkTYPE {kkDH, kkDG, kkDS, kkS0, kkCV, kkSt, kkSr, kkSv, kkZP};
+    enum kkTYPE {kkDH, kkDG, kkDS, kkS0, kkCV, kkSt, kkSr, kkSv, kkZP};
     typedef struct {
         std::string term;
         kkTYPE kk;
@@ -130,11 +130,11 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
             {
                 switch (eu[i].kk)
                 {
-		case kkZP:
-		    {
-		        *ZPVE = value;
-		    }
-		    break;
+		            case kkZP:
+		                {
+		                    *ZPVE = value;
+		                }
+		                break;
                 case kkDH:
                     if (0 == T)
                     {

--- a/src/data_utilities.cpp
+++ b/src/data_utilities.cpp
@@ -36,7 +36,6 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
                              int     Nrotbonds,
                              double  dBdT,
                              double *temperature,
-			     double *ZPVE,
                              double *DeltaHf0,
                              double *DeltaHfT,
                              double *DeltaGfT,
@@ -44,9 +43,10 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
                              double *S0T,
                              double *CVT,
                              double *CPT,
-                             std::vector<double> &Scomponents)
+                             std::vector<double> &Scomponents,
+			     double *ZPVE)
 {
-    enum kkTYPE { kkZP, kkDH, kkDG, kkDS, kkS0, kkCV, kkSt, kkSr, kkSv };
+  enum kkTYPE {kkDH, kkDG, kkDS, kkS0, kkCV, kkSt, kkSr, kkSv, kkZP};
     typedef struct {
         std::string term;
         kkTYPE kk;

--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -391,6 +391,8 @@ namespace OpenBabel
             sprintf(valbuf,"%f", result[ii]);
             add_unique_pairdata_to_mol(mol, attr[ii], valbuf, 0);
         }
+	sprintf(valbuf, "%f", ezpe*eFactor);
+        add_unique_pairdata_to_mol(mol, "zpe", valbuf, 0);
         sprintf(valbuf, "%f", CV);
         add_unique_pairdata_to_mol(mol, "cv", valbuf, 0);
         sprintf(valbuf, "%f", CV+Rgas);

--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -391,7 +391,7 @@ namespace OpenBabel
             sprintf(valbuf,"%f", result[ii]);
             add_unique_pairdata_to_mol(mol, attr[ii], valbuf, 0);
         }
-	sprintf(valbuf, "%f", ezpe*eFactor);
+        sprintf(valbuf, "%f", ezpe*eFactor);
         add_unique_pairdata_to_mol(mol, "zpe", valbuf, 0);
         sprintf(valbuf, "%f", CV);
         add_unique_pairdata_to_mol(mol, "cv", valbuf, 0);

--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -498,6 +498,9 @@ namespace OpenBabel
 
     bool grids_are_read_once = false;
     int number_of_esp_calcs  = 0;
+    
+    OBPcharges *pcharge = NULL;
+    OpenBabel::OBElementTable *OBet;
 
     //Prescan file to find second instance of "orientation:"
     //This will be the kind of coords used in the chk/fchk file
@@ -705,10 +708,11 @@ namespace OpenBabel
             }
         else if(strstr(buffer,"Total atomic charges") != NULL ||
                 strstr(buffer,"Mulliken atomic charges") != NULL ||
-                strstr(buffer, "Mulliken charges") != NULL)
+                strstr(buffer,"Mulliken charges") != NULL)
           {
             hasPartialCharges = true;
             chargeModel = "Mulliken";
+            pcharge = new OpenBabel::OBPcharges();
             ifs.getline(buffer,BUFF_SIZE);	// column headings
             ifs.getline(buffer,BUFF_SIZE);
             tokenize(vs,buffer);
@@ -719,10 +723,13 @@ namespace OpenBabel
                 if (!atom)
                   break;
                 atom->SetPartialCharge(atof(vs[2].c_str()));
-
+                pcharge->AddPcharge(atoi(vs[0].c_str()), atof(vs[2].c_str()));
                 if (!ifs.getline(buffer,BUFF_SIZE)) break;
                 tokenize(vs,buffer);
+                                    
               }
+            pcharge->SetAttribute("Mulliken Charges");
+            mol.SetData(pcharge);      
           }
         else if (strstr(buffer, "Atomic Center") != NULL && number_of_esp_calcs < 2)
           {
@@ -817,6 +824,7 @@ namespace OpenBabel
           {
             hasPartialCharges = true;
             chargeModel = "ESP";
+            pcharge = new OpenBabel::OBPcharges();
             ifs.getline(buffer,BUFF_SIZE);	// Charge / dipole line
             ifs.getline(buffer,BUFF_SIZE); // column header
             ifs.getline(buffer,BUFF_SIZE); // real charges
@@ -828,10 +836,12 @@ namespace OpenBabel
                 if (!atom)
                   break;
                 atom->SetPartialCharge(atof(vs[2].c_str()));
-
+                pcharge->AddPcharge(atoi(vs[0].c_str()), atof(vs[2].c_str()));
                 if (!ifs.getline(buffer,BUFF_SIZE)) break;
                 tokenize(vs,buffer);
               }
+            pcharge->SetAttribute("ESP Charges");
+            mol.SetData(pcharge);
           }
         else if(strstr(buffer,"Natural Population") != NULL)
           {

--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -705,7 +705,7 @@ namespace OpenBabel
             }
         else if(strstr(buffer,"Total atomic charges") != NULL ||
                 strstr(buffer,"Mulliken atomic charges") != NULL ||
-                strstr(buffer,"Mulliken charges") != NULL)
+                strstr(buffer,"Mulliken charges:") != NULL)
           {
             hasPartialCharges = true;
             chargeModel = "Mulliken";

--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -496,6 +496,9 @@ namespace OpenBabel
     bool no_symmetry=false;
     char coords_type[25];
 
+    bool grids_are_read_once = false;
+    int number_of_esp_calcs  = 0;
+
     //Prescan file to find second instance of "orientation:"
     //This will be the kind of coords used in the chk/fchk file
     //Unless the "nosym" keyword has been requested
@@ -701,7 +704,8 @@ namespace OpenBabel
               if (!ifs.getline(buffer,BUFF_SIZE)) break;
             }
         else if(strstr(buffer,"Total atomic charges") != NULL ||
-                strstr(buffer,"Mulliken atomic charges") != NULL)
+                strstr(buffer,"Mulliken atomic charges") != NULL ||
+                strstr(buffer, "Mulliken charges") != NULL)
           {
             hasPartialCharges = true;
             chargeModel = "Mulliken";
@@ -720,12 +724,18 @@ namespace OpenBabel
                 tokenize(vs,buffer);
               }
           }
-        else if (strstr(buffer, "Atomic Center") != NULL)
+        else if (strstr(buffer, "Atomic Center") != NULL && number_of_esp_calcs < 2)
           {
             // Data points for ESP calculation
             tokenize(vs,buffer);
             if (NULL == esp)
-              esp = new OpenBabel::OBFreeGrid();
+              {
+                 esp = new OpenBabel::OBFreeGrid();
+              }
+            else if (NULL != esp && grids_are_read_once)
+              {
+                 esp = new OpenBabel::OBFreeGrid();
+              }
             if (vs.size() == 8)
               {
                 esp->AddPoint(atof(vs[5].c_str()),atof(vs[6].c_str()),
@@ -740,7 +750,7 @@ namespace OpenBabel
                   }
               }
           }
-        else if (strstr(buffer, "ESP Fit Center") != NULL)
+        else if (strstr(buffer, "ESP Fit Center") != NULL && number_of_esp_calcs < 2)
           {
             // Data points for ESP calculation
             tokenize(vs,buffer);
@@ -760,7 +770,7 @@ namespace OpenBabel
                   }
               }
           }
-        else if (strstr(buffer, "Electrostatic Properties (Atomic Units)") != NULL)
+        else if (strstr(buffer, "Electrostatic Properties (Atomic Units)") != NULL && number_of_esp_calcs < 2)
           {
             int i,np;
             OpenBabel::OBFreeGridPoint *fgp;
@@ -786,8 +796,17 @@ namespace OpenBabel
               }
             if (i == np)
               {
-                esp->SetAttribute("Electrostatic Potential");
+                if (number_of_esp_calcs == 0)
+                  {
+                    esp->SetAttribute("Input Electrostatic Potential");
+                  }
+                else if (number_of_esp_calcs == 1)
+                  {
+                    esp->SetAttribute("Optimized Electrostatic Potential");
+                  }
                 mol.SetData(esp);
+                grids_are_read_once = true;
+                number_of_esp_calcs++;
               }
             else
               {

--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -1642,6 +1642,23 @@ unsigned int OBVibrationData::GetNumberOfFrequencies() const
   return this->_vFrequencies.size();
 }
 
+bool OBPcharges::FindPcharge(int    atomIndex,
+                             double *q)
+{
+  OBPcharge        *pc;
+  OBPchargeIterator pci;     
+  pci = BeginPartialCharges();
+  for (pc = BeginPartialCharge(pci); (NULL != pc); pc = NextPartialCharge(pci))
+    {
+      if (atomIndex == pc->GetAtomIndex())
+        {
+          *q = pc->GetQ();
+          return true;
+        }
+    }
+  return false;
+}
+
 } //end namespace OpenBabel
 
 //! \file generic.cpp

--- a/tools/obthermo.cpp
+++ b/tools/obthermo.cpp
@@ -127,7 +127,7 @@ int main(int argc,char **argv)
   if ((conv.Read(&mol, &ifs)) && ! mol.Empty())
   {
       OBPointGroup obPG;
-      double temperature, DeltaHf0, DeltaHfT, DeltaGfT, DeltaSfT, S0T, CVT, CPT;
+      double temperature, DeltaHf0, DeltaHfT, DeltaGfT, DeltaSfT, S0T, CVT, CPT, ZPVE;
       std::vector<double> Scomponents;
       
       obPG.Setup(&mol);
@@ -146,6 +146,7 @@ int main(int argc,char **argv)
                                   Nrot,
                                   dBdT,
                                   &temperature,
+				  &ZPVE,
                                   &DeltaHf0,
                                   &DeltaHfT,
                                   &DeltaGfT,

--- a/tools/obthermo.cpp
+++ b/tools/obthermo.cpp
@@ -146,7 +146,6 @@ int main(int argc,char **argv)
                                   Nrot,
                                   dBdT,
                                   &temperature,
-				  &ZPVE,
                                   &DeltaHf0,
                                   &DeltaHfT,
                                   &DeltaGfT,
@@ -154,7 +153,8 @@ int main(int argc,char **argv)
                                   &S0T,
                                   &CVT,
                                   &CPT,
-                                  Scomponents))
+                                  Scomponents,
+				  &ZPVE))
       {
           double Rgas  = 1.9872041; // cal/mol K
           printf("DeltaHform(0K)  %10g  %s\n", DeltaHf0*unit_factor, e_unit.c_str());

--- a/tools/obthermo.cpp
+++ b/tools/obthermo.cpp
@@ -154,7 +154,7 @@ int main(int argc,char **argv)
                                   &CVT,
                                   &CPT,
                                   Scomponents,
-				  &ZPVE))
+                                  &ZPVE))
       {
           double Rgas  = 1.9872041; // cal/mol K
           printf("DeltaHform(0K)  %10g  %s\n", DeltaHf0*unit_factor, e_unit.c_str());


### PR DESCRIPTION
Here is implemented to read more than one charge models from the Gaussian output and store them as OBGenericData in OBMol. It now reads Mulliken, Hirshfeld, CM5, and ESP charges. 