### PR TITLE
Fix reading atom symbols from XSF file

### DIFF
--- a/src/formats/xsfformat.cpp
+++ b/src/formats/xsfformat.cpp
@@ -81,6 +81,7 @@ namespace OpenBabel
     vector<string> vs;
     vector<vector3> atomPositions;
     bool createdAtoms = false;
+    int atomicNum;
 
     mol.BeginModify();
 
@@ -96,7 +97,11 @@ namespace OpenBabel
             if (!createdAtoms) {
               atom = mol.NewAtom();
               //set atomic number
-              atom->SetAtomicNum(atoi(vs[0].c_str()));
+              atomicNum = OBElements::GetAtomicNum(vs[0].c_str());
+              if (atomicNum == 0) {
+                atomicNum = atoi(vs[0].c_str());
+              }
+              atom->SetAtomicNum(atomicNum);
             }
             x = atof((char*)vs[1].c_str());
             y = atof((char*)vs[2].c_str());
@@ -137,7 +142,11 @@ namespace OpenBabel
             if (!createdAtoms) {
               atom = mol.NewAtom();
               //set atomic number
-              atom->SetAtomicNum(atoi(vs[0].c_str()));
+              atomicNum = OBElements::GetAtomicNum(vs[0].c_str());
+              if (atomicNum == 0) {
+                atomicNum = atoi(vs[0].c_str());
+              }
+              atom->SetAtomicNum(atomicNum);
             }
             x = atof((char*)vs[1].c_str());
             y = atof((char*)vs[2].c_str());

--- a/src/formats/xsfformat.cpp
+++ b/src/formats/xsfformat.cpp
@@ -90,7 +90,8 @@ namespace OpenBabel
         if (buffer[0] == '#')
           continue; // comment
         if (strstr(buffer, "ATOMS") != NULL) {
-          // Minimum of 4 columns -- atomic number, x, y, z (forces)
+          // Minimum of 4 columns -- AtNum, x, y, z (forces)
+          // where AtNum stands for atomic number (or symbol), while X Y Z are
           ifs.getline(buffer, BUFF_SIZE);
           tokenize(vs, buffer);
           while (vs.size() >= 4) {


### PR DESCRIPTION
This is from the [official definition of XSF format](http://www.xcrysden.org/doc/XSF.html#__toc__3):

> An entry for an atom looks like:
>  AtNum   X Y Z
> where AtNum stands for atomic number (or symbol), while X Y Z are
> Cartesian coordinates in ANGSTROMS units. Here is one example: # Please
> enter the commit message for your changes. Lines starting