### PR TITLE
Fix for calculating implicit H count when reading SMILES

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -539,7 +539,7 @@ namespace OpenBabel {
       int hcount = _hcount[idx - 1];
       switch (hcount) {
       case -2: { // aromatic carbon
-        unsigned int numbonds = atom->GetValence();
+        unsigned int numbonds = atom->BOSum();
         if (numbonds < 3)
           atom->SetImplicitHCount(3 - numbonds);
         else

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -67,6 +67,12 @@ class TestSuite(PythonBindings):
             mol.OBMol.AssignTotalChargeToAtoms(charge)
             self.assertEqual(mol.write("smi").rstrip(), ans)
 
+    def testReadingBenzyne(self):
+        """Check that benzyne is read correctly"""
+        smi = "c1cccc#c1"
+        mol = pybel.readstring("smi", smi)
+        self.assertEqual("C1=CC=CC#C1", mol.write("smi").rstrip())
+
     def testSmilesParsingOfAllElements(self):
         smi = "[*][H][He][Li][Be][B][C][N][O][F][Ne][Na][Mg][Al][Si][P][S][Cl][Ar][K][Ca][Sc][Ti][V][Cr][Mn][Fe][Co][Ni][Cu][Zn][Ga][Ge][As][Se][Br][Kr][Rb][Sr][Y][Zr][Nb][Mo][Tc][Ru][Rh][Pd][Ag][Cd][In][Sn][Sb][Te][I][Xe][Cs][Ba][La][Ce][Pr][Nd][Pm][Sm][Eu][Gd][Tb][Dy][Ho][Er][Tm][Yb][Lu][Hf][Ta][W][Re][Os][Ir][Pt][Au][Hg][Tl][Pb][Bi][Po][At][Rn][Fr][Ra][Ac][Th][Pa][U][Np][Pu][Am][Cm][Bk][Cf][Es][Fm][Md][No][Lr][Rf][Db][Sg][Bh][Hs][Mt][Ds][Rg][Cn][Nh][Fl][Mc][Lv][Ts][Og]"
         roundtrip = pybel.readstring("smi", smi).write("smi").rstrip()


### PR DESCRIPTION
Fix #1605. Forgot that GetValence() returns the degree not the valence. We really ought to do something about this.