### PR TITLE
Speed up SMILES writer by replacement of SSSR in SMILES writer with a bounded BFS

### DIFF
--- a/include/openbabel/obfunctions.h
+++ b/include/openbabel/obfunctions.h
@@ -1,7 +1,7 @@
 /**********************************************************************
 obfunctions.h - Various global functions
 
-Copyright (C) 2017 by Noel O'B oyle
+Copyright (C) 2017 by Noel O'Boyle
 
 This file is part of the Open Babel project.
 For more information, see <http://openbabel.org/>
@@ -23,6 +23,21 @@ General Public License for more details.
 
 namespace OpenBabel
 {
+  /**
+  \brief Return the size of the smallest ring in which a bond appears
+
+  This function returns the size of the smallest ring in which a bond appears. The
+  search is bounded by the specified bound. A value of 0 is returned if the bond
+  is not in a ring or if no ring is found of size less than or equal to the bound.
+
+  Note that alternative algorithms may be more appropriate if you wish to calculate
+  this value for all atoms in a molecule.
+
+  \return The size of the smallest ring, or 0
+  **/
+
+  OBAPI unsigned int OBBondGetSmallestRingSize(OBBond *bond, unsigned int bound);
+
   /**
    \brief Return the typical valence of an atom of a particular element
 

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2378,7 +2378,7 @@ namespace OpenBabel {
           continue;
         // Do not output cis/trans bond symbols for double bonds in rings of size IMPLICIT_CIS_RING_SIZE or less
         unsigned int boundedringsize = OBBondGetSmallestRingSize(dbl_bond, IMPLICIT_CIS_RING_SIZE);
-        if (boundedringsize > 0)
+        if (boundedringsize == 0) // either not in ring at all, or not in small ring
           _cistrans.push_back(*ct);
       }
     }

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2364,6 +2364,57 @@ namespace OpenBabel {
     return(idx);
   }
 
+  // Is this dbl bond in a ring that is of size <= IMPLICIT_CIS_RING_SIZE?
+  //
+  // A bounded BFS from one side of a bond trying to find the other side.
+  //   - The required queue is implemented using a std::vector for efficiency
+  //   - Note that items are never popped from the queue, I just move a pointer
+  //     along to mark the left hand side
+  //   - A potential improvement would be to BFS from both sides at the same time
+  static bool IsNotInRingOfSizeThatImpliesCis(OBMol *mol, OBBond *bond)
+  {
+    if (!bond->IsInRing()) return true;
+    OBAtom* start = bond->GetBeginAtom();
+    OBAtom* end = bond->GetEndAtom();
+    std::vector<OBAtom*> qatoms;
+    unsigned int numatoms = mol->NumAtoms();
+    qatoms.reserve(numatoms < 42 ? numatoms : 42); // Value chosen by inspection on ChEMBL when using maxsize of 8
+    OBBitVec seen(mol->NumAtoms() + 1);
+    seen.SetBitOn(start->GetIdx());
+    FOR_BONDS_OF_ATOM(nbond, start) {
+      if (&*nbond == bond) continue;
+      if (!nbond->IsInRing()) continue;
+      OBAtom* nbr = nbond->GetNbrAtom(start);
+      qatoms.push_back(nbr);
+    }
+    unsigned int depthmarker = qatoms.size(); // when qstart reaches this, increment the depth
+    unsigned int qstart = 0;
+    unsigned int depth = 2;
+    while (qatoms.size() - qstart) { // While queue not empty
+      OBAtom* curr = qatoms[qstart];
+      if (qstart == depthmarker) {
+        depth++;
+        depthmarker = qatoms.size();
+      }
+      qstart++;
+      if (seen.BitIsSet(curr->GetIdx()))
+        continue;
+      seen.SetBitOn(curr->GetIdx());
+      if (depth < IMPLICIT_CIS_RING_SIZE) {
+        FOR_BONDS_OF_ATOM(nbond, curr) {
+          if (!nbond->IsInRing()) continue;
+          OBAtom* nbr = nbond->GetNbrAtom(curr);
+          if (nbr == end)
+            return false;
+          if (!seen.BitIsSet(nbr->GetIdx())) {
+            qatoms.push_back(nbr);
+          }
+        }
+      }
+    }
+    return true;
+  }
+
   void OBMol2Cansmi::CreateCisTrans(OBMol &mol)
   {
     std::vector<OBGenericData*> vdata = mol.GetAllData(OBGenericDataType::StereoData);
@@ -2377,8 +2428,7 @@ namespace OpenBabel {
         if (!dbl_bond)
           continue;
         // Do not output cis/trans bond symbols for double bonds in rings of size IMPLICIT_CIS_RING_SIZE or less
-        OBRing* ring = dbl_bond->FindSmallestRing();
-        if (!ring || ring->Size()>IMPLICIT_CIS_RING_SIZE)
+        if (IsNotInRingOfSizeThatImpliesCis(&mol, dbl_bond))
           _cistrans.push_back(*ct);
       }
     }

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -88,6 +88,21 @@ class TestSuite(PythonBindings):
         mol.removeh()
         self.assertEqual(mol.write("smi", opt={"a":True}).rstrip(), "C[NH:2]")
 
+    def testImplicitCisDblBond(self):
+        """Ensure that dbl bonds in rings of size 8 or less are always
+        implicitly cis"""
+        smi = "C1/C=C/C"
+        for i in range(5): # from size 4 to 8
+            ringsize = i + 4
+            ringsmi = smi + "1"
+            roundtrip = pybel.readstring("smi", ringsmi).write("smi")
+            self.assertTrue("/" not in roundtrip)
+            smi += "C"
+        ringsize = 9
+        ringsmi = smi + "1"
+        roundtrip = pybel.readstring("smi", ringsmi).write("smi")
+        self.assertTrue("/" in roundtrip)
+
     def testKekulizationOfcn(self):
         """We were previously not reading 'cn' correctly, or at least how
         Daylight would"""


### PR DESCRIPTION
To test whether a double bond is implicitly cis (and thus requires no stereobond symbols), the original code used SSSR based ring perception. In fact, it always triggered it, even where the bond was not in a ring. Doh!

The replacement code does not use the SSSR.