### PR TITLE
Fix warning in fastsearch substructure fingerprint screen

### DIFF
--- a/src/fingerprint.cpp
+++ b/src/fingerprint.cpp
@@ -155,19 +155,23 @@ namespace OpenBabel
     unsigned int* ppat0 = &vecwords[0];
     unsigned int* p;
     unsigned int* ppat;
-    unsigned int a;
     unsigned int i;
     for(i=0;i<dataSize; ++i) //speed critical section
       {
         p=nextp;
         nextp += words;
         ppat=ppat0;
-        a=0;
+        bool ppat_has_additional_bits = false;
         while(p<nextp)
           {
-            if ( (a=((*ppat) & (*p++)) ^ (*ppat++)) ) break;
+            if ((*ppat & *p) ^ *ppat) { // any bits in ppat that are not in p?
+              ppat_has_additional_bits = true;
+              break;
+            }
+            p++;
+            ppat++;
           }
-        if(!a)
+        if(!ppat_has_additional_bits)
           {
             candidates.push_back(i);
             if(candidates.size()>=MaxCandidates)


### PR DESCRIPTION
This was a bug found by the gcc warnings. It's the same as the one that bit me in #1723. In the expression:
```
if ( (a=((*ppat) & (*p++)) ^ (*ppat++)) ) break;
```
...the order of evaluation of *ppat and *ppat++ is undefined. Which means that our fingerprint screen may not have been working as intended for some users who compiled it (though I'm not aware of any complaints).

Actually, the rewrite should be slightly faster as the break now occurs before ppat and p are incremented.