### PR TITLE
Speed up the SMILES writer

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2806,13 +2806,11 @@ namespace OpenBabel {
                                           vector<unsigned int> &symmetry_classes,
                                           char *stereo)
   {
-    OBAtom *atom = node->GetAtom();
-    OBMol *mol = (OBMol*) atom->GetParent();
-
     // If not enough chiral neighbors were passed in, we're done
     if (chiral_neighbors.size() < 4)
       return false;
 
+    OBAtom *atom = node->GetAtom();
     OBTetrahedralStereo *ts = _stereoFacade->GetTetrahedralStereo(atom->GetId());
     // If atom is not a tetrahedral center, we're done
     if (!ts)
@@ -2868,16 +2866,13 @@ namespace OpenBabel {
                                            vector<unsigned int> &symmetry_classes,
                                            char *stereo)
   {
-    OBAtom *atom = node->GetAtom();
-    OBMol *mol = (OBMol*) atom->GetParent();
-
     // If no chiral neighbors were passed in, we're done
     if (chiral_neighbors.size() < 4)
       return false;
+    
+    OBAtom *atom = node->GetAtom();
 
-    // OBStereoFacade will run symmetry analysis & stereo perception if needed
-    OBStereoFacade stereoFacade(mol);
-    OBSquarePlanarStereo *sp = stereoFacade.GetSquarePlanarStereo(atom->GetId());
+    OBSquarePlanarStereo *sp = _stereoFacade->GetSquarePlanarStereo(atom->GetId());
     // If atom is not a square-planar center, we're done
     if (!sp)
       return false;

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2658,35 +2658,35 @@ namespace OpenBabel {
           for(externalBond = externalBonds->begin();externalBond != externalBonds->end();++externalBond) {
             if (externalBond->second.first == atom) {
               external = true;
-              strcpy(symbol,"&");
+              buffer += '&';
               OBBond *bond = externalBond->second.second;
               if (bond->IsUp()) {
                 if ( (bond->GetBeginAtom())->HasDoubleBond() ||
                      (bond->GetEndAtom())->HasDoubleBond() )
-                  strcat(symbol,"\\");
+                  buffer += '\\';
               }
               if (bond->IsDown()) {
                 if ( (bond->GetBeginAtom())->HasDoubleBond() ||
                      (bond->GetEndAtom())->HasDoubleBond() )
-                  strcat(symbol,"/");
+                  buffer += '/';
               }
               if (bond->GetBO() == 2 && !bond->IsAromatic()) // TODO: need to check for kekulesmi
-                strcat(symbol,"=");
+                buffer += '=';
               if (bond->GetBO() == 2 && bond->IsAromatic())
-                strcat(symbol,":");
+                buffer += ':';
               if (bond->GetBO() == 3)
-                strcat(symbol,"#");
+                buffer += '#';
               if (bond->GetBO() == 4)
-                strcat(symbol,"$");
-              sprintf(symbol+strlen(symbol),"%d",externalBond->first);
+                buffer += '$';
+              char tmp[10];
+              snprintf(tmp, 10, "%d", externalBond->first);
+              buffer += tmp;
               break;
             }
           }
 
         if(!external)
           buffer += '*';
-        else
-          buffer += symbol;
       }
 
       return true;

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2638,13 +2638,16 @@ namespace OpenBabel {
 
       // Ordinary non-bracket element
       if (element) {
-        strcpy(symbol,OBElements::GetSymbol(atom->GetAtomicNum()));
-        if (!kekulesmi && atom->IsAromatic())
-          symbol[0] = tolower(symbol[0]);
-
-        //Radical centres lc if r option set
-        if(atom->GetSpinMultiplicity() && _pconv && _pconv->IsOption ("r"))
-          symbol[0] = tolower(symbol[0]);
+        const char* symbol = OBElements::GetSymbol(atom->GetAtomicNum());
+        if ((!kekulesmi && atom->IsAromatic()) || // aromatic atom
+            (atom->GetSpinMultiplicity() && _pconv->IsOption("r"))) //Radical centres lowercase if r option set
+        {
+          buffer += symbol[0] + ('a' - 'A');
+          if (symbol[1])
+            buffer += symbol[1];
+        }
+        else
+          buffer += symbol;
       }
 
       // Atomic number zero - either '*' or an external atom
@@ -2684,11 +2687,12 @@ namespace OpenBabel {
           }
 
         if(!external)
-          strcpy(symbol,"*");
+          buffer += '*';
+        else
+          buffer += symbol;
       }
 
-      buffer += symbol;
-      return(true);
+      return true;
     }
 
     // Bracketed atoms, e.g. [Pb], [OH-], [C@]
@@ -2764,7 +2768,7 @@ namespace OpenBabel {
     if (strlen(bracketBuffer) > 1 || bracketElement) {
       buffer += '[';
       buffer += bracketBuffer;
-      buffer += '[';
+      buffer += ']';
     } else {
       buffer += bracketBuffer;
     }
@@ -2790,7 +2794,8 @@ namespace OpenBabel {
 
   bool OBMol2Cansmi::AtomIsChiral(OBAtom *atom)
   {
-    return _stereoFacade->HasTetrahedralStereo(atom->GetId()) || _stereoFacade->HasSquarePlanarStereo(atom->GetId());
+    unsigned long atomid = atom->GetId();
+    return _stereoFacade->HasTetrahedralStereo(atomid) || _stereoFacade->HasSquarePlanarStereo(atomid);
   }
 
   /***************************************************************************

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2696,13 +2696,13 @@ namespace OpenBabel {
     buffer += '[';
     unsigned short iso = atom->GetIsotope();
     if (isomeric && iso) {
-      if (iso >= 10000) { // max 4 characters
-        obErrorLog.ThrowError(__FUNCTION__, "Isotope value larger than 9999", obError);
-        return false;
+      if (iso >= 10000) // max 4 characters
+        obErrorLog.ThrowError(__FUNCTION__, "Isotope value larger than 9999. Ignoring value.", obWarning);
+      else {
+        char iso[5]; // 4 characters plus null
+        sprintf(iso, "%d", atom->GetIsotope());
+        buffer += iso;
       }
-      char iso[5]; // 4 characters plus null
-      sprintf(iso,"%d",atom->GetIsotope());
-      buffer += iso;
     }
     if (!atom->GetAtomicNum())
       buffer += '*';

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -120,7 +120,7 @@ class TestSuite(PythonBindings):
         self.assertRaises(IOError, pybel.readstring, "smi", "[11111C]")
         mol = pybel.readstring("smi", "[C]")
         mol.atoms[0].OBAtom.SetIsotope(65535)
-        self.assertEqual(mol.write("smi").rstrip(), "")
+        self.assertEqual(mol.write("smi").rstrip(), "[C]")
 
     def testWhetherAllElementsAreSupported(self):
         """Check whether a new element has been correctly added"""


### PR DESCRIPTION
This PR makes SMILES writing fast.

The main speedup was to avoid regenerating an OBStereoFacade each time we needed to look up a single atom. This was occurring in multiple places. Now a single OBStereoFacade is used for the molecule.

Also, I have removed all uses of strcpy, strlen and strcat.

There is some room for further speedups but I might move onto other stuff for now.