### PR TITLE
Correct spelling of file name for Perl bindings

### DIFF
--- a/scripts/perl/MANIFEST
+++ b/scripts/perl/MANIFEST
@@ -4,7 +4,7 @@ MANIFEST				 This file (list of files in dist.)
 Makefile.PL				 MakeMaker build
 README					 General information, use, etc.
 OpenBabel.pm				 Perl interface to Open Babel
-openbabel_perl.cpp			 C++ extension for openbabel.pm
+openbabel-perl.cpp			 C++ extension for openbabel.pm
 examples/example.pl			 Examples of Chemistry::OpenBabel
 META.yml                                 Module meta-data (added by MakeMaker)
 inc/Devel/CheckLib.pm                    Utility to check for installed libs

--- a/scripts/perl/Makefile.PL
+++ b/scripts/perl/Makefile.PL
@@ -36,6 +36,6 @@ WriteMakefile(
     'LDFROM'    => $ldfrom,
     'CC'        => $CC,
     'LD'        => '$(CC)',
-    'INC'       => '-I../../include -I'.$cmakesrcdir.'/include',
+    'INC'       => '-I../../include -I../../build/include -I'.$cmakesrcdir.'/include',
     'OBJECT'    => 'openbabel-perl.o'
 );


### PR DESCRIPTION
The MANIFEST file has openbabel-perl.cpp spelled with
an underscore rather than a dash.  This causes a
confusing but otherwise harmless warning when running
`perl Makefile.PL`.