### PR TITLE
Fix SMILES parsing fuzz test failures from AFL

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2058,21 +2058,22 @@ namespace OpenBabel {
         ChiralSearch = _tetrahedralMap.find(mol.GetAtom(bond->prev));
         if (ChiralSearch != _tetrahedralMap.end() && ChiralSearch->second != NULL) {
           int insertpos = bond->numConnections - 1;
-          if (insertpos < 0) {
+          switch(insertpos) {
+          case -1:
             if (ChiralSearch->second->from != OBStereo::NoRef)
               obErrorLog.ThrowError(__FUNCTION__, "Warning: Overwriting previous from reference id.", obWarning);
-
             (ChiralSearch->second)->from = mol.GetAtom(_prev)->GetId();
-            // cerr << "Adding " << mol.GetAtom(_prev)->GetId() << " at Config.from to " << ChiralSearch->second << endl;
-          } else {
+            break;
+          case 0: case 1: case 2:
             if (ChiralSearch->second->refs[insertpos] != OBStereo::NoRef)
               obErrorLog.ThrowError(__FUNCTION__, "Warning: Overwriting previously set reference id.", obWarning);
-
             (ChiralSearch->second)->refs[insertpos] = mol.GetAtom(_prev)->GetId();
-            // cerr << "Adding " << mol.GetAtom(_prev)->GetId() << " at "
-            //     << insertpos << " to " << ChiralSearch->second << endl;
+            break;
+          default:
+            obErrorLog.ThrowError(__FUNCTION__, "Warning: Tetrahedral stereo specified for atom with more than 4 connections.", obWarning);
+            break;
           }
-       }
+        }
 
         //CM ensure neither atoms in ring closure is a radical centre
         OBAtom* patom = mol.GetAtom(_prev);

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -442,10 +442,14 @@ namespace OpenBabel {
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9':
       case '%':  //ring open/close
+        if (_prev == 0)
+          return false;
         if (!ParseRingBond(mol))
           return false;
         break;
       case '&': //external bond
+        if (_prev == 0)
+          return false;
         if (!ParseExternalBond(mol))
           return false;
         break;
@@ -470,25 +474,39 @@ namespace OpenBabel {
         }
         break;
       case '-':
+        if (_prev == 0)
+          return false;
         _order = 1;
         break;
       case '=':
+        if (_prev == 0)
+          return false;
         _order = 2;
         break;
       case '#':
+        if (_prev == 0)
+          return false;
         _order = 3;
         break;
       case '$':
+        if (_prev == 0)
+          return false;
         _order = 4;
         break;
       case ':':
+        if (_prev == 0)
+          return false;
         _order = 0; // no-op
         break;
       case '/':
+        if (_prev == 0)
+          return false;
         _order = 1;
         _updown = BondDownChar;
         break;
       case '\\':
+        if (_prev == 0)
+          return false;
         _order = 1;
         _updown = BondUpChar;
         break;
@@ -2000,6 +2018,11 @@ namespace OpenBabel {
     int upDown, bondOrder;
     for (bond = _rclose.begin(); bond != _rclose.end(); ++bond) {
       if (bond->digit == digit) {
+        // Check for self-bonding, e.g. C11
+        if (bond->prev == _prev) {
+          obErrorLog.ThrowError(__FUNCTION__, "Invalid SMILES: Ring closures imply atom bonded to itself.", obWarning);
+          return false;
+        }
         upDown = (_updown > bond->updown) ? _updown : bond->updown;
         bondOrder = (_order > bond->order) ? _order : bond->order;
         // Check if this ring closure bond may be aromatic and set order accordingly

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -870,23 +870,23 @@ namespace OpenBabel {
     if (ChiralSearch != _squarePlanarMap.end() && ChiralSearch->second != NULL)
     {
       int insertpos = NumConnections(ChiralSearch->first) - 1;
-      if (insertpos < 0) {
+      switch(insertpos) {
+      case -1:
         if (ChiralSearch->second->refs[0] != OBStereo::NoRef)
           obErrorLog.ThrowError(__FUNCTION__, "Warning: Overwriting previous from reference id.", obWarning);
-
         (ChiralSearch->second)->refs[0] = id;
-        //cerr << "Adding " << id << " at Config.refs[0] to " << ChiralSearch->second << endl;
-      } else {
+        break;
+      case 0: case 1: case 2: case 3:
         if (ChiralSearch->second->refs[insertpos] != OBStereo::NoRef)
           obErrorLog.ThrowError(__FUNCTION__, "Warning: Overwriting previously set reference id.", obWarning);
-
         (ChiralSearch->second)->refs[insertpos] = id;
-        //cerr << "Adding " << id << " at " << insertpos << " to " << ChiralSearch->second << endl;
+        break;
+      default:
+        obErrorLog.ThrowError(__FUNCTION__, "Warning: Square planar stereo specified for atom with more than 4 connections.", obWarning);
+        break;
       }
     }
   }
-
-
 
   bool OBSmilesParser::ParseSimple(OBMol &mol)
   {

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -1675,7 +1675,7 @@ namespace OpenBabel {
           {
           case '@':
             _ptr++;
-            if (*_ptr == 'S') {
+            if (*_ptr == 'S' && _ptr[1] == 'P') { // @SP1/2/3
               // square planar atom found
               squarePlanarWatch = true;
               if (_squarePlanarMap.find(atom)==_squarePlanarMap.end()) // Prevent memory leak for malformed smiles (PR#3428432)
@@ -1683,12 +1683,17 @@ namespace OpenBabel {
               _squarePlanarMap[atom]->refs = OBStereo::Refs(4, OBStereo::NoRef);
               _squarePlanarMap[atom]->center = atom->GetId();
               _ptr += 2;
-              if (*_ptr == '1')
-                _squarePlanarMap[atom]->shape = OBStereo::ShapeU;
-              if (*_ptr == '2')
-                _squarePlanarMap[atom]->shape = OBStereo::Shape4;
-              if (*_ptr == '3')
-                _squarePlanarMap[atom]->shape = OBStereo::ShapeZ;
+              switch(*_ptr) {
+              case '1':
+                _squarePlanarMap[atom]->shape = OBStereo::ShapeU; break;
+              case '2':
+                _squarePlanarMap[atom]->shape = OBStereo::Shape4; break;
+              case '3':
+                _squarePlanarMap[atom]->shape = OBStereo::ShapeZ; break;
+              default:
+                obErrorLog.ThrowError(__FUNCTION__, "Square planar stereochemistry must be one of SP1, SP2 or SP3", obWarning);
+                return false;
+              }
             } else {
               // tetrahedral atom found
               chiralWatch=true;

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -101,6 +101,46 @@ class TestSuite(PythonBindings):
         mol.removeh()
         self.assertEqual(mol.write("smi", opt={"a":True}).rstrip(), "C[NH:2]")
 
+    def testSquarePlanar(self):
+        """Tighten up the parsing of SP stereochemistry in SMILES"""
+        good = [
+                "C[S@SP1](Cl)(Br)I",
+                "C[S@SP2](Cl)(Br)I",
+                "C[S@SP3](Cl)(Br)I",
+                ]
+        bad = [ # raises error
+                "C[S@SP0](Cl)(Br)I",
+                "C[S@SP4](Cl)(Br)I",
+                "C[S@@SP1](Cl)(Br)I",
+                "C[S@SP11](Cl)(Br)I",
+                "C[S@SO1](Cl)(Br)I",
+              ]
+        alsobad = [ # just a warning
+                "C[S@SP1](Cl)(Br)(F)I",
+                "C[S@SP1](Cl)(Br)(F)1CCCC1",
+                ]
+        for smi in good:
+            mol = pybel.readstring("smi", smi)
+            self.assertTrue(mol.OBMol.GetData(ob.StereoData))
+        for smi in bad:
+            self.assertRaises(IOError, pybel.readstring, "smi", smi)
+        for smi in alsobad:
+            mol = pybel.readstring("smi", smi)
+            self.assertTrue(mol.OBMol.GetData(ob.StereoData))
+
+    def testFuzzingTestCases(self):
+        """Ensure that fuzzing testcases do not cause crashes"""
+
+        # rejected as invalid smiles
+        smis = [r"\0", "&0", "=&",
+                "[H][S][S][S@S00]0[S][S@S00H](0[S@S00][S])0n"]
+        for smi in smis:
+            self.assertRaises(IOError, pybel.readstring, "smi", smi)
+
+        smis = ["c0C[C@H](B)00O0"] # warning and stereo ignored
+        for smi in smis:
+            pybel.readstring("smi", smi)
+
     def testImplicitCisDblBond(self):
         """Ensure that dbl bonds in rings of size 8 or less are always
         implicitly cis"""


### PR DESCRIPTION
I finally got the AFL fuzz tester to work. This was on Linux with a static build.  The build failed when linking the obabel executable, but works if you do it manually after removing the "-rdynamic" from the VERBOSE=1 output.

Anyway, I ran it for a while (-ismi -onul) and fixed the segfaults it found:
1. SMILES starting with a bond symbol
2. Self-bonding through ring closures
3. Square planar and tetrahedral stereo with 5 nbors (where the nbor might be described by a ring closure)

Anything that's a reaction SMILES also segfaults if read as smi (I rejected these SMILES when testing), but hopefully we can fix this as described in my enhancement proposal.

I also tightened up the parsing of square planar stereo so that only @SP1/2/3 are accepted.