### PR TITLE
When reading, don't pre-scan the SMILES string for illegal characters

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -348,13 +348,6 @@ namespace OpenBabel {
       else
         smiles = ln;
     }
-    pos= smiles.find_first_of(",<\"\'!^&_|{}");
-    if(pos!=string::npos)
-    {
-      obErrorLog.ThrowError(__FUNCTION__,
-        smiles + " contained a character '" + smiles[pos] + "' which is invalid in SMILES", obError);
-      return false;
-    }
 
     pmol->SetDimension(0);
     OBSmilesParser sp(pConv->IsOption("a", OBConversion::INOPTIONS));
@@ -976,7 +969,15 @@ namespace OpenBabel {
         element = 16;
         break;
       default:
+        {
+        std::string err;
+        err += "SMILES string contains a character '";
+        err += *_ptr;
+        err += "' which is invalid";
+        obErrorLog.ThrowError(__FUNCTION__,
+          err, obError);
         return false;
+        }
       }
 
     OBAtom *atom = mol.NewAtom();
@@ -1643,7 +1644,15 @@ namespace OpenBabel {
         break;
 
       default:
-        return false;
+        {
+          std::string err;
+          err += "SMILES string contains a character '";
+          err += *_ptr;
+          err += "' which is invalid";
+          obErrorLog.ThrowError(__FUNCTION__,
+            err, obError);
+          return false;
+        }
       }
 
     //handle hydrogen count, stereochemistry, and charge

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -94,6 +94,15 @@ class TestSuite(PythonBindings):
         mol = pybel.readstring("smi", "cn")
         self.assertEqual("C=N", mol.write("smi").rstrip())
 
+    def testInvalidCharsInSmiles(self):
+        """Check that inserting a comma in a SMILES string in various positions
+        does not result in a valid SMILES"""
+        data = "C, ,C [C,] [,C] [1,C] [C:,1] [C:1,] [CH,] [C+,] [C++,]"
+        data += " [C@,](Br)(Cl)(I)F C1,CC1 C%1,1CC%11 C%(1,1)CC%11"
+        data += " C=,C"
+        for smi in data.split(" "):
+            self.assertRaises(IOError, pybel.readstring, "smi", smi)
+
     def testOBMolAssignTotalChargeToAtoms(self):
         """Run the test cases described in the source code"""
         data = [("[NH4]", +1, "[NH4+]"),


### PR DESCRIPTION
The change I've made is simply to remove the prescan for illegal characters as we shouldn't be scanning over the SMILES string twice. It's enough to do this in the parser.

I've moved the warning message into ParseSimple and ParseComplex, but depending on the location of the illegal character, the parser will often just "return false;" without any warning message. The day will come when we improve the warning messages across the board, but that's not the focus of this PR, just to reduce the work we're doing.