### PR TITLE
Fix warning about size_t versus int cast

### DIFF
--- a/include/openbabel/generic.h
+++ b/include/openbabel/generic.h
@@ -1148,7 +1148,7 @@ namespace OpenBabel
 
     int NumPoints() 
     { 
-      return _points.size(); 
+      return (int)_points.size();
     }
     
     void AddPoint(double x,double y,double z, double V) 


### PR DESCRIPTION
On a 64-bit system, size_t must be bigger than int. Here I've added an explicit cast which keeps the original behavior; an alternative would be to return size_t directly.