### PR TITLE
Solving #1569

### DIFF
--- a/src/formats/hinformat.cpp
+++ b/src/formats/hinformat.cpp
@@ -135,9 +135,17 @@ namespace OpenBabel
       }
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    // blank lines cleaning codes rewritten for avoiding peek() and tellg() bugs
+    // https://github.com/openbabel/openbabel/issues/1569
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && ipos != EOF);
+    ifs.seekg(ipos);
+
 
     mol.EndModify();
 

--- a/src/formats/hinformat.cpp
+++ b/src/formats/hinformat.cpp
@@ -143,7 +143,7 @@ namespace OpenBabel
       ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
     }
-    while(strlen(buffer) == 0 && ipos != EOF);
+    while(strlen(buffer) == 0 && !ifs.eof() );
     ifs.seekg(ipos);
 
 


### PR DESCRIPTION
I just found that the position of ifs.peek() is moved 1 character forward after ifs.tellg() called. And that's  the reason of issue #1569. Therefore I rewrote tail blank line removing codes to avoid use of ifs.peek().