### PR TITLE
Fix TESTDIR definition to allow space in path

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,8 +92,6 @@ foreach(origtest ${origtests})
   endif()
 endforeach()
 
-add_definitions(-DTESTDIR="${CMAKE_CURRENT_SOURCE_DIR}")
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 create_test_sourcelist(srclist test_runner.cpp
                        ${cpptestsrc})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -92,7 +92,7 @@ foreach(origtest ${origtests})
   endif()
 endforeach()
 
-add_definitions(-DTESTDIR=${CMAKE_CURRENT_SOURCE_DIR})
+add_definitions(-DTESTDIR="${CMAKE_CURRENT_SOURCE_DIR}")
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 create_test_sourcelist(srclist test_runner.cpp


### PR DESCRIPTION
I'm not sure where this definition is even used? But this change appears to be necessary to compile when there is whitespace in the path to the Open Babel source directory.