### PR TITLE
Avoid logging messages that are taking time

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -1433,8 +1433,9 @@ namespace OpenBabel
 
   bool OBMol::Clear()
   {
-    obErrorLog.ThrowError(__FUNCTION__,
-                          "Ran OpenBabel::Clear Molecule", obAuditMsg);
+    if (obErrorLog.GetOutputLevel() >= obAuditMsg)
+      obErrorLog.ThrowError(__FUNCTION__,
+                            "Ran OpenBabel::Clear Molecule", obAuditMsg);
 
     vector<OBAtom*>::iterator i;
     vector<OBBond*>::iterator j;

--- a/src/ring.cpp
+++ b/src/ring.cpp
@@ -559,8 +559,9 @@ namespace OpenBabel
   {
     if (HasFlag(OB_RINGFLAGS_MOL))
       return;
-    obErrorLog.ThrowError(__FUNCTION__,
-                          "Ran OpenBabel::FindRingAtomsAndBonds", obAuditMsg);
+    if (obErrorLog.GetOutputLevel() >= obAuditMsg)
+      obErrorLog.ThrowError(__FUNCTION__,
+                            "Ran OpenBabel::FindRingAtomsAndBonds", obAuditMsg);
     FindRingAtomsAndBonds2(*this);
   }
 

--- a/src/stereo/perception.cpp
+++ b/src/stereo/perception.cpp
@@ -82,8 +82,8 @@ namespace OpenBabel {
         StereoFrom0D(mol);
         break;
     }
-
-    obErrorLog.ThrowError(__FUNCTION__, "Ran OpenBabel::PerceiveStereo", obAuditMsg);
+    if (obErrorLog.GetOutputLevel() >= obAuditMsg)
+      obErrorLog.ThrowError(__FUNCTION__, "Ran OpenBabel::PerceiveStereo", obAuditMsg);
   }
 
   /**


### PR DESCRIPTION
ThrowError was taking a total of 1.9% of the time for smi->smi. This was mainly attributed to three log messages, all audits. I've added an 'if' statement to check the logger's output level before throwing the error. I think it would make sense for this to be an idiom throughout the library.