### PR TITLE
Remove some audit messages

### DIFF
--- a/src/obmolecformat.cpp
+++ b/src/obmolecformat.cpp
@@ -37,13 +37,6 @@ namespace OpenBabel
 
     OBMol* pmol = new OBMol;
 
-    std::string auditMsg = "OpenBabel::Read molecule ";
-    std::string description(pFormat->Description());
-    auditMsg += description.substr(0,description.find('\n'));
-    obErrorLog.ThrowError(__FUNCTION__,
-                          auditMsg,
-                          obAuditMsg);
-
     if(pConv->IsOption("C",OBConversion::GENOPTIONS))
       return DeferMolOutput(pmol, pConv, pFormat);
 
@@ -168,13 +161,6 @@ namespace OpenBabel
                                   obInfo);
           }
         ret=true;
-
-        std::string auditMsg = "OpenBabel::Write molecule ";
-        std::string description(pFormat->Description());
-        auditMsg += description.substr(0,description.find('\n'));
-        obErrorLog.ThrowError(__FUNCTION__,
-                              auditMsg,
-                              obAuditMsg);
 
         ret = DoOutputOptions(pOb, pConv);
 
@@ -403,11 +389,6 @@ namespace OpenBabel
         pConv->SetOutputIndex(i);
         if(itr==lastitr)
           pConv->SetOneObjectOnly(); //to set IsLast
-
-        std::string auditMsg = "OpenBabel::Write molecule ";
-        std::string description((pConv->GetOutFormat())->Description());
-        auditMsg += description.substr(0,description.find('\n'));
-        obErrorLog.ThrowError(__FUNCTION__, auditMsg,  obAuditMsg);
 
         ret = pConv->GetOutFormat()->WriteMolecule(itr->second, pConv);
 


### PR DESCRIPTION
Remove some audit messages that copy the entire format description and then substring it.

For smi->smi conversion, 1.6% of the total conversion time was spent on one of these audit message blocks, the majority of which on the string copy of the format description (which is not small for SMILES).

Since the other ones are similar, why not remove all three? Actually, I would remove all audit and debug level logging statements throughout the library (I have never used them for debugging), so I have no qualms about removing these three. They could be rewritten to avoid the string copy, but... What do they think?

