### PR TITLE
Fix ChemDraw CDX incremental value

### DIFF
--- a/data/chemdrawcdx.h
+++ b/data/chemdrawcdx.h
@@ -373,7 +373,7 @@ enum CDXDatumID {
 	kCDXObj_BracketedGroup,				// 0x8017
 	kCDXObj_BracketAttachment,			// 0x8018
 	kCDXObj_CrossingBond,				// 0x8019
-	kCDXObj_Border,						// 0x8020
+	kCDXObj_Border = 0x8020,						// 0x8020
 	kCDXObj_Geometry,					// 0x8021
 	kCDXObj_Constraint,					// 0x8022
 	kCDXObj_TLCPlate,					// 0x8023

--- a/include/chemdrawcdx.h
+++ b/include/chemdrawcdx.h
@@ -373,7 +373,7 @@ enum CDXDatumID {
 	kCDXObj_BracketedGroup,				// 0x8017
 	kCDXObj_BracketAttachment,			// 0x8018
 	kCDXObj_CrossingBond,				// 0x8019
-	kCDXObj_Border,						// 0x8020
+	kCDXObj_Border = 0x8020,						// 0x8020
 	kCDXObj_Geometry,					// 0x8021
 	kCDXObj_Constraint,					// 0x8022
 	kCDXObj_TLCPlate,					// 0x8023


### PR DESCRIPTION
I am not sure if I am correct. But while implementing some more feature with ChemDraw CDX files, I found this one. 
The current value of `kCDXObj_Border` is `0x801a` which is the next value from `0x8019`, it should be `0x8020`.