### PR TITLE
Fix regression. Ensure that asterisk is unbracketed when writing a SMILES string

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -1753,7 +1753,7 @@ namespace OpenBabel {
 
     if (charge) {
       atom->SetFormalCharge(charge);
-      if (abs(charge) > 10 || charge > element) { // if the charge is +/- 10 or more than the number of electrons
+      if (abs(charge) > 10 || (element && charge > element)) { // if the charge is +/- 10 or more than the number of electrons
         errorMsg << "Atom " << atom->GetIdx() << " had an unrealistic charge of " << charge 
                  << "." << endl;
         obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
@@ -2613,13 +2613,19 @@ namespace OpenBabel {
     else {
       numImplicitHs = atom->GetImplicitHCount() + numExplicitHsToSuppress;
       if (!bracketElement) {
-        int bosum = atom->BOSum() - numExplicitHsToSuppress;
-        unsigned int implicitValence = SmilesValence(element, bosum, false);
-        unsigned int defaultNumImplicitHs = implicitValence - bosum;
-        if (implicitValence == 0 // hypervalent
-           ||  numImplicitHs != defaultNumImplicitHs // undervalent
-           || (!options.kekulesmi && element != 6 && atom->IsAromatic() && numImplicitHs != 0) ) // aromatic nitrogen/phosphorus
-          bracketElement = true;
+        if (element == 0) { // asterisk is always hypervalent but we don't bracket it unless has Hs
+          if (numImplicitHs > 0)
+            bracketElement = true;
+        }
+        else {
+          int bosum = atom->BOSum() - numExplicitHsToSuppress;
+          unsigned int implicitValence = SmilesValence(element, bosum, false);
+          unsigned int defaultNumImplicitHs = implicitValence - bosum;
+          if (implicitValence == 0 // hypervalent
+             ||  numImplicitHs != defaultNumImplicitHs // undervalent
+             || (!options.kekulesmi && element != 6 && atom->IsAromatic() && numImplicitHs != 0) ) // aromatic nitrogen/phosphorus
+            bracketElement = true;
+        }
       }
     }
 

--- a/src/formats/smilesvalence.h
+++ b/src/formats/smilesvalence.h
@@ -19,6 +19,7 @@ GNU General Public License for more details.
 static bool IsOutsideOrganicSubset(unsigned int elem)
 {
   switch (elem) {
+  case  0: // *
   case  5: // B
   case  6: // C
   case  7: // N

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -54,6 +54,22 @@ class PybelWrapper(PythonBindings):
 
 class TestSuite(PythonBindings):
 
+    def testAsterisk(self):
+        """Ensure that asterisk in SMILES is bracketed when needed
+        and not otherwise"""
+        smis = [ # these don't need brackets for *
+                "*", "*C", "C*C",
+                # these do need brackets for *
+                "[*+]", "[*-]", "[*H]",
+                "*[H]", # this one is written as [*H]
+                "[1*]", "[*@@](F)(Cl)(Br)I", "[*:1]"]
+
+        for smi in smis:
+            needsbracket = "[" in smi
+            roundtrip = pybel.readstring("smi", smi).write("smi", opt={"a":True})
+            hasbracket = "[" in roundtrip
+            self.assertEqual(hasbracket, needsbracket)
+
     def testSmilesAtomOrder(self):
         """Ensure that SMILES atom order is written correctly"""
         data = [("CC", "1 2"),
@@ -152,7 +168,7 @@ class TestSuite(PythonBindings):
         self.assertEqual("C1=CC=CC#C1", mol.write("smi").rstrip())
 
     def testSmilesParsingOfAllElements(self):
-        smi = "[*][H][He][Li][Be][B][C][N][O][F][Ne][Na][Mg][Al][Si][P][S][Cl][Ar][K][Ca][Sc][Ti][V][Cr][Mn][Fe][Co][Ni][Cu][Zn][Ga][Ge][As][Se][Br][Kr][Rb][Sr][Y][Zr][Nb][Mo][Tc][Ru][Rh][Pd][Ag][Cd][In][Sn][Sb][Te][I][Xe][Cs][Ba][La][Ce][Pr][Nd][Pm][Sm][Eu][Gd][Tb][Dy][Ho][Er][Tm][Yb][Lu][Hf][Ta][W][Re][Os][Ir][Pt][Au][Hg][Tl][Pb][Bi][Po][At][Rn][Fr][Ra][Ac][Th][Pa][U][Np][Pu][Am][Cm][Bk][Cf][Es][Fm][Md][No][Lr][Rf][Db][Sg][Bh][Hs][Mt][Ds][Rg][Cn][Nh][Fl][Mc][Lv][Ts][Og]"
+        smi = "*[H][He][Li][Be][B][C][N][O][F][Ne][Na][Mg][Al][Si][P][S][Cl][Ar][K][Ca][Sc][Ti][V][Cr][Mn][Fe][Co][Ni][Cu][Zn][Ga][Ge][As][Se][Br][Kr][Rb][Sr][Y][Zr][Nb][Mo][Tc][Ru][Rh][Pd][Ag][Cd][In][Sn][Sb][Te][I][Xe][Cs][Ba][La][Ce][Pr][Nd][Pm][Sm][Eu][Gd][Tb][Dy][Ho][Er][Tm][Yb][Lu][Hf][Ta][W][Re][Os][Ir][Pt][Au][Hg][Tl][Pb][Bi][Po][At][Rn][Fr][Ra][Ac][Th][Pa][U][Np][Pu][Am][Cm][Bk][Cf][Es][Fm][Md][No][Lr][Rf][Db][Sg][Bh][Hs][Mt][Ds][Rg][Cn][Nh][Fl][Mc][Lv][Ts][Og]"
         roundtrip = pybel.readstring("smi", smi).write("smi").rstrip()
         self.assertEqual(roundtrip, smi.replace("[O]", "O").replace("[S]", "S"))
         # aromatic


### PR DESCRIPTION
The original behavior of the toolkit is to write asterisk without brackets. This is the behavior of Daylight. The rewrite of the handling of implicit hydrogens caused them to be bracketed. 

This PR ensures returns to the original behavior, that asterisk is not bracketed unless necessary. This involved adding asterisk to the organic subset (with valence 0), and special-casing the handling of hypervalent "*" (as we now add square brackets around hypervalent atoms).

Also I got rid of a warning about unrealistic charge state for [*+] (triggered because the charge is greater than the atomic no).