### PR TITLE
A small improvement of a bugfix solving segfault when reading GAMESS output with vibrations

### DIFF
--- a/src/formats/gamessformat.cpp
+++ b/src/formats/gamessformat.cpp
@@ -545,14 +545,12 @@ namespace OpenBabel {
 
         ifs.getline(buffer, BUFF_SIZE);
         tokenize(vs, buffer);
-        unsigned int modeCount = vs.size() - 3;
+        int modeCount = vs.size() - 3;
         double massNormalization;
         vector<double> x, y, z;
         while (modeCount >= 1) {
           // 1/sqrt(atomic mass)
           atom = mol.GetAtom(atoi(vs[0].c_str()));
-          if (!atom)
-            break; // something is very wrong
           massNormalization = 1 / sqrt( atom->GetAtomicMass() );
 
           x.clear();


### PR DESCRIPTION
This pull request is related to issue #1298 on which I have commented. The segfault was caused by line with symmetry of the mode like this one:
>       FREQUENCY:         2.93        1.88        0.55        0.35        0.16
>       SYMMETRY:          E           E           E           E           E
>       REDUCED MASS:      6.79503     6.40438    13.42881    10.66293     9.71937
The line was skipped by the program and the following loop did not read atoms correctly. The problem was apparently fixed in master, however fixing it exposes new segfault caused by the fact that `modeCount` variable is defined in line **548** as `unsigned int` and then used to leave the loop in lines **551-591**. At the end of loop there is a line
```
modeCount = vs.size() - 3;
```
For an empty vector the result (-3) is incorrectly casted to `unsigned int` and the condition in line **551**
```
while (modeCount >= 1) {
```
fails. This has been resolved in lines **554-555** like this:
```
if (!atom)
            break; // something is very wrong
```
My suggestion is to simply declare `modeCount` as `int`.