### PR TITLE
Gaussformat reading electrostatic potentials

### DIFF
--- a/include/openbabel/generic.h
+++ b/include/openbabel/generic.h
@@ -1177,6 +1177,8 @@ namespace OpenBabel
       ++i;
       return((i == _points.end()) ? (OBFreeGridPoint*)NULL : (OBFreeGridPoint*)*i);
     }
+    
+    void Clear();
 
   };
 

--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -1644,11 +1644,7 @@ unsigned int OBVibrationData::GetNumberOfFrequencies() const
 
 void OBFreeGrid::Clear()
 {
-    //for(OBFreeGridPointIterator point = _points.begin(); point != _points.end(); ++point)
-    //{
-    //    delete *point;	//deallocate old points to prevent memory leak
-    //}
-    _points.clear();
+  _points.clear();
 }
 
 } //end namespace OpenBabel

--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -1642,6 +1642,15 @@ unsigned int OBVibrationData::GetNumberOfFrequencies() const
   return this->_vFrequencies.size();
 }
 
+void OBFreeGrid::Clear()
+{
+    //for(OBFreeGridPointIterator point = _points.begin(); point != _points.end(); ++point)
+    //{
+    //    delete *point;	//deallocate old points to prevent memory leak
+    //}
+    _points.clear();
+}
+
 } //end namespace OpenBabel
 
 //! \file generic.cpp


### PR DESCRIPTION
ESP is calculated once unless the Opt and Pop jobs are combined. In this case, ESP is calculated once before the geometry optmization and once after. If this happens, the second ESP must be added to OBMol. 