### PR TITLE
Make sure to handle molecular total charge by default for keywords

### DIFF
--- a/src/formats/mopacformat.cpp
+++ b/src/formats/mopacformat.cpp
@@ -771,9 +771,7 @@ namespace OpenBabel
     string defaultKeywords = "PUT KEYWORDS HERE";
 
     if(keywords)
-      {
-        defaultKeywords = keywords;
-      }
+      defaultKeywords = keywords;
 
     if (keywordFile)
       {
@@ -785,8 +783,14 @@ namespace OpenBabel
               ofs << keyBuffer << endl;
           }
       }
-    else
-      ofs << defaultKeywords << endl;
+    else {
+      ofs << defaultKeywords;
+      if (mol.GetTotalCharge() != 0)
+        ofs << " CHARGE=" << mol.GetTotalCharge();
+      
+      // should handle GetTotalSpinMultiplicity() too
+      ofs << endl;
+    }
 
     ofs << mol.GetTitle() << endl;
     ofs << endl; // comment


### PR DESCRIPTION
If the OBMol has a total charge, make sure that's passed along to the keywords line by default.

Improves batch processing files (e.g., singlet cations and anions).