### PR TITLE
Fixes for ring closure parsing

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -1982,6 +1982,7 @@ namespace OpenBabel {
         _ptr++;
         char* start = _ptr;
         while (isdigit(*_ptr)) {
+          digit *= 10;
           digit += *_ptr - '0';
           _ptr++;
           if (_ptr - start > 5) {
@@ -1999,7 +2000,8 @@ namespace OpenBabel {
           obErrorLog.ThrowError(__FUNCTION__, "Two digits expected after %", obWarning);
           return false;
         }
-        digit = (*_ptr - '0') * 10 + *(++_ptr) - '0';
+        digit = (*_ptr - '0') * 10 + *(_ptr+1) - '0';
+        _ptr++;
       }
     }
     else {

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -134,14 +134,14 @@ class testOBabel(BaseTest):
 
     def testRingClosures(self):
         # Test positives
-        data = ["c1ccccc1", "c%11ccccc%11", "c%(1)ccccc%(1)",
+        data = ["c1ccccc1", "c%11ccccc%11", "c%(1)ccccc%(1)", "c%(51)ccccc%51",
                 "c%(99999)ccccc%(99999)"]
         for smi in data:
             output, error = run_exec("obabel -:%s -osmi" % smi)
             self.assertEqual("c1ccccc1", output.rstrip())
         # Test negatives
         data = ["c%1ccccc%1", "c%a1cccc%a1", "c%(a1)ccccc%(a1)",
-                "c%(000001)ccccc%(000001)"]
+                "c%(000001)ccccc%(000001)", "c%(51)ccccc%(15)"]
         for smi in data:
             output, error = run_exec("obabel -:%s -osmi" % smi)
             self.assertTrue("0 molecules converted" in error)


### PR DESCRIPTION
So...I introduced some errors in ring closure parsing back in https://github.com/openbabel/openbabel/pull/1677. The ring closure numbers were not being read correctly for %NN or %(NNN).

For %NNN, I was not multiplying the existing value by 10 when adding the new digit.

For %NN, it was a bit more subtle:
```
digit = (*_ptr - '0') * 10 + *(++_ptr) - '0';
```
Can you see the problem? It's A = B + C - D, but sometimes C is evaluated before B. I don't usually increment pointers in expressions, but I made the mistake of doing it this time.
