### PR TITLE
Make sure that OBAtom::IsInRing always triggers ring perception if not set as perceived

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -801,18 +801,14 @@ namespace OpenBabel
 
   bool OBAtom::IsInRing() const
   {
-    if (((OBAtom*)this)->HasFlag(OB_RING_ATOM))
-      return(true);
-
-    OBMol *mol = (OBMol*)((OBAtom*)this)->GetParent();
+    OBMol *mol = ((OBAtom*)this)->GetParent();
     if (!mol->HasRingAtomsAndBondsPerceived())
-      {
-        mol->FindRingAtomsAndBonds();
-        if (((OBAtom*)this)->HasFlag(OB_RING_ATOM))
-          return(true);
-      }
+      mol->FindRingAtomsAndBonds();
 
-    return(false);
+    if (((OBAtom*)this)->HasFlag(OB_RING_ATOM))
+      return true;
+
+    return false;
   }
 
   //! @todo


### PR DESCRIPTION
Previously, if the OBAtom was marked as a ring atom, then no ring perception was done, even where the rings were marked as unperceived. It should be the case that when a perceived property is marked as unset, that perception will always be triggered when queried.

I made a similar change recently for IsAromatic(), and it looks like there are more SSSR ring-related functions that may have the same problem. 