### PR TITLE
Remove erroneous -1 in switch statement

### DIFF
--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -93,8 +93,8 @@ namespace OpenBabel
     FOR_BONDS_OF_ATOM(bond, atom) {
       if (bond->IsAromatic()) continue;
       OBAtom *nbr = bond->GetNbrAtom(atom);
-      switch ((int) bond->GetBondOrder()) {
-      case -1: case 0: case 1:
+      switch (bond->GetBondOrder()) {
+      case 0: case 1:
         continue;
       case 2:
         if (IsSpecialCase(atom, nbr))


### PR DESCRIPTION
This is to a tweak to #1619 where the problem was in my kekulize code. The "-1" causing the problem has been removed, as it wasn't correct - it could never be -1.