### PR TITLE
add Molecule.make2D function

### DIFF
--- a/scripts/python/examples/testpybel.py
+++ b/scripts/python/examples/testpybel.py
@@ -125,9 +125,10 @@ class TestToolkit(myTestCase):
 
     def testMake2D(self):
         """Test that 2D coordinate generation does something"""
-        mol = self.mols[0]
+        mol = self.mols[1]
         mol.make2D()
-        self.assertNotEqual(mol.atoms[3].coords, (0., 0., 0.))
+        self.assertNotEqual(mol.atoms[2].coords, (0., 0., 0.))
+        self.assertEqual(mol.atoms[2].coords[2], 0.)
 
     def testMake3D(self):
         """Test that 3D coordinate generation does something"""

--- a/scripts/python/examples/testpybel.py
+++ b/scripts/python/examples/testpybel.py
@@ -123,6 +123,12 @@ class TestToolkit(myTestCase):
         mol.localopt()
         self.assertNotEqual(mol.atoms[3].coords, (0., 0., 0.))
 
+    def testMake2D(self):
+        """Test that 2D coordinate generation does something"""
+        mol = self.mols[0]
+        mol.make2D()
+        self.assertNotEqual(mol.atoms[3].coords, (0., 0., 0.))
+
     def testMake3D(self):
         """Test that 3D coordinate generation does something"""
         mol = self.mols[0]
@@ -441,6 +447,10 @@ class TestCDK(TestToolkit):
 
     def testLocalOpt(self):
         """No local opt testing done"""
+        pass
+
+    def testMake2D(self):
+        """No 2D coordinate generation done"""
         pass
 
     def testMake3D(self):

--- a/scripts/python/pybel.py
+++ b/scripts/python/pybel.py
@@ -297,7 +297,7 @@ class Molecule(object):
     (refer to the Open Babel library documentation for more info).
 
     Methods:
-       addh(), calcfp(), calcdesc(), draw(), localopt(), make3D(),
+       addh(), calcfp(), calcdesc(), draw(), localopt(), make2D(), make3D()
        calccharges(), removeh(), write()
 
     The underlying Open Babel molecule can be accessed using the attribute:
@@ -573,6 +573,13 @@ class Molecule(object):
             return
         ff.SteepestDescent(steps)
         ff.GetCoordinates(self.OBMol)
+
+    def make2D(self):
+        """Generate 2D coordinates.
+
+        OASA is used for 2D coordinate generation.
+        """
+        _operations['gen2D'].Do(self.OBMol)
 
     def make3D(self, forcefield="mmff94", steps=50):
         """Generate 3D coordinates.

--- a/scripts/python/pybel.py
+++ b/scripts/python/pybel.py
@@ -575,10 +575,7 @@ class Molecule(object):
         ff.GetCoordinates(self.OBMol)
 
     def make2D(self):
-        """Generate 2D coordinates.
-
-        OASA is used for 2D coordinate generation.
-        """
+        """Generate 2D coordinates."""
         _operations['gen2D'].Do(self.OBMol)
 
     def make3D(self, forcefield="mmff94", steps=50):


### PR DESCRIPTION
I wanted to generate molfile with 2d coordinates from SMILES and I was not able to do it in a nice way using pybel.

The only option I had was doing something like this:

from pybel import _operations
_operations['gen2D'].Do(mol.OBMol)

I think that would be nicer to have a mol.make2D() function.
