### PR TITLE
Simplify user installation by creating build directory upfront

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.py[cod]
 build
+!build/.keep
 nbproject
 scripts/*/*.cpp
 scripts/python/openbabel.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.py[cod]
-build
+build/*
 !build/.keep
 nbproject
 scripts/*/*.cpp

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
  - sudo apt-get install -qq swig libeigen3-dev
 
 before_script:
- - mkdir build
  - cd build
  - cmake ${FLAGS} ..
 

--- a/INSTALL
+++ b/INSTALL
@@ -24,25 +24,20 @@ section.
 The following instructions assume that the Open Babel source distribution is in
 the directory ~/openbabel-2.4.0.
 
-1. Create a 'build' directory:
-
-   mkdir build
-   cd build
-
-2. Configure the build system. You can specify additional build
+1. Configure the build system. You can specify additional build
 options at this time (see below):
 
-   cmake ..
+   cmake
 
-3. Compile:
+2. Compile:
 
    make -j2
 
-4. Test (optional):
+3. Test (optional):
 
    make test
 
-5. Install:
+4. Install:
 
    sudo make install
 


### PR DESCRIPTION
Build dir contains empty .keep file just to avoid creating it by user. Any other build files will be ignored