### PR TITLE
For SIESTA format, use obErrorLog instead of cerr

### DIFF
--- a/src/formats/siestaformat.cpp
+++ b/src/formats/siestaformat.cpp
@@ -77,6 +77,8 @@ namespace OpenBabel {
     //Define some references so we can use the old parameter names
     istream &ifs = *pConv->GetInStream();
 
+    std::stringstream errorMsg;
+
     bool struct_out_found = false;
     bool coordsAreFractional = false;
     bool coordsAreAngstrom = false;
@@ -99,8 +101,9 @@ namespace OpenBabel {
     // for atomic positions and cell coordinates.
     string filePath = pConv->GetInFilename();
     if (filePath.empty()) {
-      cerr << "Invalid path specified for siesta output file.\n";
       delete cell;
+      errorMsg << "Invalid path specified for siesta output file.\n";
+      obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
       return false;
     }
 
@@ -133,9 +136,11 @@ namespace OpenBabel {
     // If these failed, we'll just look for the coordinates in the .out file
     // Send a message to the user if the .STRUCT_OUT was not found
     if (!struct_out_found) {
-      cerr << "Could not find " << fileName
-           << ".STRUCT_OUT\nAttempting to read " << "coordinates from "
-           << fileName << ".out " << "instead.\n";
+      errorMsg << "Could not find " << fileName
+               << ".STRUCT_OUT\nAttempting to read " << "coordinates from "
+               << fileName << ".out " << "instead.\n";
+      obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
+      errorMsg.clear();
     }
 
     // Read the .STRUCT_OUT file if it was found
@@ -191,9 +196,10 @@ namespace OpenBabel {
         atomsIterated++;
       }
       if (atomsIterated != numAtoms) {
-        cerr << "Error reading the .STRUCT_OUT file. Make sure it was " <<
-                "saved correctly\n";
         delete cell;
+        errorMsg << "Error reading the .STRUCT_OUT file. Make sure it was "
+                 << "saved correctly\n";
+        obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
         return false;
       }
     } // Done reading .STRUCT_OUT !
@@ -251,8 +257,9 @@ namespace OpenBabel {
           it = atomTypeLabels.find(atoi(vs.at(3).c_str()));
           // Just a basic find() error check
           if(it == atomTypeLabels.end()) {
-             cerr << "Error reading AtomicSpecies\n";
              delete cell;
+             errorMsg << "Error reading AtomicSpecies\n";
+             obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
              pmol->EndModify();
              return false;
           }
@@ -377,9 +384,10 @@ namespace OpenBabel {
     }
 
     if (!EOFReached) {
-      cerr << "Error! The EOF for siesta was not reached. Check the file " <<
-              "to see if it was saved properly.\n";
       delete cell;
+      errorMsg << "Error! The EOF for siesta was not reached. Check the file "
+               << "to see if it was saved properly.\n";
+      obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
       pmol->EndModify();
       return false;
     }


### PR DESCRIPTION
This is in response to #1623