### PR TITLE
Handle undervalent atoms and radicals in Mol files and Smiles

### DIFF
--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -1124,7 +1124,8 @@ namespace OpenBabel
         int impval = MDLValence(atom->GetAtomicNum(), atom->GetFormalCharge(), expval);
         int actual_impval = expval + atom->GetImplicitHCount();
         int valence;
-        if (!alwaysSpecifyValence && actual_impval == impval)
+        int spin = atom->GetSpinMultiplicity(); // the spin condition below is used for "M  RAD"
+        if (!alwaysSpecifyValence && actual_impval == impval && (spin == 0 || spin >= 4))
           valence = 0;
         else
           valence = actual_impval == 0 ? 15 : actual_impval;

--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -790,7 +790,7 @@ namespace OpenBabel
           }
         }
         else {
-          impval = MDLValence(elem, charge, expval) - expval;
+          impval = MDLValence(elem, charge, expval);
           // adjust for M RAD
           int mult = atom->GetSpinMultiplicity();
           int delta;
@@ -806,8 +806,8 @@ namespace OpenBabel
           }
           impval -= delta;
         }
-        int nimpval = impval - expval;
-        atom->SetImplicitHCount(nimpval > 0 ? nimpval : 0);
+        int numH = impval - expval;
+        atom->SetImplicitHCount(numH > 0 ? numH : 0);
       }
     }
 

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -129,14 +129,33 @@ class TestSuite(PythonBindings):
 
 class Radicals(PythonBindings):
     def testSmilesToMol(self):
-        smis = ["C", "[CH3]", "[CH2]", "[CH2]C"]
-        valences = [0, 3, 2, 3]
+        smis = ["C", "[CH3]", "[CH2]", "[CH2]C", "[C]"]
+        valences = [0, 3, 2, 3, 15]
+        # Note to self: why is this loop so slow? 2.8s for this test!
         for smi, valence in zip(smis, valences):
             mol = pybel.readstring("smi", smi)
             molfile = mol.write("mol")
             firstcarbon = molfile.split("\n")[4]
             mvalence = int(firstcarbon[48:53])
             self.assertEqual(valence, mvalence)
+            # test molfile->smiles
+            msmi = pybel.readstring("mol", molfile).write("smi").rstrip()
+            self.assertEqual(smi, msmi)
+    def testMolfileInvalidValencyToSmiles(self):
+        """Should trigger warning about invalid valency field
+        Unfortunately - there's no way to test this from Python as it requires
+        streams :-/"""
+        molfile = """
+ OpenBabel07291719012D
+
+  2  1  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0 15  0  0  0  0  0  0
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  4  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+M  END
+"""
+        mol = pybel.readstring("mol", molfile)
+        self.assertEqual("[C]C", mol.write("smi").rstrip())
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -127,5 +127,16 @@ class TestSuite(PythonBindings):
 
         self.assertTrue(N > 100)
 
+class Radicals(PythonBindings):
+    def testSmilesToMol(self):
+        smis = ["C", "[CH3]", "[CH2]", "[CH2]C"]
+        valences = [0, 3, 2, 3]
+        for smi, valence in zip(smis, valences):
+            mol = pybel.readstring("smi", smi)
+            molfile = mol.write("mol")
+            firstcarbon = molfile.split("\n")[4]
+            mvalence = int(firstcarbon[48:53])
+            self.assertEqual(valence, mvalence)
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -169,6 +169,17 @@ M  END
 """
         mol = pybel.readstring("mol", molfile)
         self.assertEqual("[C]C", mol.write("smi").rstrip())
+    def testSettingSpinMult(self):
+        """Set spin and read/write it"""
+        mol = pybel.readstring("smi", "C")
+        mol.atoms[0].OBAtom.SetSpinMultiplicity(2)
+        molfile = mol.write("mol")
+        self.assertEqual("M  RAD  1   1   2", molfile.split("\n")[5])
+        molb = pybel.readstring("mol", molfile)
+        self.assertEqual(2, molb.atoms[0].OBAtom.GetSpinMultiplicity())
+        self.assertEqual(4, molb.atoms[0].OBAtom.GetImplicitHCount())
+        
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -144,7 +144,6 @@ class Radicals(PythonBindings):
     def testSmilesToMol(self):
         smis = ["C", "[CH3]", "[CH2]", "[CH2]C", "[C]"]
         valences = [0, 3, 2, 3, 15]
-        # Note to self: why is this loop so slow? 2.8s for this test!
         for smi, valence in zip(smis, valences):
             mol = pybel.readstring("smi", smi)
             molfile = mol.write("mol")
@@ -178,8 +177,6 @@ M  END
         molb = pybel.readstring("mol", molfile)
         self.assertEqual(2, molb.atoms[0].OBAtom.GetSpinMultiplicity())
         self.assertEqual(4, molb.atoms[0].OBAtom.GetImplicitHCount())
-        
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a follow-on from the work on implicit hydrogens. In the end no changes were made to the data structures used to store information, but the handling of the existing file formats has been tweaked.

Storing undervalent atoms in MOL files now uses the valence field, rather than M RAD. M RAD is only used if a spin has been specified.

Now reading undervalent atoms from SMILES does not set the spin (it did previously). For depiction, changes were needed to ensure that radical dots were depicted in the same situations as before (by testing for either spin or undervalence).