### PR TITLE
Fix a memory leak to due OBGraphSym having a virtual destructor

### DIFF
--- a/include/openbabel/graphsym.h
+++ b/include/openbabel/graphsym.h
@@ -49,7 +49,7 @@ namespace OpenBabel {
       //! Constructor
       OBGraphSym(OBMol* pmol, const OBBitVec* frag_atoms = NULL);
       //! Destructor
-      virtual ~OBGraphSym();
+      ~OBGraphSym();
 
       static const unsigned int NoSymmetryClass;
 


### PR DESCRIPTION
Dr Memory flagged this up as a memory leak. I can't remember if it's just when used in the Python bindings or not. Either way, only abstract base classes should have a virtual destructor.