### PR TITLE
Faster SMILES: Replace std::endl by "\n"

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -4019,7 +4019,7 @@ namespace OpenBabel {
 
     // Title only option?
     if(pConv->IsOption("t")) {
-      ofs << pmol->GetTitle() <<endl;
+      ofs << pmol->GetTitle() << "\n";
       return true;
     }
 
@@ -4052,31 +4052,37 @@ namespace OpenBabel {
       CreateCansmiString(*pmol, buffer, fragatoms, !pConv->IsOption("i"), pConv->IsOption("k"), pConv);
     }
 
-    ofs << buffer;
     if(!pConv->IsOption("smilesonly")) {
 
-      if(!pConv->IsOption("n"))
-        ofs << '\t' <<  pmol->GetTitle();
+      if(!pConv->IsOption("n")) {
+        buffer += '\t';
+        buffer += pmol->GetTitle();
+      }
 
       if (pConv->IsOption("x") && pmol->HasData("SMILES Atom Order")) {
         vector<string> vs;
         string canorder = pmol->GetData("SMILES Atom Order")->GetValue();
         tokenize(vs, canorder);
-        ofs << '\t';
+        buffer += '\t';
+        char tmp[15];
         for (unsigned int i = 0; i < vs.size(); i++) {
           int idx = atoi(vs[i].c_str());
           OBAtom *atom = pmol->GetAtom(idx);
           if (i > 0)
-            ofs << ",";
-          ofs << atom->GetX() << "," << atom->GetY();
+            buffer += ',';
+          snprintf(tmp, 15, "%.4f", atom->GetX());
+          buffer += tmp;
+          buffer += ',';
+          snprintf(tmp, 15, "%.4f", atom->GetY());
+          buffer += tmp;
         }
       }
 
       if(!pConv->IsOption("nonewline"))
-        ofs << endl;
+        buffer += "\n";
     }
 
-    //cout << "end SMIBaseFromat::WriteMolecule()" << endl;
+    ofs << buffer;
     return true;
   }
 
@@ -4120,7 +4126,6 @@ namespace OpenBabel {
 
   bool FIXFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
   {
-    //cout << "FIXFromat::WriteMolecule()" << endl;
     OBMol* pmol = dynamic_cast<OBMol*>(pOb);
     if(pmol==NULL)
       return false;

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -3998,6 +3998,15 @@ namespace OpenBabel {
     return success;
   }
 
+  static const char* NewLine()
+  {
+#ifdef _WIN32
+    return "\r\n";
+#else
+    return "\n";
+#endif
+  }
+
   //////////////////////////////////////////////////
   bool SMIBaseFormat::WriteMolecule(OBBase* pOb,OBConversion* pConv)
   {
@@ -4011,7 +4020,7 @@ namespace OpenBabel {
     if (pConv->IsOption("I")) {
       bool success = GetInchifiedSMILESMolecule(pmol, false);
       if (!success) {
-        ofs << "\n";
+        ofs << NewLine();
         obErrorLog.ThrowError(__FUNCTION__, "Cannot generate Universal NSMILES for this molecule", obError);
         return false;
       }
@@ -4019,7 +4028,7 @@ namespace OpenBabel {
 
     // Title only option?
     if(pConv->IsOption("t")) {
-      ofs << pmol->GetTitle() << "\n";
+      ofs << pmol->GetTitle() << NewLine();
       return true;
     }
 
@@ -4052,6 +4061,7 @@ namespace OpenBabel {
       CreateCansmiString(*pmol, buffer, fragatoms, !pConv->IsOption("i"), pConv->IsOption("k"), pConv);
     }
 
+    bool writenewline = false;
     if(!pConv->IsOption("smilesonly")) {
 
       if(!pConv->IsOption("n")) {
@@ -4079,10 +4089,13 @@ namespace OpenBabel {
       }
 
       if(!pConv->IsOption("nonewline"))
-        buffer += "\n";
+        writenewline = true;
     }
 
     ofs << buffer;
+    if (writenewline)
+      ofs << NewLine();
+
     return true;
   }
 


### PR DESCRIPTION
3.5% of the time for SMI->SMI conversion is spent on writing std::endl, which flushes the buffers. I've replaced it with just "\n" for non-Windows, and "\r\n" for Windows. Does this need a further 'ifdef' for the Mac @ghutchis?

I've also edited the code to have just a single write to the output file stream. I note in passing that GetTitle(), by default, seems to be doing more work than necessary (a job for another day).