### PR TITLE
Fix install regression with element data

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -5,7 +5,6 @@ set(to_install
     atomtyp.txt
     babel_povray3.inc
     bondtyp.txt
-    element.txt
     eem.txt
     eem2015ba.txt
     eem2015bm.txt
@@ -18,8 +17,6 @@ set(to_install
     gaff.dat
     gaff.prm
     ghemical.prm
-    isotope-small.txt
-    isotope.txt
     logp.txt
     MACCS.txt
     mmff94.ff


### PR DESCRIPTION
Fixes a minor installation regression from PR #1601.  `make install` crashed with the following error:

```
CMake Error at data/cmake_install.cmake:39 (file):
  file INSTALL cannot find
  "/cygdrive/c/Users/Benjamin/Git/Contrib/openbabel/data/element.txt".
Call Stack (most recent call first):
  cmake_install.cmake:68 (include)
```

Removing the deleted files from the cmake target allowed installation to proceed.

I haven't used Travis much yet, but would a `make install` test in CI be useful?