### PR TITLE
Allow RSMI format to read partial reactions

### DIFF
--- a/src/formats/rsmiformat.cpp
+++ b/src/formats/rsmiformat.cpp
@@ -115,6 +115,17 @@ namespace OpenBabel
   //Make an instance of the format class
   SmiReactFormat theSmiReactFormat;
 
+  static bool IsNotEndChar(char t)
+  {
+    switch (t) {
+    case '\0':
+    case '\t':
+    case ' ':
+      return false;
+    }
+    return true;
+  }
+
   /////////////////////////////////////////////////////////////////
   bool SmiReactFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
   {
@@ -174,7 +185,7 @@ namespace OpenBabel
     //Extract reactants and split into individual molecules
     OBMol jreactants;
     s = rsmiles.substr(0,pos);
-    if(!sconv.ReadString(&jreactants, s))
+    if(pos > 0 && !sconv.ReadString(&jreactants, s))
     {
       obErrorLog.ThrowError(__FUNCTION__, "Cannot read reactant", obError);
       return false;
@@ -207,7 +218,7 @@ namespace OpenBabel
     //Extract products and split into separate molecules
     OBMol jproducts;
     s = rsmiles.substr(pos2+1);
-    if(!sconv.ReadString(&jproducts, s))
+    if(IsNotEndChar(s[0]) && !sconv.ReadString(&jproducts, s))
     {
       obErrorLog.ThrowError(__FUNCTION__, "Cannot read product", obError);
       return false;

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -102,13 +102,56 @@ class BaseTest(unittest.TestCase):
                          "Number of molecules converted is %d "
                          "but should be %d" % (conversion_no, N))        
 
-class testBabel(BaseTest):
-    """A series of tests relating to the Babel executable"""
+class testOBabel(BaseTest):
+    """A series of tests relating to the obabel executable"""
         
     def testSMItoInChI(self):
-        self.canFindExecutable("babel")
-        output, error = run_exec("CC(=O)Cl", "babel -ismi -oinchi")
+        self.canFindExecutable("obabel")
+        output, error = run_exec("CC(=O)Cl", "obabel -ismi -oinchi")
         self.assertEqual(output.rstrip(), "InChI=1S/C2H3ClO/c1-2(3)4/h1H3")
+
+    def testRSMItoRSMI(self):
+        # Check possible combinations of missing rxn components
+        data = ["O>N>S", "O>>S", "O>N>", "O>>",
+                ">N>S", ">>S", ">>"]
+        for rsmi in data:
+            output, error = run_exec('obabel -:%s -irsmi -orsmi' % rsmi)
+            self.assertEqual(output.rstrip(), rsmi)
+        # Check handling of invalid rxn components
+        data = ["Noel>N>S", "O>Noel>S", "O>N>Noel"]
+        errors = ["reactant", "agent", "product"]
+        for rsmi, error in zip(data, errors):
+            output, errormsg = run_exec('obabel -:%s -irsmi -orsmi' % rsmi)
+            self.assertTrue(error in errormsg)
+
+    def sort(self, rsmi):
+        # TODO: Change OBMol.Separate to preserve the order. This
+        # function shouldn't be necessary.
+        tmp = rsmi.split(">")
+        r = ".".join(sorted(tmp[0].split(".")))
+        p = ".".join(sorted(tmp[2].split(".")))
+        return "%s>%s>%s" % (r, tmp[1], p)
+
+    def testRoundtripThroughRXN(self):
+        self.canFindExecutable("obabel")
+        data = ["C>N>O", "C>>O", "C.N>>O", "C>>O.N"]
+        # TODO - when partial reaction support is merged:
+        # ["C>>O", ">>O", "C>>", ">N>", ">>"]
+        for rsmi in data:
+            output, error = run_exec("obabel -irsmi -:%s -orxn" % rsmi)
+            moutput, error = run_exec(output, "obabel -irxn -orsmi")
+            self.assertEqual(self.sort(moutput.rstrip()), self.sort(rsmi))
+        rsmi = "C>N>O"
+        ans = {"agent": "C>N>O",
+               "reactant": "C.N>>O",
+               "product": "C>>O.N",
+               "both": "C.N>>O.N",
+               "ignore": "C>>O"}
+        for option, result in ans.iteritems():
+            output, error = run_exec("obabel -irsmi -:%s -orxn -xG %s" %
+                                     (rsmi, option))
+            moutput, error = run_exec(output, "obabel -irxn -orsmi")
+            self.assertEqual(self.sort(moutput.rstrip()), self.sort(result))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -110,34 +110,5 @@ class testBabel(BaseTest):
         output, error = run_exec("CC(=O)Cl", "babel -ismi -oinchi")
         self.assertEqual(output.rstrip(), "InChI=1S/C2H3ClO/c1-2(3)4/h1H3")
 
-    def sort(self, rsmi):
-        # TODO: Change OBMol.Separate to preserve the order. This
-        # function shouldn't be necessary.
-        tmp = rsmi.split(">")
-        r = ".".join(sorted(tmp[0].split(".")))
-        p = ".".join(sorted(tmp[2].split(".")))
-        return "%s>%s>%s" % (r, tmp[1], p)
-
-    def testRoundtripThroughRXN(self):
-        self.canFindExecutable("obabel")
-        data = ["C>N>O", "C>>O", "C.N>>O", "C>>O.N"]
-        # TODO - when partial reaction support is merged:
-        # ["C>>O", ">>O", "C>>", ">N>", ">>"]
-        for rsmi in data:
-            output, error = run_exec("obabel -irsmi -:%s -orxn" % rsmi)
-            moutput, error = run_exec(output, "obabel -irxn -orsmi")
-            self.assertEqual(self.sort(moutput.rstrip()), self.sort(rsmi))
-        rsmi = "C>N>O"
-        ans = {"agent": "C>N>O",
-               "reactant": "C.N>>O",
-               "product": "C>>O.N",
-               "both": "C.N>>O.N",
-               "ignore": "C>>O"}
-        for option, result in ans.iteritems():
-            output, error = run_exec("obabel -irsmi -:%s -orxn -xG %s" %
-                                     (rsmi, option))
-            moutput, error = run_exec(output, "obabel -irxn -orsmi")
-            self.assertEqual(self.sort(moutput.rstrip()), self.sort(result))
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It is perfectly valid in RSMI to be missing a reactant or product (or indeed both). I've added support for these so that the following are now read without any trouble:
```
>>N
O>>
>>
```
These are also written out exactly as above - no changes were made to make this happen. Test cases included.