### PR TITLE
Clarify python examples

### DIFF
--- a/scripts/python/Examples.html
+++ b/scripts/python/Examples.html
@@ -60,6 +60,7 @@ More commonly, Open Babel can be used to read in molecules using the OBConversio
 <pre>
 import openbabel
 
+mol = openbabel.OBMol()
 obConversion = openbabel.OBConversion()
 obConversion.SetInAndOutFormats("smi", "mdl")
 
@@ -82,6 +83,7 @@ The following script writes out a file using a filename, rather than reading and
 <pre>
 import openbabel
 
+mol = openbabel.OBMol()
 obConversion = openbabel.OBConversion()
 obConversion.SetInAndOutFormats("pdb", "mol2")
 


### PR DESCRIPTION
Clarified required use of OBMol object:
While running the code as given originally would work, the repeated `import openbabel` made it seem that the second and third examples would work independently when in fact they won't without defining `mol = openbabel.OBMol()`.