### PR TITLE
Tweak the handling of implicit Hs when reading SMILES

### DIFF
--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -53,6 +53,13 @@ class PybelWrapper(PythonBindings):
         self.assertTrue(pybel is not None, "Failed to import the Pybel module")
 
 class TestSuite(PythonBindings):
+
+    def testKekulizationOfcn(self):
+        """We were previously not reading 'cn' correctly, or at least how
+        Daylight would"""
+        mol = pybel.readstring("smi", "cn")
+        self.assertEqual("C=N", mol.write("smi").rstrip())
+
     def testOBMolAssignTotalChargeToAtoms(self):
         """Run the test cases described in the source code"""
         data = [("[NH4]", +1, "[NH4+]"),


### PR DESCRIPTION
My code was not quite right for determining the number of attached Hs to an aromatic atom in SMILES. I was special-casing lowercase c versus everything else. I've now got a one size fits all. Thanks again to @johnmay for pointing out the issue with 'cn' and the solution.