### PR TITLE
Expose obfunctions api through python bindings

### DIFF
--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -31,6 +31,7 @@
 
 #include <openbabel/ring.h>
 #include <openbabel/obconversion.h>
+#include <openbabel/obfunctions.h>
 #include <openbabel/oberror.h>
 #include <openbabel/plugin.h>
 #include <openbabel/fingerprint.h>
@@ -261,6 +262,7 @@ namespace std { class stringbuf {}; }
 %include <openbabel/oberror.h>
 %include <openbabel/format.h>
 %include <openbabel/obconversion.h>
+%include <openbabel/obfunctions.h>
 %include <openbabel/residue.h>
 %include <openbabel/internalcoord.h>
 %include <openbabel/atom.h>


### PR DESCRIPTION
A recent API change (#1576) broke FragIt (https://github.com/FragIt/fragit-main) which depended on the knowledge about implicit bonds. Now, #1576 did include new utility functions (obfunctions.h) but these functions were never exposed through the python API.

1. This PR exposes those functions hidden away in obfunctions.h so I can use them in FragIt

This PR does not add or remove anything in the API apart from exposing functionality in the API through the python-bindings but I am unsure whether I am required to add some form of test or other documentation?