### PR TITLE
Fix #1684

### DIFF
--- a/src/descriptor.cpp
+++ b/src/descriptor.cpp
@@ -266,7 +266,7 @@ double OBDescriptor::ParsePredicate(istream& optionText, char& ch1, char& ch2, s
   streampos spos = optionText.tellg();
   optionText >> val;
    //only a number when the param has no additional text or only a closing bracket
-  if(!optionText.eof() && isalpha(optionText.peek()))
+  if(!optionText.eof() && (optionText.fail() || isalpha(optionText.peek())))
     val = std::numeric_limits<double>::quiet_NaN();
   optionText.clear();
   optionText.seekg(spos);


### PR DESCRIPTION
When figuring out if a filter value is numeric by casting to double, Mac and Linux
set the failbit if the cast cannot be done, so peek returns -1. This checks for
said failbit.

Note, in 1684, the current code appears to work for Noel, so behavior on windows may be different.