### PR TITLE
Speed up the SMILES writer by avoiding creating the SMILES atom order vector

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -3882,6 +3882,7 @@ else {
       char tmp[15];
       snprintf(tmp, 15, "%d", *it);
       outorder += tmp;
+      ++it;
       for (; it != _atmorder.end(); ++it) {
         snprintf(tmp, 15, "%d", *it);
         outorder += ' ';
@@ -4025,6 +4026,12 @@ else {
       ofs << pmol->GetTitle() <<endl;
       return true;
     }
+
+    // Option 'x' needs "SMILES Atom Order" to be set
+    // FIXME: When we support features of CXN extended SMILES
+    //        we can rewrite this
+    if (pConv->IsOption("x"))
+      pConv->AddOption("O");
 
     std::string buffer;
 

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -54,6 +54,19 @@ class PybelWrapper(PythonBindings):
 
 class TestSuite(PythonBindings):
 
+    def testSmilesAtomOrder(self):
+        """Ensure that SMILES atom order is written correctly"""
+        data = [("CC", "1 2"),
+                ("O=CCl", "3 2 1")]
+        for smi, atomorder in data:
+            mol = pybel.readstring("smi", smi)
+            mol.write("can", opt={"O": True})
+            res = mol.data["SMILES Atom Order"]
+            self.assertEqual(res, atomorder)
+        mol = pybel.readstring("smi", "CC")
+        mol.write("can")
+        self.assertFalse("SMILES Atom Order" in mol.data)
+
     def testAtomMapsAfterCopying(self):
         """Copying a molecule should copy the atom maps"""
         smi = "C[CH2:2]O[Cl:6]"


### PR DESCRIPTION
Creating the SMILES atom order OBPairData was taking 10% of the time of SMI->SMI conversion. I rewrote it to avoid using stringstream and I made it optional.