### PR TITLE
Allow multiple agents in OBReaction

### DIFF
--- a/include/openbabel/reaction.h
+++ b/include/openbabel/reaction.h
@@ -38,6 +38,7 @@ class OBReaction : public OBBase
 private:
   std::vector<obsharedptr<OBMol> > _reactants;
   std::vector<obsharedptr<OBMol> > _products;
+  std::vector<obsharedptr<OBMol> > _agents;
   obsharedptr<OBMol> _ts;
   obsharedptr<OBMol> _agent;
   std::string _title;
@@ -53,6 +54,11 @@ public:
   int NumProducts()const
   { return static_cast<int> (_products.size()); }
 
+  int NumAgents() const
+  {
+    return static_cast<int> (_agents.size());
+  }
+
   void AddReactant(const obsharedptr<OBMol> sp)
   { _reactants.push_back(sp); }
 
@@ -63,7 +69,7 @@ public:
   { _ts = sp; }
 
   void AddAgent(const obsharedptr<OBMol> sp)
-  { _agent = sp; }
+  { _agents.push_back(sp); }
 
   obsharedptr<OBMol> GetReactant(const unsigned i)
   {
@@ -79,12 +85,16 @@ public:
       sp = _products[i];
     return sp; //returns empty if out of range
   }
+  obsharedptr<OBMol> GetAgent(const unsigned i)
+  {
+    obsharedptr<OBMol> sp;
+    if (i<_agents.size())
+      sp = _agents[i];
+    return sp; //returns empty if out of range
+  }
 
   obsharedptr<OBMol> GetTransitionState()const
   { return _ts; }
-
-  obsharedptr<OBMol> GetAgent()const
-  { return _agent; }
 
   std::string GetTitle()	const { return _title; }
   std::string GetComment()	const { return _comment; }
@@ -103,6 +113,7 @@ public:
   {
     _reactants.clear();
     _products.clear();
+    _agents.clear();
     _ts.reset();
     _agent.reset();
     _title.clear();

--- a/include/openbabel/reaction.h
+++ b/include/openbabel/reaction.h
@@ -40,7 +40,6 @@ private:
   std::vector<obsharedptr<OBMol> > _products;
   std::vector<obsharedptr<OBMol> > _agents;
   obsharedptr<OBMol> _ts;
-  obsharedptr<OBMol> _agent;
   std::string _title;
   std::string _comment;
   bool _reversible;
@@ -115,7 +114,6 @@ public:
     _products.clear();
     _agents.clear();
     _ts.reset();
-    _agent.reset();
     _title.clear();
     _comment.clear();
     _reversible = false;

--- a/src/formats/rsmiformat.cpp
+++ b/src/formats/rsmiformat.cpp
@@ -247,10 +247,12 @@ namespace OpenBabel
 
     ofs << '>';
 
-    obsharedptr<OBMol> spAgent = pReact->GetAgent();
-    if(spAgent.get())
-      if(!pSmiFormat->WriteMolecule(spAgent.get(), pConv))
-        return false;
+    OBMol jAgents;
+    for (int i = 0; i<pReact->NumAgents(); ++i)
+      jAgents += *(pReact->GetAgent(i));
+
+    if(!pSmiFormat->WriteMolecule(&jAgents, pConv))
+      return false;
 
     ofs << '>';
 

--- a/src/obmolecformat.cpp
+++ b/src/obmolecformat.cpp
@@ -445,9 +445,9 @@ namespace OpenBabel
       mols.push_back(pReact->GetReactant(i));
     for(i=0;i<pReact->NumProducts();i++)
       mols.push_back(pReact->GetProduct(i));
+    for (i = 0; i<pReact->NumAgents(); i++)
+      mols.push_back(pReact->GetAgent(i));
 
-    if(pReact->GetAgent())
-      mols.push_back(pReact->GetAgent());
     if(pReact->GetTransitionState())
       mols.push_back(pReact->GetTransitionState());
 


### PR DESCRIPTION
Add support for multiple agents in OBReaction. This opens the way for implementing RInChI, for example.