### PR TITLE
In the Python bindings, avoid adding methods from the iterated object to the iterator itself

### DIFF
--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -364,6 +364,27 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 %ignore OBResidueIter(OBMol &);
 %ignore OBResidueAtomIter(OBResidue &);
 
+// SWIG treats operator-> specially (see 6.24 "Smart pointers and operator->()").
+// If we leave this in, it adds
+// all of the methods of the underlying object (e.g. OBAtom) to the
+// iterator object, causing bloat.
+%ignore OpenBabel::OBAtomAtomIter::operator->;
+%ignore OpenBabel::OBAtomBondIter::operator->;
+%ignore OpenBabel::OBMolAngleIter::operator->;
+%ignore OpenBabel::OBMolAtomIter::operator->;
+%ignore OpenBabel::OBMolAtomBFSIter::operator->;
+%ignore OpenBabel::OBMolAtomDFSIter::operator->;
+%ignore OpenBabel::OBMolAtomBFSIter::operator->;
+%ignore OpenBabel::OBMolAtomDFSIter::operator->;
+%ignore OpenBabel::OBMolBondIter::operator->;
+%ignore OpenBabel::OBMolBondBFSIter::operator->;
+%ignore OpenBabel::OBMolBondBFSIter::operator->;
+%ignore OpenBabel::OBMolPairIter::operator->;
+%ignore OpenBabel::OBMolRingIter::operator->;
+%ignore OpenBabel::OBMolTorsionIter::operator->;
+%ignore OpenBabel::OBResidueIter::operator->;
+%ignore OpenBabel::OBResidueAtomIter::operator->;
+
 // These classes are renamed so that they can be replaced by Python
 // classes of the same name which provide Pythonic iterators
 // (see %pythoncode section below)

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -211,6 +211,16 @@ class TestSuite(PythonBindings):
 
         self.assertTrue(N > 100)
 
+    def testIterators(self):
+        """Basic check that at least two iterators are working"""
+        mol = pybel.readstring("smi", "c1ccccc1C(=O)Cl")
+        atoms = list(ob.OBMolAtomIter(mol.OBMol))
+        self.assertEqual(len(atoms), 9)
+        elements = [atom.GetAtomicNum() for atom in atoms]
+        self.assertEqual(elements, [6,6,6,6,6,6,6,8,17])
+        bonds = list(ob.OBMolBondIter(mol.OBMol))
+        self.assertEqual(len(bonds), 9)
+
 class Radicals(PythonBindings):
     def testSmilesToMol(self):
         smis = ["C", "[CH3]", "[CH2]", "[CH2]C", "[C]"]


### PR DESCRIPTION
The generated bindings for the iterators included all of the methods of the underlying object (e.g. OBAtom), due to the -> operator. This is unnecessary in Python; by telling SWIG to ignore it, the total size of the bindings (the openbabel-python.cpp file) is reduced by ~20% without any loss in functionality.