### PR TITLE
Fix GCC warnings

### DIFF
--- a/include/openbabel/data.h
+++ b/include/openbabel/data.h
@@ -34,7 +34,6 @@ namespace OpenBabel
 
   class OBAtom;
   class OBMol;
-  class OBBitVec;
 
   /** \class OBGlobalDataBase data.h <openbabel/data.h>
       \brief Base data table class, handles reading data files
@@ -260,8 +259,7 @@ namespace OpenBabel
       bool LookupType(const std::string &,std::string&,int&);
       //! Assign bond orders, atom types and residues for the supplied OBMol
       //! based on the residue information assigned to atoms
-      //! \deprecated second OBBitVec argument is ignored
-      bool AssignBonds(OBMol &,OBBitVec &);
+      bool AssignBonds(OBMol &);
     };
 
 } // end namespace OpenBabel

--- a/include/openbabel/generic.h
+++ b/include/openbabel/generic.h
@@ -973,11 +973,11 @@ namespace OpenBabel
 
     //! \brief Convenience function for common cases of closed-shell calculations -- pass the energies and symmetries
     //! This method will fill the OBOrbital objects for you
-    void LoadClosedShellOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, int alphaHOMO);
+    void LoadClosedShellOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, unsigned int alphaHOMO);
     //! \brief Convenience function to load alpha orbitals in an open-shell calculation
-    void LoadAlphaOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, int alphaHOMO);
+    void LoadAlphaOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, unsigned int alphaHOMO);
     //! \brief Convenience function to load beta orbitals in an open-shell calculation
-    void LoadBetaOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, int betaHOMO);
+    void LoadBetaOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, unsigned int betaHOMO);
 
   protected:
     std::vector<OBOrbital> _alphaOrbitals; //!< List of orbitals. In case of unrestricted calculations, this contains the alpha spin-orbitals

--- a/include/openbabel/generic.h
+++ b/include/openbabel/generic.h
@@ -243,17 +243,17 @@ namespace OpenBabel
  class OBAPI OBVirtualBond : public OBGenericData
   {
   protected:
-    int _bgn;
-    int _end;
-    int _ord;
+    unsigned int _bgn;
+    unsigned int _end;
+    unsigned int _ord;
     int _stereo;
   public:
     OBVirtualBond();
     virtual OBGenericData* Clone(OBBase* /*parent*/) const{return new OBVirtualBond(*this);}
-    OBVirtualBond(int,int,int,int stereo=0);
-    int GetBgn()    {      return(_bgn);    }
-    int GetEnd()    {      return(_end);    }
-    int GetOrder()  {      return(_ord);    }
+    OBVirtualBond(unsigned int, unsigned int, unsigned int,int stereo=0);
+    unsigned int GetBgn()    {      return(_bgn);    }
+    unsigned int GetEnd()    {      return(_end);    }
+    unsigned int GetOrder()  {      return(_ord);    }
     int GetStereo() {      return(_stereo); }
   };
 

--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -471,7 +471,7 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     //! If @p threshold is not specified or is zero, remove all but the largest
     //! contiguous fragment. If @p threshold is non-zero, remove any fragments with fewer
     //! than @p threshold atoms.
-    bool StripSalts(int threshold=0);
+    bool StripSalts(unsigned int threshold=0);
     //! Copies each disconnected fragment as a separate OBMol
     std::vector<OBMol> Separate(int StartIndex=1);
     //! Iterative component of Separate to copy one fragment at a time
@@ -605,8 +605,8 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     //! Add a new set of coordinates @p f as a new conformer
     void    AddConformer(double *f)    {  _vconf.push_back(f);    }
     //! Set the molecule's current conformer to @p i
-    //! Does nothing if @p i is less than 0 or i is larger than NumConformers()
-    void    SetConformer(int i);
+    //! Does nothing if @p i is larger than NumConformers()
+    void    SetConformer(unsigned int i);
     //! Copy the conformer @p nconf into the array @p c
     //! \warning Does no checking to see if @p c is large enough
     void    CopyConformer(double* c,int nconf);

--- a/include/openbabel/rotor.h
+++ b/include/openbabel/rotor.h
@@ -153,13 +153,13 @@ namespace OpenBabel
     void SetBond(OBBond *bond)
     {
       _bond = bond;
-      SetRings(bond);
+      SetRings();
     }
     /**
      * Set the rings associated with this bond (if it's a ring bond)
      * \since Version 2.4
      */
-    void SetRings(OBBond *bond);
+    void SetRings();
     /**
      * Set the index for this rotor. Used by OBRotorList
      */

--- a/include/openbabel/stereo/stereo.h
+++ b/include/openbabel/stereo/stereo.h
@@ -233,7 +233,7 @@ namespace OpenBabel {
      *
      * @note This method does nothing if i equals j.
      */
-    static void Permutate(Refs &refs, int i, int j);
+    static void Permutate(Refs &refs, unsigned int i, unsigned int j);
     /**
      * Get @p refs with element @p i and @p j permutated.
      *
@@ -245,7 +245,7 @@ namespace OpenBabel {
      *
      * @note This method does nothing if @p i equals @p j.
      */
-    static Refs Permutated(const Refs &refs, int i, int j);
+    static Refs Permutated(const Refs &refs, unsigned int i, unsigned int j);
     //@}
 
   };

--- a/include/openbabel/typer.h
+++ b/include/openbabel/typer.h
@@ -55,17 +55,12 @@ public:
 };
 
 // class introduction in typer.cpp
-class OBAPI OBAromaticTyper : public OBGlobalDataBase
+class OBAPI OBAromaticTyper
 {
-    friend class OBAromaticTyperMolState;
 public:
-    OBAromaticTyper();
+    OBAromaticTyper() {};
     ~OBAromaticTyper();
 
-    //! \return the number of SMARTS patterns
-    size_t GetSize()                 { return 0;} // SMARTS are no longer used by this class
-
-    void ParseLine(const char*);
     //! Assign aromaticity flag to atoms and bonds
     void AssignAromaticFlags(OBMol &);
 };

--- a/include/openbabel/typer.h
+++ b/include/openbabel/typer.h
@@ -59,7 +59,7 @@ class OBAPI OBAromaticTyper
 {
 public:
     OBAromaticTyper() {};
-    ~OBAromaticTyper();
+    ~OBAromaticTyper() {};
 
     //! Assign aromaticity flag to atoms and bonds
     void AssignAromaticFlags(OBMol &);

--- a/scripts/openbabel-R.i
+++ b/scripts/openbabel-R.i
@@ -265,6 +265,8 @@ CAST_GENERICDATA_TO(VirtualBond)
 %include <openbabel/math/transform3d.h>
 %warnfilter(516) OpenBabel::SpaceGroup; // Ignoring std::string methods in favour of char* ones
 %include <openbabel/math/spacegroup.h>
+%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
+%include <openbabel/bitvec.h>
 
 // CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
@@ -346,8 +348,6 @@ IGNORE_ITER(OBMol, Residue)
 %include <openbabel/canon.h>
 %include <openbabel/stereo/stereo.h>
 
-%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
-%include <openbabel/bitvec.h>
 // Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>

--- a/scripts/openbabel-csharp.i
+++ b/scripts/openbabel-csharp.i
@@ -751,6 +751,8 @@ using System.Runtime.InteropServices;
 %include <openbabel/math/transform3d.h>
 %warnfilter(516) OpenBabel::SpaceGroup; // Ignoring std::string methods in favour of char* ones
 %include <openbabel/math/spacegroup.h>
+%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
+%include <openbabel/bitvec.h>
 
 // CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
@@ -886,9 +888,6 @@ namespace std { class stringbuf {}; }
 
 %include <openbabel/builder.h>
 %include <openbabel/op.h>
-
-%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
-%include <openbabel/bitvec.h>
 
 %include <openbabel/rotor.h>
 %ignore OpenBabel::Swab;

--- a/scripts/openbabel-java.i
+++ b/scripts/openbabel-java.i
@@ -230,6 +230,8 @@ CAST_GENERICDATA_TO(VirtualBond)
 %include <openbabel/math/transform3d.h>
 %warnfilter(516) OpenBabel::SpaceGroup; // Ignoring std::string methods in favour of char* ones
 %include <openbabel/math/spacegroup.h>
+%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
+%include <openbabel/bitvec.h>
 
 // CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
@@ -326,8 +328,6 @@ IGNORE_ITER(OBMol, Residue)
 %include <openbabel/canon.h>
 %include <openbabel/stereo/stereo.h>
 
-%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
-%include <openbabel/bitvec.h>
 // Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>

--- a/scripts/openbabel-mono.i
+++ b/scripts/openbabel-mono.i
@@ -251,6 +251,8 @@ SWIG_STD_VECTOR_SPECIALIZE_MINIMUM(OBBond, OpenBabel::OBBond*);
 %include <openbabel/math/matrix3x3.h>
 %include <openbabel/math/transform3d.h>
 %include <openbabel/math/spacegroup.h>
+%include <openbabel/bitvec.h>
+
 %include <openbabel/base.h>
 
 %include <openbabel/generic.h>
@@ -309,8 +311,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 %include <openbabel/forcefield.h>
 
 %include <openbabel/op.h>
-
-%include <openbabel/bitvec.h>
 
 // The following %ignores avoid warning messages due to shadowed classes.
 // This does not imply a loss of functionality as (in this case)

--- a/scripts/openbabel-perl.i
+++ b/scripts/openbabel-perl.i
@@ -176,6 +176,8 @@ CAST_GENERICDATA_TO(VirtualBond)
 %include <openbabel/math/matrix3x3.h>
 
 %import <openbabel/math/spacegroup.h>
+%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
+%include <openbabel/bitvec.h>
 
 // CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
@@ -229,8 +231,6 @@ namespace std { class stringbuf {}; }
 %include <openbabel/builder.h>
 %include <openbabel/op.h>
 
-%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
-%include <openbabel/bitvec.h>
 // Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %warnfilter(314); // 'next' is a Perl keyword

--- a/scripts/openbabel-php.i
+++ b/scripts/openbabel-php.i
@@ -211,6 +211,8 @@ CAST_GENERICDATA_TO(VirtualBond)
 %include <openbabel/math/matrix3x3.h>
 %include <openbabel/math/transform3d.h>
 %include <openbabel/math/spacegroup.h>
+%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
+%include <openbabel/bitvec.h>
 
 // CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
@@ -276,8 +278,6 @@ IGNORE_ITER(OBMol, Residue)
 %include <openbabel/canon.h>
 %include <openbabel/stereo/stereo.h>
 
-%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
-%include <openbabel/bitvec.h>
 // Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>

--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -236,6 +236,8 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 %include <openbabel/math/matrix3x3.h>
 %include <openbabel/math/transform3d.h>
 %include <openbabel/math/spacegroup.h>
+%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
+%include <openbabel/bitvec.h>
 
 // CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
@@ -325,8 +327,6 @@ OBMol.BeginResidues = OBMol.EndResidues = OBMol.BeginResidue = OBMol.EndResidue 
 
 %include <openbabel/stereo/stereo.h>
 
-%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
-%include <openbabel/bitvec.h>
 // Ignore shadowed method
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>

--- a/scripts/openbabel-ruby.i
+++ b/scripts/openbabel-ruby.i
@@ -178,6 +178,8 @@ CAST_GENERICDATA_TO(VirtualBond)
 %include <openbabel/math/matrix3x3.h>
 
 %import <openbabel/math/spacegroup.h>
+%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
+%include <openbabel/bitvec.h>
 
 // CloneData should be used instead of the following method
 %ignore OpenBabel::OBBase::SetData;
@@ -231,8 +233,6 @@ namespace std { class stringbuf {}; }
 %include <openbabel/builder.h>
 %include <openbabel/op.h>
 
-%warnfilter(503) OpenBabel::OBBitVec; // Not wrapping any of the overloaded operators
-%include <openbabel/bitvec.h>
 %ignore OpenBabel::OBRotor::GetRotAtoms() const;
 %include <openbabel/rotor.h>
 %ignore OpenBabel::Swab;

--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -23,6 +23,8 @@ GNU General Public License for more details.
 #include <openbabel/shared_ptr.h>
 #include <openbabel/elements.h>
 
+#define MARK_UNUSED(x) (void)(x)
+
 using namespace std;
 namespace OpenBabel
 {
@@ -384,8 +386,12 @@ public:
 OpGenAlias theOpGenAlias("genalias"); //Global instance
 
 /////////////////////////////////////////////////////////////////
-bool OpGenAlias::Do(OBBase* pOb, __attribute__((unused)) const char* OptionText, __attribute__((unused)) OpMap* pmap, OBConversion*)
+bool OpGenAlias::Do(OBBase* pOb, const char* OptionText, OpMap* pmap, OBConversion*)
 {
+  // Mark variables as unused to avoid warnings
+  MARK_UNUSED(OptionText);
+  MARK_UNUSED(pmap);
+
   OBMol* pmol = dynamic_cast<OBMol*>(pOb);
   if(!pmol)
     return false;

--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -384,7 +384,7 @@ public:
 OpGenAlias theOpGenAlias("genalias"); //Global instance
 
 /////////////////////////////////////////////////////////////////
-bool OpGenAlias::Do(OBBase* pOb, const char* OptionText, OpMap* pmap, OBConversion*)
+bool OpGenAlias::Do(OBBase* pOb, __attribute__((unused)) const char* OptionText, __attribute__((unused)) OpMap* pmap, OBConversion*)
 {
   OBMol* pmol = dynamic_cast<OBMol*>(pOb);
   if(!pmol)

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -301,7 +301,7 @@ namespace OpenBabel
 
   int OBAtom::HighestBondOrder()
   {
-    int highest = 0;
+    unsigned int highest = 0;
     OBBond *bond;
     OBBondIterator i;
     for(bond = BeginBond(i); bond; bond = NextBond(i))

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -186,18 +186,18 @@ namespace OpenBabel
       // make sure we place the new atom trans to a-2 (if there is an a-2 atom)
       //
       //   (a-2)             (a-2)
-      //     \                 \
+      //     \                 \                                             //
       //    (a-1)==a   --->   (a-1)==a          angle(a-1, a, *) = 120
-      //                              \
+      //                              \                                      //
       //                               *
       // hyb * = 3
       // ^^^^^^^^^
       // make sure we place the new atom trans to a-2 (if there is an a-2 atom)
       //
       //   (a-2)             (a-2)
-      //     \                 \
+      //     \                 \                                             //
       //    (a-1)--a   --->   (a-1)--a          angle(a-1, a, *) = 109
-      //                              \
+      //                              \                                      //
       //                               *
       if (atom->GetValence() == 1) {
         bool isCarboxylateO = atom->IsCarboxylOxygen();
@@ -263,7 +263,7 @@ namespace OpenBabel
       }
 
       //
-      //    \	      \
+      //    \	      \                                                     //
       //     X  --->   X--*
       //    /         /
       //
@@ -1043,7 +1043,7 @@ namespace OpenBabel
 
             // Have any atoms of this match already been added?
             int alreadydone = 0;
-            int match_idx;
+            int match_idx = 0;
             for (k = j->begin(); k != j->end(); ++k) // for all atoms of the fragment
               if (vfrag.BitIsSet(*k)) {
                 alreadydone += 1;
@@ -1219,7 +1219,7 @@ namespace OpenBabel
     //                                        \   /
     //  \        \   /    bisect  \             P    align   \                /
     //   P  and    P       --->    P--v1  and   |    --->     P--v1  and v2--P
-    //  /                         /             v2           /                \
+    //  /                         /             v2           /                \  //
 
     // Get v1 (from the existing fragment)
     vector3 bond1, bond2, bond3, bond4, v1;
@@ -1328,7 +1328,7 @@ namespace OpenBabel
         // refs[0]            refs[3]
         //        \          /
         //         begin==end
-        //        /          \
+        //        /          \                                                /
         // refs[1]            refs[2]
 
         a = mol.GetAtomById(config.refs[0]);

--- a/src/canon.cpp
+++ b/src/canon.cpp
@@ -692,7 +692,7 @@ namespace OpenBabel {
             const OBBitVec &_fragment, std::vector<StereoCenter> &_stereoCenters,
             std::vector<FullCode> &_identityCodes, Orbits &_orbits, OBBitVec &_mcr,
             bool _onlyOne) : symmetry_classes(_symmetry_classes), fragment(_fragment),
-          stereoCenters(_stereoCenters), onlyOne(_onlyOne),
+          onlyOne(_onlyOne), stereoCenters(_stereoCenters),
           code(_symmetry_classes.size()), identityCodes(_identityCodes),
           backtrackDepth(0), orbits(_orbits), mcr(_mcr)
       {
@@ -1133,7 +1133,7 @@ namespace OpenBabel {
     /**
      * Update the minimum cell representations (mcr).
      */
-    static void UpdateMcr(OBBitVec &mcr, Orbits &orbits, OBMol *mol, const std::vector<unsigned int> &bestLabels)
+    static void UpdateMcr(OBBitVec &mcr, Orbits &orbits, const std::vector<unsigned int> &bestLabels)
     {
       //print_orbits("UpdateMcr", orbits);
 
@@ -1219,7 +1219,7 @@ namespace OpenBabel {
           }
 
         if (fullcode.code == bestCode.code) {
-          UpdateMcr(state.mcr, state.orbits, mol, bestCode.labels);
+          UpdateMcr(state.mcr, state.orbits, bestCode.labels);
           FindOrbits(state.orbits, mol, fullcode.labels, bestCode.labels);
         } else if (fullcode > bestCode) {
           // if fullcode is greater than bestCode, we have found a new greatest code

--- a/src/chains.cpp
+++ b/src/chains.cpp
@@ -1217,7 +1217,10 @@ namespace OpenBabel
   {
     static OBAtom *neighbour[6];
     Template *pep;
-    OBAtom *na,*nb,*nc,*nd;
+    OBAtom *na = (OBAtom*)0;
+    OBAtom *nb = (OBAtom*)0;
+    OBAtom *nc = (OBAtom*)0;
+    OBAtom *nd = (OBAtom*)0;
     OBAtom *atom, *nbr;
     bool change, result;
     int i, count;
@@ -1354,7 +1357,9 @@ namespace OpenBabel
   void OBChainsParser::TracePeptideChain(OBMol &mol, unsigned int i, int r)
   {
     unsigned int neighbour[4];
-    unsigned int na,nb,nc;
+    unsigned int na = 0;
+    unsigned int nb = 0;
+    unsigned int nc = 0;
     OBAtom *atom, *nbr;
     int count;
     int j,k;

--- a/src/confsearch.cpp
+++ b/src/confsearch.cpp
@@ -79,7 +79,7 @@ namespace OpenBabel
   inline unsigned int LFSR::GetNext()
   {
     do {
-      _lfsr = (_lfsr >> 1) ^ (unsigned int)(0 - (_lfsr & 1u) & _poly);
+      _lfsr = (_lfsr >> 1) ^ (unsigned int)(-(_lfsr & 1u) & _poly);
     } while (_lfsr > _range);
 
     return _lfsr;
@@ -109,7 +109,7 @@ namespace OpenBabel
     private:
       bool _percise;
       vector<vector3> GetHeavyAtomCoords(const vector<vector3> &all_coords);
-      int natoms;
+      unsigned int natoms;
       Tree poses;
       std::vector<double> levels;
       OBAlign* palign;
@@ -119,9 +119,10 @@ namespace OpenBabel
     };
 
   OBDiversePoses::OBDiversePoses(const OBMol &ref, double RMSD, bool percise):
-          palign(new OBAlign(false, percise)), cutoff(RMSD), _percise(percise)
+          _percise(percise), cutoff(RMSD) 
   {
     natoms = ref.NumAtoms();
+    palign = new OBAlign(false, _percise);
     palign->SetRefMol(ref);
     palign->SetMethod(OBAlign::QCP);
     n_rmsd = 0;
@@ -137,7 +138,7 @@ namespace OpenBabel
 
     // Remember the hydrogens
     hydrogens.Resize(natoms);
-    for (int i=1; i<=natoms; i++)
+    for (unsigned int i=1; i<=natoms; i++)
       if (ref.GetAtom(i)->GetAtomicNum() == OBElements::Hydrogen)
         hydrogens.SetBitOn(i - 1);
   }
@@ -247,7 +248,7 @@ namespace OpenBabel
     vector<int>::iterator c = insert_level.begin();
     for (vector<Tree_it>::iterator a = insert_pt.begin(); a != insert_pt.end(); ++a, ++b, ++c) {
       node = *a;
-      for (int k = *c; k < levels.size(); ++k) {
+      for (unsigned int k = *c; k < levels.size(); ++k) {
         node = poses.append_child(node, *b);
       }
     }
@@ -353,8 +354,6 @@ int OBForceField::DiverseConfGen(double rmsd, unsigned int nconfs, double energy
     FastRotorSearch(true);
     double lowest_energy = Energy(false);
 
-    int origLogLevel = _loglvl;
-
     OBRotorList rl;
     OBBitVec fixed = _constraints.GetFixedBitVec();
     rl.SetFixAtoms(fixed);
@@ -377,7 +376,7 @@ int OBForceField::DiverseConfGen(double rmsd, unsigned int nconfs, double energy
     OBRotor* rotor = rl.BeginRotor(ri);
     unsigned int combinations = 1;
     vector<size_t> rotor_sizes;
-    for (int i = 1; i < rl.Size() + 1; ++i, rotor = rl.NextRotor(ri)) { // foreach rotor
+    for (unsigned int i = 1; i < rl.Size() + 1; ++i, rotor = rl.NextRotor(ri)) { // foreach rotor
       size_t size = rotor->GetResolution().size();
       rotorKeys.AddRotor(size);
       combinations *= size;
@@ -405,7 +404,7 @@ int OBForceField::DiverseConfGen(double rmsd, unsigned int nconfs, double energy
     unsigned int combination;
     OBDiversePoses divposes(_mol, rmsd, false);
     vector<int> my_rotorkey(rotor_sizes.size() + 1, 0);
-    int counter = 0;
+    unsigned int counter = 0;
 
     // Main loop over rotamers
     unsigned int N_low_energy = 0;
@@ -415,7 +414,7 @@ int OBForceField::DiverseConfGen(double rmsd, unsigned int nconfs, double energy
       combination = lfsr.GetNext();
       unsigned int t = combination;
       // Convert the combination number into a rotorkey
-      for (int i = 0 ; i < rotor_sizes.size(); ++i) {
+      for (unsigned int i = 0 ; i < rotor_sizes.size(); ++i) {
         my_rotorkey[i + 1] = t % rotor_sizes[i];
         t /= rotor_sizes[i];
       }

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -434,7 +434,7 @@ namespace OpenBabel
     _dataptr = ResidueData;
   }
 
-  bool OBResidueData::AssignBonds(OBMol &mol,OBBitVec &bv)
+  bool OBResidueData::AssignBonds(OBMol &mol)
   {
     if (!_init)
       Init();

--- a/src/data_utilities.cpp
+++ b/src/data_utilities.cpp
@@ -124,7 +124,7 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
                 }
             }
         }
-        for(int i = 0; (i<NEU); i++)
+        for(unsigned int i = 0; (i<NEU); i++)
         {
             if (strstr(term.c_str(), eu[i].term.c_str()) != 0)
             {

--- a/src/formats/pdbformat.cpp
+++ b/src/formats/pdbformat.cpp
@@ -118,7 +118,6 @@ namespace OpenBabel
 
     int chainNum = 1;
     char buffer[BUFF_SIZE];
-    OBBitVec bs;
     string line, key, value;
     OBPairData *dp;
 
@@ -148,8 +147,6 @@ namespace OpenBabel
                          << "  Problems reading a ATOM/HETATM record.\n";
                 obErrorLog.ThrowError(__FUNCTION__, errorMsg.str() , obError);
               }
-            if (EQn(buffer,"ATOM",4))
-              bs.SetBitOn(mol.NumAtoms());
             continue;
           }
 
@@ -218,7 +215,7 @@ namespace OpenBabel
       return(false);
     }
 
-    resdat.AssignBonds(mol,bs);
+    resdat.AssignBonds(mol);
     /*assign hetatm bonds based on distance*/
 
     mol.EndModify();

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -153,7 +153,6 @@ namespace OpenBabel
 
     int chainNum = 1;
     char buffer[BUFF_SIZE];
-    OBBitVec bs;
     string line, key, value;
     OBPairData *dp;
 
@@ -219,7 +218,6 @@ namespace OpenBabel
             << endl << buffer << endl;
           obErrorLog.ThrowError(__FUNCTION__, errorMsg.str() , obError);
         }
-        if (EQn(buffer,"ATOM",4)) {bs.SetBitOn(mol.NumAtoms());}
         continue;
       }
       if ((EQn(buffer,"REMARK",6)) || (EQn(buffer,"USER",4)))
@@ -288,7 +286,7 @@ namespace OpenBabel
       return(false);
     }
 
-    resdat.AssignBonds(mol,bs);
+    resdat.AssignBonds(mol);
     /*assign hetatm bonds based on distance*/
 
     mol.EndModify();

--- a/src/formats/pqrformat.cpp
+++ b/src/formats/pqrformat.cpp
@@ -97,7 +97,6 @@ namespace OpenBabel
 
     int chainNum = 1;
     char buffer[BUFF_SIZE];
-    OBBitVec bs;
     vector<double> charges, radii;
     string line, key, value;
 
@@ -128,9 +127,6 @@ namespace OpenBabel
                 obErrorLog.ThrowError(__FUNCTION__, errorMsg.str() , obError);
               }
 
-            if (EQn(buffer,"ATOM",4))
-              bs.SetBitOn(mol.NumAtoms());
-
             // Read in the partial charge and radius too
             charges.push_back( parseAtomCharge(buffer, mol) );
             radii.push_back( parseAtomRadius(buffer, mol) );
@@ -144,7 +140,7 @@ namespace OpenBabel
     }
 
     // Use residue definitions to assign bond orders
-    resdat.AssignBonds(mol,bs);
+    resdat.AssignBonds(mol);
 
     mol.EndModify();
 

--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -239,7 +239,7 @@ namespace OpenBabel
     _bgn(0), _end(0), _ord(0), _stereo(0)
   {  }
 
-  OBVirtualBond::OBVirtualBond(int bgn,int end,int ord,int stereo):
+  OBVirtualBond::OBVirtualBond(unsigned int bgn, unsigned int end, unsigned int ord, int stereo):
     OBGenericData("VirtualBondData", OBGenericDataType::VirtualBondData, perceived),
     _bgn(bgn), _end(end), _ord(ord), _stereo(stereo)
   {  }

--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -1458,13 +1458,11 @@ void OBDOSData::SetData(double fermi,
 
   // member functions for OBOrbitalData
 
-  void OBOrbitalData::LoadClosedShellOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, int alphaHOMO)
+  void OBOrbitalData::LoadClosedShellOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, unsigned int alphaHOMO)
   {
     if (energies.size() < symmetries.size())
       return; // something is very weird -- it's OK to pass no symmetries (we'll assume "A")
     if (energies.size() == 0)
-      return;
-    if (alphaHOMO <= 0)
       return;
     if (alphaHOMO > energies.size())
       return;
@@ -1491,13 +1489,11 @@ void OBDOSData::SetData(double fermi,
       }
   }
 
-  void OBOrbitalData::LoadAlphaOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, int alphaHOMO)
+  void OBOrbitalData::LoadAlphaOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, unsigned int alphaHOMO)
   {
     if (energies.size() < symmetries.size())
       return; // something is very weird -- it's OK to pass no symmetries (we'll assume "A")
     if (energies.size() == 0)
-      return;
-    if (alphaHOMO <= -1)
       return;
     if (alphaHOMO > energies.size())
       return;
@@ -1522,13 +1518,11 @@ void OBDOSData::SetData(double fermi,
       }
   }
 
-  void OBOrbitalData::LoadBetaOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, int betaHOMO)
+  void OBOrbitalData::LoadBetaOrbitals(std::vector<double> energies, std::vector<std::string> symmetries, unsigned int betaHOMO)
   {
     if (energies.size() < symmetries.size())
       return; // something is very weird -- it's OK to pass no symmetries (we'll assume "A")
     if (energies.size() == 0)
-      return;
-    if (betaHOMO <= -1)
       return;
     if (betaHOMO > energies.size())
       return;

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -367,7 +367,7 @@ namespace OpenBabel
       m_path.push_back(idx);
       needs_dbl_bond->SetBitOff(m_path[0]);
       // Flip all of the bond orders on the path from double<-->single
-      for (int i = 0; i < m_path.size()-1; ++i) {
+      for (unsigned int i = 0; i < m_path.size()-1; ++i) {
         OBBond *bond = m_mol->GetBond(m_path[i], m_path[i + 1]);
         if (i % 2 == 0)
           doubleBonds->SetBitOn(bond->GetIdx());

--- a/src/math/align.cpp
+++ b/src/math/align.cpp
@@ -397,7 +397,7 @@ namespace OpenBabel
       VectorsToMatrix(&target_coords, mtarget);
 
       // Subtract the centroid of the non-H atoms
-      for (vector<vector3>::size_type i=0; i<mtarget.cols(); ++i)
+      for (unsigned int i=0; i<mtarget.cols(); ++i)
         mtarget.col(i) -= _target_centr;
 
       // Rotate

--- a/src/math/spacegroup.cpp
+++ b/src/math/spacegroup.cpp
@@ -140,7 +140,7 @@ namespace OpenBabel
   }
 
   SpaceGroup::SpaceGroup():
-    m_HM(""),m_Hall(""),m_id(0),m_OriginAlternative(0), HEXAGONAL_ORIGIN(10)
+    HEXAGONAL_ORIGIN(10), m_HM(""),m_Hall(""),m_id(0),m_OriginAlternative(0)
   {
   }
 

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -1818,7 +1818,7 @@ namespace OpenBabel
     return(true);
   }
 
-  bool OBMol::StripSalts(int threshold)
+  bool OBMol::StripSalts(unsigned int threshold)
   {
     vector<vector<int> > cfl;
     vector<vector<int> >::iterator i,max;
@@ -2399,7 +2399,7 @@ namespace OpenBabel
   }
 
   // Used by DeleteAtom below. Code based on StereoRefToImplicit
-  const void DeleteStereoOnAtom(OBMol& mol, OBStereo::Ref atomId)
+  static void DeleteStereoOnAtom(OBMol& mol, OBStereo::Ref atomId)
   {
     std::vector<OBGenericData*> vdata = mol.GetAllData(OBGenericDataType::StereoData);
     for (std::vector<OBGenericData*>::iterator data = vdata.begin(); data != vdata.end(); ++data) {
@@ -3680,9 +3680,9 @@ namespace OpenBabel
 
   }
 
-  void OBMol::SetConformer(int i)
+  void OBMol::SetConformer(unsigned int i)
   {
-    if (i >= 0 && i < _vconf.size())
+    if (i < _vconf.size())
       _c = _vconf[i];
   }
 
@@ -3786,7 +3786,7 @@ namespace OpenBabel
         OBBondIterator bi;
         for (bestbond = bond = patom->BeginBond(bi); bond; bond = patom->NextBond(bi))
         {
-          int bo = bond->GetBO();
+          unsigned int bo = bond->GetBO();
           if(bo>=2 && bo<=4)
           {
             bool het = IsNotCorH(bond->GetNbrAtom(patom));
@@ -3857,7 +3857,7 @@ namespace OpenBabel
         int bi = 0;
         if (bonds.size() > 1) {
           vector<int> scores(bonds.size());
-          for (int n = 0; n < bonds.size(); n++) {
+          for (unsigned int n = 0; n < bonds.size(); n++) {
             OBAtom *bgn = bonds[n]->GetBeginAtom();
             OBAtom *end = bonds[n]->GetEndAtom();
             int score = 0;
@@ -3879,7 +3879,7 @@ namespace OpenBabel
             }
             scores[n] = score;
           }
-          for (int n = 1; n < scores.size(); n++) {
+          for (unsigned int n = 1; n < scores.size(); n++) {
             if (scores[n] < scores[bi]) {
               bi = n;
             }

--- a/src/obmolecformat.cpp
+++ b/src/obmolecformat.cpp
@@ -190,7 +190,7 @@ namespace OpenBabel
     if(pmol) {
       if(pConv->IsOption("writeconformers", OBConversion::GENOPTIONS)) {
         //The last conformer is written in the calling function
-        unsigned int c = 0;
+        int c = 0;
         for (; c < pmol->NumConformers()-1; ++c) {
           pmol->SetConformer(c);
           if(!pConv->GetOutFormat()->WriteMolecule(pmol, pConv))
@@ -421,10 +421,9 @@ namespace OpenBabel
 
     //Collect the molecules first, just for convenience
     vector<obsharedptr<OBMol> > mols;
-    unsigned i;
-    for(i=0;i<pReact->NumReactants();i++)
+    for(int i=0;i<pReact->NumReactants();i++)
       mols.push_back(pReact->GetReactant(i));
-    for(i=0;i<pReact->NumProducts();i++)
+    for(int i=0;i<pReact->NumProducts();i++)
       mols.push_back(pReact->GetProduct(i));
     for (i = 0; i<pReact->NumAgents(); i++)
       mols.push_back(pReact->GetAgent(i));
@@ -442,7 +441,7 @@ namespace OpenBabel
       mols.resize(1);
     }
     bool ok = true;
-    for(i=0;i<mols.size() && ok;++i)
+    for(unsigned int i=0;i<mols.size() && ok;++i)
     {
       if(mols[i])
       {

--- a/src/obmolecformat.cpp
+++ b/src/obmolecformat.cpp
@@ -425,7 +425,7 @@ namespace OpenBabel
       mols.push_back(pReact->GetReactant(i));
     for(int i=0;i<pReact->NumProducts();i++)
       mols.push_back(pReact->GetProduct(i));
-    for (i = 0; i<pReact->NumAgents(); i++)
+    for (int i = 0; i<pReact->NumAgents(); i++)
       mols.push_back(pReact->GetAgent(i));
 
     if(pReact->GetTransitionState())

--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -152,7 +152,6 @@ namespace OpenBabel
 #define BE_DOWNUNSPEC   16
 
 
-  static int GetVectorBinding();
   static int CreateAtom(Pattern*,AtomExpr*,int,int vb=0);
 
   const int SmartsImplicitRef = -9999; // Used as a placeholder when recording atom nbrs for chiral atoms
@@ -292,11 +291,6 @@ namespace OpenBabel
   {
     return flag ? BuildAtomLeaf(AE_AROMELEM,elem)
                 : BuildAtomLeaf(AE_ALIPHELEM,elem);
-  }
-
-  static int IsInvalidAtom( AtomExpr *expr )
-  {
-    return !expr || expr->type==AE_FALSE;
   }
 
   /*================================*/
@@ -1490,7 +1484,7 @@ namespace OpenBabel
 
                 CreateBond(pat,bexpr,prev,stat->closure[index]);
                 pat->atom[prev].nbrs.push_back(stat->closure[index]);
-                for (int nbr_idx=0; nbr_idx < pat->atom[stat->closure[index]].nbrs.size(); ++nbr_idx) {
+                for (unsigned int nbr_idx=0; nbr_idx < pat->atom[stat->closure[index]].nbrs.size(); ++nbr_idx) {
                   if (pat->atom[stat->closure[index]].nbrs[nbr_idx] == -index)
                     pat->atom[stat->closure[index]].nbrs[nbr_idx] = prev;
                 }
@@ -1712,45 +1706,6 @@ namespace OpenBabel
 
     return ParseSMARTSString(ptr);
   }
-
-  /*================================*/
-  /*  SMARTS Pattern simplification */
-  /*================================*/
-
-  static AtomExpr *NotAtomExpr( AtomExpr *expr )
-  {
-    AtomExpr *result;
-
-    switch (expr->type)
-      {
-      case AE_TRUE:
-        expr->type = AE_FALSE;
-        return expr;
-      case AE_FALSE:
-        expr->type = AE_TRUE;
-        return expr;
-      case AE_AROMATIC:
-        expr->type = AE_ALIPHATIC;
-        return expr;
-      case AE_ALIPHATIC:
-        expr->type = AE_AROMATIC;
-        return expr;
-      case AE_CYCLIC:
-        expr->type = AE_ACYCLIC;
-        return expr;
-      case AE_ACYCLIC:
-        expr->type = AE_CYCLIC;
-        return expr;
-      
-      case AE_NOT:
-        result = expr->mon.arg;
-        expr->mon.arg = (AtomExpr*)0;
-        FreeAtomExpr(expr);
-        return result;
-      }
-    return BuildAtomNot(expr);
-  }
-
 
   //**********************************
   //********Pattern Matching**********

--- a/src/rotor.cpp
+++ b/src/rotor.cpp
@@ -253,7 +253,7 @@ namespace OpenBabel
           this_side = end; other_side = begin;
         }
 
-        for (int hyb=2; hyb<=3; ++hyb) { // sp2 and sp3 carbons, with explicit Hs
+        for (unsigned int hyb=2; hyb<=3; ++hyb) { // sp2 and sp3 carbons, with explicit Hs
           if (this_side->GetAtomicNum() == 6 && this_side->GetHyb() == hyb && this_side->GetValence() == (hyb + 1) ) {
             syms.clear();
             FOR_NBORS_OF_ATOM(nbr, this_side) {
@@ -484,7 +484,7 @@ namespace OpenBabel
   {
   }
 
-  void OBRotor::SetRings(OBBond *bond)
+  void OBRotor::SetRings()
   {
     _rings.clear();
     if (_bond == NULL)

--- a/src/spectrophore.cpp
+++ b/src/spectrophore.cpp
@@ -30,13 +30,13 @@ namespace OpenBabel
 
 OBSpectrophore::OBSpectrophore(void)
 :  _resolution(3.0)
-,  _beginProbe(0)
-,  _endProbe(0)
-,  _numberOfProbes(0)
 ,  _property(NULL)
 ,  _radii(NULL)
 ,  _oricoor(NULL)
 ,  _coor(NULL)
+,  _beginProbe(0)
+,  _endProbe(0)
+,  _numberOfProbes(0)
 {
    SetAccuracy(OBSpectrophore::AngStepSize20);
    SetStereo(OBSpectrophore::NoStereoSpecificProbes);
@@ -47,14 +47,14 @@ OBSpectrophore::OBSpectrophore(void)
 
 OBSpectrophore::OBSpectrophore(const OBSpectrophore& s)
 :  _resolution(s._resolution)
-,  _beginProbe(s._beginProbe)
-,  _endProbe(s._endProbe)
-,  _numberOfProbes(s._numberOfProbes)
-,  _spectro(s._spectro)
 ,  _property(NULL)
 ,  _radii(NULL)
 ,  _oricoor(NULL)
 ,  _coor(NULL)
+,  _beginProbe(s._beginProbe)
+,  _endProbe(s._endProbe)
+,  _numberOfProbes(s._numberOfProbes)
+,  _spectro(s._spectro)
 {
    SetAccuracy(s.GetAccuracy());
    SetStereo(s.GetStereo());
@@ -1885,14 +1885,12 @@ OBSpectrophore::_luDecompose(double** A, std::vector<int>& I, unsigned int dim)
 void
 OBSpectrophore::_luSolve(double** A, std::vector<int>& I, double* B, unsigned int dim)
 {
-   unsigned int i, k;
-
-   for (i = 0; i < dim; ++i) _swapRows(B, i, I[i]);
+   for (unsigned int i = 0; i < dim; ++i) _swapRows(B, i, I[i]);
 
    // forward substitution pass
-   for (k = 0; k < dim; ++k)
+   for (unsigned int k = 0; k < dim; ++k)
    {
-      for (i = k+1; i < dim; ++i)
+      for (unsigned int i = k+1; i < dim; ++i)
       {
          B[i] -= A[i][k] * B[k];
       }
@@ -1902,7 +1900,7 @@ OBSpectrophore::_luSolve(double** A, std::vector<int>& I, double* B, unsigned in
    for (int i = dim - 1; i >= 0; --i)
    {
       B[i] /= A[i][i];
-      for (k = 0; k < i; ++k)
+      for (int k = 0; k < i; ++k)
       {
          B[k] -= A[k][i] * B[i];
       }

--- a/src/stereo/stereo.cpp
+++ b/src/stereo/stereo.cpp
@@ -72,22 +72,22 @@ namespace OpenBabel {
     return sum;
   }
 
-  void OBStereo::Permutate(OBStereo::Refs &refs, int i, int j)
+  void OBStereo::Permutate(OBStereo::Refs &refs, unsigned int i, unsigned int j)
   {
-    if (i < 0 || i >= refs.size())
+    if (i >= refs.size())
       return;
-    if (j < 0 || j >= refs.size())
+    if (j >= refs.size())
       return;
     unsigned long id = refs.at(i);
     refs[i] = refs.at(j);
     refs[j] = id;
   }
 
-  OBStereo::Refs OBStereo::Permutated(const OBStereo::Refs &refs, int i, int j)
+  OBStereo::Refs OBStereo::Permutated(const OBStereo::Refs &refs, unsigned int i, unsigned int j)
   {
-    if (i < 0 || i >= refs.size())
+    if (i >= refs.size())
       return refs;
-    if (j < 0 || j >= refs.size())
+    if (j >= refs.size())
       return refs;
     OBStereo::Refs result(refs);
     result[i] = refs.at(j);

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -198,7 +198,7 @@ namespace OpenBabel
           //number of atoms in the pattern (passed as a string in the option text)
           //has to be the same as in the molecule.
           itr2 = pOptions->find("exactmatch");
-          if(itr2!=pOptions->end() && NumHvyAtoms()!=atoi(itr2->second.c_str()))
+          if(itr2!=pOptions->end() && (int)NumHvyAtoms()!=atoi(itr2->second.c_str()))
             fmatch=false;
           else
             {

--- a/src/typer.cpp
+++ b/src/typer.cpp
@@ -638,28 +638,8 @@ namespace OpenBabel
     \code
     atom->IsAromatic();
     bond->IsAromatic();
-    bond->IsDouble(); // needs to check aromaticity and define Kekule structures
     \endcode
   */
-  OBAromaticTyper::OBAromaticTyper()
-  {
-    _init = true;
-    // The following values are no longer used by this class
-    _dir = BABEL_DATADIR;
-    _envvar = "BABEL_DATADIR";
-    _filename = "aromatic.txt";
-    _subdir = "data";
-    _dataptr = (const char*)0;
-  }
-
-  void OBAromaticTyper::ParseLine(const char *buffer)
-  {
-     // This function is no longer used by this class
-  }
-
-  OBAromaticTyper::~OBAromaticTyper()
-  {
-  }
 
   void OBAromaticTyper::AssignAromaticFlags(OBMol &mol)
   {

--- a/src/zipstreamimpl.h
+++ b/src/zipstreamimpl.h
@@ -398,7 +398,6 @@ std::streampos
   // We can't really randomly skip around, so we go to the beginning and read until we hit the right spot
   // So the first step is to calculate the final positioning
   std::streampos finalpos;
-  char ch;
   switch ( way )
     {
     case std::ios_base::beg :
@@ -408,7 +407,7 @@ std::streampos
     case std::ios_base::end:
       // find the end of the file -- might be enough if off = 0
       while(this->sgetc() != EOF) {
-        ch = this->sbumpc();
+        this->sbumpc();
       }
       finalpos = this->currentpos() + off;
       if (off == 0)
@@ -433,7 +432,7 @@ std::streampos
 
   // Now we keep going, throwing away the data until we get to the right place
   while(this->sgetc() != EOF && this->currentpos() != finalpos) {
-    ch = this->sbumpc();
+    this->sbumpc();
   }
 
   return this->currentpos();
@@ -453,9 +452,8 @@ std::streampos
   this->check_header();
 
   // Now we keep going, throwing away the data until we get to the right place
-  char ch;
   while(this->sgetc() != EOF && this->currentpos() != sp) {
-    ch = this->sbumpc();
+    this->sbumpc();
   }
 
   return this->currentpos();


### PR DESCRIPTION
Here are a bunch of commits to fix warnings observed in the core API source files. These warnings are found with -DCMAKE_CXX_FLAGS="-W -Wall". There are still more warnings in other files, but this is a first pass.

Most of these warnings are harmless and relate to signed/unsigned. Here and there I've made a minor mod to the API where a parameter should have been unsigned int in the first place, rather than int, but I don't think there should be anything much controversial in here.

I note in passing that some of the other warnings I've yet to tackle are actual bugs, so it's a useful exercise, especially if we can squash them all and turn on -Werror in Travis.