### PR TITLE
 Fix some small misspellings in the csharp bindings

### DIFF
--- a/scripts/openbabel-csharp.i
+++ b/scripts/openbabel-csharp.i
@@ -132,7 +132,13 @@
 		get{return new OBVector3(0,0,0);}
 	}
 %}
-  
+%typemap(cscode) OpenBabel::matrix3x3
+%{
+  public static OBVector3 Mul(OBMatrix3x3 m, OBVector3 v)
+  {
+    return new OBVector3(v.x()*m.Get(0,0) + v.y()*m.Get(0,1) + v.z()*m.Get(0,2), v.x()*m.Get(1,0) + v.y()*m.Get(1,1) + v.z()*m.Get(1,2), v.x()*m.Get(2,0) + v.y()*m.Get(2,1) + v.z()*m.Get(2,2));
+  }
+%}
 //simplified public Downcast method
 //this is defined up here because something
 //lower down in the file interferes with it

--- a/scripts/openbabel-csharp.i
+++ b/scripts/openbabel-csharp.i
@@ -134,10 +134,27 @@
 %}
 %typemap(cscode) OpenBabel::matrix3x3
 %{
-  public static OBVector3 Mul(OBMatrix3x3 m, OBVector3 v)
-  {
-    return new OBVector3(v.x()*m.Get(0,0) + v.y()*m.Get(0,1) + v.z()*m.Get(0,2), v.x()*m.Get(1,0) + v.y()*m.Get(1,1) + v.z()*m.Get(1,2), v.x()*m.Get(2,0) + v.y()*m.Get(2,1) + v.z()*m.Get(2,2));
-  }
+  	public static OBVector3 Mul(OBMatrix3x3 m, OBVector3 v)
+  	{
+    		return new OBVector3(v.x()*m.Get(0,0) + v.y()*m.Get(0,1) + v.z()*m.Get(0,2), v.x()*m.Get(1,0) + v.y()*m.Get(1,1) + v.z()*m.Get(1,2), v.x()*m.Get(2,0) + v.y()*m.Get(2,1) + v.z()*m.Get(2,2));
+  	}
+	public static OBMatrix3x3 Mul(OBMatrix3x3 A, OBMatrix3x3 B)
+	{
+		OBMatrix3x3 result = new OBMatrix3x3();
+	    
+		result.Set(0,0, A.Get(0,0)*B.Get(0,0) + A.Get(0,1)*B.Get(1,0) + A.Get(0,2)*B.Get(2,0));
+		result.Set(0,1, A.Get(0,0)*B.Get(0,1) + A.Get(0,1)*B.Get(1,1) + A.Get(0,2)*B.Get(2,1));
+		result.Set(0,2, A.Get(0,0)*B.Get(0,2) + A.Get(0,1)*B.Get(1,2) + A.Get(0,2)*B.Get(2,2));
+		
+		result.Set(1,0, A.Get(1,0)*B.Get(0,0) + A.Get(1,1)*B.Get(1,0) + A.Get(1,2)*B.Get(2,0));
+		result.Set(1,1, A.Get(1,0)*B.Get(0,1) + A.Get(1,1)*B.Get(1,1) + A.Get(1,2)*B.Get(2,1));
+		result.Set(1,2, A.Get(1,0)*B.Get(0,2) + A.Get(1,1)*B.Get(1,2) + A.Get(1,2)*B.Get(2,2));
+		
+		result.Set(2,0, A.Get(2,0)*B.Get(0,0) + A.Get(2,1)*B.Get(1,0) + A.Get(2,2)*B.Get(2,0));
+		result.Set(2,1, A.Get(2,0)*B.Get(0,1) + A.Get(2,1)*B.Get(1,1) + A.Get(2,2)*B.Get(2,1));
+		result.Set(2,2, A.Get(2,0)*B.Get(0,2) + A.Get(2,1)*B.Get(1,2) + A.Get(2,2)*B.Get(2,2));
+		return(result);
+	}
 %}
 //simplified public Downcast method
 //this is defined up here because something

--- a/scripts/openbabel-csharp.i
+++ b/scripts/openbabel-csharp.i
@@ -976,8 +976,8 @@ WRAPITERATOR(OBMolBondBFSIter,OpenBabel::OBMolBondBFSIter,OBBond);
 WRAPITERATOR(OBMolAngleIter,OpenBabel::OBMolAngleIter,VectorUInt);
 WRAPITERATOR(OBAtomAtomIter,OpenBabel::OBAtomAtomIter,OBAtom)
 WRAPITERATOR(OBAtomBondIter,OpenBabel::OBAtomBondIter,OBBond);
-WRAPITERATOR(OBMolRingIter,OpenBabel::OBRingIter,OBRing);
-WRAPITERATOR(OBMolTorsionIter,OpenBabel::OBTorsionIter,VectorUInt);
+WRAPITERATOR(OBMolRingIter,OpenBabel::OBMolRingIter,OBRing);
+WRAPITERATOR(OBMolTorsionIter,OpenBabel::OBMolTorsionIter,VectorUInt);
 WRAPITERATOR(OBResidueIter,OpenBabel::OBResidueIter,OBResidue);
 WRAPITERATOR(OBResidueAtomIter,OpenBabel::OBResidueAtomIter,OBAtom);
 WRAPITERATOR(OBMolPairIter,OpenBabel::OBMolPairIter,VectorUInt)


### PR DESCRIPTION
the functions for OBTorsionIter and OBRingIter are misspelled in the swig interface file for the csharp bindings