### PR TITLE
Fix for 1731. Store atom classes in CML atomids by appending _ATOMCLASS.

### DIFF
--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -331,14 +331,13 @@ class AtomClass(PythonBindings):
         self.assertEqual(smi, out)
 
     def testCML(self):
-        """Atom classes map onto CML atom ids in OB's implementation"""
-        # CH3:6 --> aa6
-        # OH:6  --> ab6 (second use of an atom class)
-        smis = ["[CH3:6]C", "[CH3:6][OH:6]"]
+        """OB stores atom classes using _NN at the end of atom ids"""
+        smis = ["[CH3:6]C", "[CH3:6][OH:6]",
+                "O"+"[CH2:2]"*27+"O"
+                ]
         for smi in smis:
             mol = pybel.readstring("smi", smi)
             cml = mol.write("cml")
-            self.assertTrue("aa6" in cml)
             molb = pybel.readstring("mol", cml)
             out = mol.write("smi", opt={"a":True, "n":True, "nonewline":True})
             self.assertEqual(smi, out)


### PR DESCRIPTION
Fix for #1731. Changes how atom class information is used in CML. CML doesn't itself provide a way to do this, so we hack it into the atomid. The existing code used a complex method, perhaps because of a belief that the atomid had to be letters followed by a number. Checking the CML spec, this doesn't appear to be the case. It just should be alphanumeric (or also underscore and minus), and unique within the molecule.

Given that, there's a very simple alternative; just append _ATOMCLASS to the end of the existing atomid. So what was "a3" for atom number 3, now might be a3_4 if that atom had atom class 4.