### PR TITLE
Fix MSVC warning about type conversion

### DIFF
--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -1341,7 +1341,7 @@ namespace OpenBabel
 
     char num_rotors_to_permute, num_permutations;
     if (permute)
-      num_rotors_to_permute = std::min<size_t> (4, vrotors.size());
+      num_rotors_to_permute = (char)std::min<size_t> (4, vrotors.size());
     else
       num_rotors_to_permute = 1; // i.e. just use the original order
     num_permutations = factorial[num_rotors_to_permute];


### PR DESCRIPTION
MSVC was warning:
```
1>C:\Tools\openbabel\baoilleach\src\forcefield.cpp(1344): warning C4267: '=': conversion from 'size_t' to 'char', possible loss of data
```
I added a cast to a char, which in the context seems to be fine.