### PR TITLE
ECFP Fixup

### DIFF
--- a/src/fingerprints/fingerecfp.cpp
+++ b/src/fingerprints/fingerecfp.cpp
@@ -33,9 +33,13 @@ public:
       _radius(radius), _keepdups(keepdups), _flags(0){};
 
 	virtual const char* Description()
-	{ return "Extended-Connectivity Fingerprints (ECFPs)\n"
-      "Circular topological fingerprints of specified radius\n"
-  ;}
+	{ 
+          // Important! The second line is used by some output formats (e.g. FPS)
+	  // to determine the default size
+	  return "Extended-Connectivity Fingerprints (ECFPs)\n"
+                 "4096 bits.\n"
+                 "Circular topological fingerprints of specified radius\n";
+	}
 
 	//Calculates the fingerprint
 	virtual bool GetFingerprint(OBBase* pOb, vector<unsigned int>&fp, int nbits=0);
@@ -234,6 +238,11 @@ bool fingerprintECFP::GetFingerprint(OBBase* pOb, vector<unsigned int>&fp, int n
 {
 	OBMol* pmol = dynamic_cast<OBMol*>(pOb);
 	if(!pmol) return false;
+	
+	// default fingeprint size
+	if (nbits <= 0)
+	  nbits = 4096;
+
 	fp.resize(nbits/Getbitsperint());
 	
   _ss.str("");


### PR DESCRIPTION
a) The ECFP implementation was expecting the ``std::vector<int>`` to be treated as a list of hashes whilst the callers were expected it to be a bit set. Whilst return the raw hash values is useful it would require a new API point.
b) Resolves #1651

With these changes the fingerprint scores 76.2% on the Briem Lessel benchmark. 

Also looks like the ``Fold()`` function is doing the wrong thing elsewhere too. For example if I generate MACCS keys...
```
0000000000021000014416cf1be5b083ad2fef7f1f	204
0004200000000021418004afa160b00910a1e46a1b	205
8004040000100200000816cf8d69b847856dfefb19	206
000000002000002141d034e82b61b08b01230d2d1f	207
00000000204000840194b1091b73b3e781eb2fff1f	208
```
and then fold them to say 256 bits... one would expect the output to be padded with trailing zeros
```
000000000000300001d204de90699425843952fe1f0000000000000000000000	173
801480800d580b84e5fc9ded3773d16fd6efeb7f1f0000000000000000000000	174
000000040000000000000006800c2e84290404d6080000000000000000000000	175
0000000000000000810002401b510165546fc3ff1f0000000000000000000000	176
000000002000002001d0169e9b61b16340e3cdfb1f0000000000000000000000	177
0000000000400084015085871013a7e58deff7df1f0000000000000000000000	178
```
good... but now 512...
```
000004000001002001c4301e9b61bd43cce17deb1f00000000000000000000007373000000000000510000000000000000000000000000000900000006000000	17
0000000000000001038002461a81a18149a1c5391f00000000000000000000007373000000000000510000000000000024000000000000002400000000000000	18
0000000000002000800230510000016604dcbafa1f00000000000000000000007373000000000000b10000000000000090460828177f00000000000000000000	19
0000000000000000004434c80960b1e38963afff1f00000000000000000000007373000000000000210000000000000090be6d000000000098be6d0000000000	20
000000002000102181d41ecf133192635c6feafd1f00000000000000000000007373000000000000f10100000000000058f86d000000000008fc6e0000000000	21
0000800008108364600cb1703f59ecafdbbb7fff1f0000000000000000000000737300000000000021000000000000000f000000000000009cbe6d0000000000	22
000000002000380011d00caa9361b6095c2154ae1f000000000000000000000073730000000000007100000000000000204e6d0000000000a0686e0000000000	23
```
I think this is just a missing ``memset(0)`` but thought I should point it out.

