### PR TITLE
Changes needed to compile with C++17

### DIFF
--- a/src/bitvec.cpp
+++ b/src/bitvec.cpp
@@ -66,7 +66,7 @@ namespace OpenBabel
 
 #ifndef LowBit
 #define LowBit(set, bit)                                        \
-  {register int m;                                              \
+  {int m;                                                       \
     if (set != 0)                                               \
       {                                                         \
         bit = 31;                                               \

--- a/src/fingerprint.cpp
+++ b/src/fingerprint.cpp
@@ -146,9 +146,9 @@ namespace OpenBabel
     unsigned int words = _index.header.words;
     unsigned int* nextp = &_index.fptdata[0];
     unsigned int* ppat0 = &vecwords[0];
-    register unsigned int* p;
-    register unsigned int* ppat;
-    register unsigned int a;
+    unsigned int* p;
+    unsigned int* ppat;
+    unsigned int a;
     unsigned int i; 
     for(i=0;i<dataSize; ++i) //speed critical section
       {
@@ -197,8 +197,8 @@ namespace OpenBabel
   unsigned int words = _index.header.words;
   unsigned int* nextp = &_index.fptdata[0]; // start of next FP in index
   unsigned int* ppat0 = &vecwords[0];       // start of target FP
-  register unsigned int* p;                 // current position in index
-  register unsigned int* ppat;              // current position in target FP
+  unsigned int* p;                          // current position in index
+  unsigned int* ppat;                       // current position in target FP
   unsigned int i; // need address of this, can't be register
   for(i=0;i<dataSize; ++i) //speed critical section
   {
@@ -234,8 +234,8 @@ namespace OpenBabel
     unsigned int words = _index.header.words;
     unsigned int dataSize = _index.header.nEntries;
     unsigned int* nextp = &_index.fptdata[0];
-    register unsigned int* p;
-    register unsigned int i;
+    unsigned int* p;
+    unsigned int i;
     for(i=0;i<dataSize; ++i) //speed critical section
       {
         p=nextp;
@@ -269,8 +269,8 @@ namespace OpenBabel
     unsigned int words = _index.header.words;
     unsigned int dataSize = _index.header.nEntries;
     unsigned int* nextp = &_index.fptdata[0];
-    register unsigned int* p;
-    register unsigned int i;
+    unsigned int* p;
+    unsigned int i;
     for(i=0;i<dataSize; ++i) //speed critical section
       {
         p=nextp;

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -93,7 +93,7 @@ namespace OpenBabel
     FOR_BONDS_OF_ATOM(bond, atom) {
       if (bond->IsAromatic()) continue;
       OBAtom *nbr = bond->GetNbrAtom(atom);
-      switch (bond->GetBondOrder()) {
+      switch ((int) bond->GetBondOrder()) {
       case -1: case 0: case 1:
         continue;
       case 2:

--- a/src/math/matrix3x3.cpp
+++ b/src/math/matrix3x3.cpp
@@ -563,7 +563,7 @@ namespace OpenBabel
     double onorm, dnorm;
     double b, dma, q, t, c, s;
     double  atemp, vtemp, dtemp;
-    register int i, j, k, l;
+    int i, j, k, l;
     int nrot;
 
     int MAX_SWEEPS=50;

--- a/src/obutil.cpp
+++ b/src/obutil.cpp
@@ -680,7 +680,7 @@ namespace OpenBabel
 
   void qtrfit (double *r,double *f,int size, double u[3][3])
   {
-    register int i;
+    int i;
     double xxyx, xxyy, xxyz;
     double xyyx, xyyy, xyyz;
     double xzyx, xzyy, xzyz;
@@ -793,7 +793,7 @@ namespace OpenBabel
    */
   int SolveQuadratic(double A,double B,double C)
   {
-    register double Descr, Temp, TwoA;
+    double Descr, Temp, TwoA;
 
     if( IsZero(A) )
       return( SolveLinear(B,C) );
@@ -838,9 +838,9 @@ namespace OpenBabel
 
   int SolveCubic(double A,double B,double C,double D)
   {
-    register double TwoA, ThreeA, BOver3A;
-    register double Temp, POver3, QOver2;
-    register double Desc, Rho, Psi;
+    double TwoA, ThreeA, BOver3A;
+    double Temp, POver3, QOver2;
+    double Desc, Rho, Psi;
 
 
     if( IsZero(A) )

--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -178,7 +178,7 @@ namespace OpenBabel
 
   static AtomExpr *CopyAtomExpr( AtomExpr *expr )
   {
-    register AtomExpr *result;
+    AtomExpr *result;
 
     result = new AtomExpr;
     result->type = expr->type;
@@ -234,7 +234,7 @@ namespace OpenBabel
 
   static AtomExpr *BuildAtomPred( int type )
   {
-    register AtomExpr *result;
+    AtomExpr *result;
 
     result = new AtomExpr;
     result->leaf.type = type;
@@ -244,7 +244,7 @@ namespace OpenBabel
 
   static AtomExpr *BuildAtomLeaf( int type, int val )
   {
-    register AtomExpr *result;
+    AtomExpr *result;
 
     result = new AtomExpr;
     result->leaf.type = type;
@@ -254,7 +254,7 @@ namespace OpenBabel
 
   static AtomExpr *BuildAtomNot( AtomExpr *expr )
   {
-    register AtomExpr *result;
+    AtomExpr *result;
 
     result = new AtomExpr;
     result->mon.type = AE_NOT;
@@ -264,7 +264,7 @@ namespace OpenBabel
 
   static AtomExpr *BuildAtomBin( int op, AtomExpr *lft, AtomExpr *rgt )
   {
-    register AtomExpr *result;
+    AtomExpr *result;
 
     result = new AtomExpr;
     result->bin.type = op;
@@ -275,7 +275,7 @@ namespace OpenBabel
 
   static AtomExpr *BuildAtomRecurs( Pattern *pat )
   {
-    register AtomExpr *result;
+    AtomExpr *result;
 
     result = new AtomExpr;
     result->recur.type = AE_RECUR;
@@ -305,7 +305,7 @@ namespace OpenBabel
 
   static BondExpr *CopyBondExpr( BondExpr *expr )
   {
-    register BondExpr *result;
+    BondExpr *result;
 
     result = new BondExpr;
     result->type = expr->type;
@@ -388,7 +388,7 @@ namespace OpenBabel
 
   static BondExpr *BuildBondLeaf( int type )
   {
-    register BondExpr *result;
+    BondExpr *result;
 
     result = new BondExpr;
     result->type = type;
@@ -397,7 +397,7 @@ namespace OpenBabel
 
   static BondExpr *BuildBondNot( BondExpr *expr )
   {
-    register BondExpr *result;
+    BondExpr *result;
 
     result = new BondExpr;
     result->mon.type = BE_NOT;
@@ -407,7 +407,7 @@ namespace OpenBabel
 
   static BondExpr *BuildBondBin( int op, BondExpr *lft, BondExpr *rgt )
   {
-    register BondExpr *result;
+    BondExpr *result;
 
     result = new BondExpr;
     result->bin.type = op;
@@ -647,8 +647,8 @@ namespace OpenBabel
 
   AtomExpr *OBSmartsPattern::ParseComplexAtomPrimitive( void )
   {
-    register Pattern *pat;
-    register int index;
+    Pattern *pat;
+    int index;
 
     switch( *LexPtr++ )
       {
@@ -1167,9 +1167,9 @@ namespace OpenBabel
 
   AtomExpr *OBSmartsPattern::ParseAtomExpr( int level )
   {
-    register AtomExpr *expr1 = NULL;
-    register AtomExpr *expr2 = NULL;
-    register char *prev;
+    AtomExpr *expr1 = NULL;
+    AtomExpr *expr2 = NULL;
+    char *prev;
 
     switch( level )
       {
@@ -1267,9 +1267,9 @@ namespace OpenBabel
 
   BondExpr *OBSmartsPattern::ParseBondExpr( int level )
   {
-    register BondExpr *expr1 = NULL;
-    register BondExpr *expr2 = NULL;
-    register char *prev;
+    BondExpr *expr1 = NULL;
+    BondExpr *expr2 = NULL;
+    char *prev;
 
     switch( level )
       {
@@ -1368,9 +1368,9 @@ namespace OpenBabel
                                 int prev, int part )
   {
     int vb = 0;
-    register AtomExpr *aexpr;
-    register BondExpr *bexpr;
-    register int index;
+    AtomExpr *aexpr;
+    BondExpr *bexpr;
+    int index;
 
     bexpr = (BondExpr*)0;
 
@@ -1683,7 +1683,7 @@ namespace OpenBabel
 
   Pattern *OBSmartsPattern::ParseSMARTSString( char *ptr )
   {
-    register Pattern *result;
+    Pattern *result;
 
     if( !ptr || !*ptr )
       return (Pattern*)0;
@@ -1697,7 +1697,7 @@ namespace OpenBabel
 
   Pattern *OBSmartsPattern::ParseSMARTSRecord( char *ptr )
   {
-    register char *src;
+    char *src;
 
     src = ptr;
     while( *src && !isspace(*src) )
@@ -1719,7 +1719,7 @@ namespace OpenBabel
 
   static AtomExpr *NotAtomExpr( AtomExpr *expr )
   {
-    register AtomExpr *result;
+    AtomExpr *result;
 
     switch (expr->type)
       {

--- a/src/rand.cpp
+++ b/src/rand.cpp
@@ -93,9 +93,9 @@ namespace OpenBabel
 
   static unsigned int isqrt( unsigned int val )
   {
-    register unsigned int temp;
-    register unsigned int rem;
-    register int i,result;
+    unsigned int temp;
+    unsigned int rem;
+    int i,result;
 
     i = 16;
     while( !(val&((unsigned int)3<<30)) && i )
@@ -133,8 +133,8 @@ namespace OpenBabel
 
   static int IsOddPrime( unsigned int x )
   {
-    register unsigned int root;
-    register unsigned int i;
+    unsigned int root;
+    unsigned int i;
 
     root = isqrt(x);
     for( i=2; i<MAXPRIMES-1; i++ )
@@ -201,9 +201,9 @@ namespace OpenBabel
 
   void DoubleMultiply( unsigned int x, unsigned int y, DoubleType *z )
   {
-    register unsigned int x0, x1, x2, x3;
-    register unsigned int hx, lx;
-    register unsigned int hy, ly;
+    unsigned int x0, x1, x2, x3;
+    unsigned int hx, lx;
+    unsigned int hy, ly;
 
     hx = HiPart(x);
     lx = LoPart(x);
@@ -256,9 +256,9 @@ namespace OpenBabel
 
   unsigned int DoubleModulus( DoubleType *n,  unsigned int d )
   {
-    register unsigned int d1, d0;
-    register unsigned int r1, r0;
-    register unsigned int m,s;
+    unsigned int d1, d0;
+    unsigned int r1, r0;
+    unsigned int m,s;
 
     s = LeadingZeros(d);
     if( s > 0 )
@@ -297,9 +297,9 @@ namespace OpenBabel
   static int DeterminePotency( unsigned int m, unsigned int a )
   {
     DoubleType d;
-    register unsigned int k;
-    register unsigned int b;
-    register int s;
+    unsigned int k;
+    unsigned int b;
+    int s;
 
     b = a-1;
     k = b;
@@ -315,9 +315,9 @@ namespace OpenBabel
 
   static int DetermineFactors( unsigned int x, unsigned int *factors )
   {
-    register unsigned int *ptr;
-    register unsigned int half;
-    register unsigned int i;
+    unsigned int *ptr;
+    unsigned int half;
+    unsigned int i;
 
     half = x/2;
     ptr = factors;
@@ -337,9 +337,9 @@ namespace OpenBabel
 
   static unsigned int DetermineIncrement( unsigned int m )
   {
-    register unsigned int hi,lo;
-    register unsigned int half;
-    register unsigned int i;
+    unsigned int hi,lo;
+    unsigned int half;
+    unsigned int i;
 
     /* 1/2 + sqrt(3)/6 */
     hi = (int)floor(0.7886751345948*m+0.5);
@@ -371,12 +371,12 @@ namespace OpenBabel
                          unsigned int *pc )
   {
     unsigned int fact[MAXFACT];
-    register unsigned int a=0, c;
-    register unsigned int b;
-    register int pot,best;
-    register int count;
-    register int flag;
-    register int i;
+    unsigned int a=0, c;
+    unsigned int b;
+    int pot,best;
+    int count;
+    int flag;
+    int i;
 
     do
       {
@@ -428,8 +428,8 @@ namespace OpenBabel
   void GenerateSequence( unsigned int p, unsigned int m,
                          unsigned int a, unsigned int c )
   {
-    register unsigned int i;
-    register unsigned int x;
+    unsigned int i;
+    unsigned int x;
     DoubleType d;
 
     x = 0;  /* seed */


### PR DESCRIPTION
Fixes issues preventing compilation with C++17 standard.

Two changes are made: register keywords are removed
and an implicit cast in a switch is made explicit.