### PR TITLE
In the Python bindings, reset the DL open flags after importing _openbabel

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -82,9 +82,11 @@ if (DO_PYTHON_BINDINGS)
               COMMAND ${CMAKE_COMMAND} -E echo "import sys" > ob.py
               COMMAND ${CMAKE_COMMAND} -E echo "if sys.platform.find('linux'\) != -1:" >> ob.py
               COMMAND ${CMAKE_COMMAND} -E echo "  import ctypes" >> ob.py
+              COMMAND ${CMAKE_COMMAND} -E echo "  flags = sys.getdlopenflags()" >> ob.py
               COMMAND ${CMAKE_COMMAND} -E echo "  sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)" >> ob.py
-              COMMAND cat ${openbabel_SOURCE_DIR}/scripts/python/openbabel.py >> ob.py
-              COMMAND ${CMAKE_COMMAND} -E copy ob.py ${openbabel_SOURCE_DIR}/scripts/python/openbabel.py
+              COMMAND ${CMAKE_COMMAND} -E echo "  OBPlugin.LoadAllPlugins()" >> ob.py
+              COMMAND ${CMAKE_COMMAND} -E echo "  sys.setdlopenflags(flags)" >> ob.py
+              COMMAND cat ob.py >> ${openbabel_SOURCE_DIR}/scripts/python/openbabel.py
               COMMAND ${CMAKE_COMMAND} -E remove ob.py
               MAIN_DEPENDENCY openbabel-python.i
               VERBATIM

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -79,15 +79,6 @@ if (DO_PYTHON_BINDINGS)
       else(WIN32)
         add_custom_command(OUTPUT ${openbabel_SOURCE_DIR}/scripts/python/openbabel-python.cpp ${openbabel_SOURCE_DIR}/scripts/python/openbabel.py
             COMMAND ${SWIG_EXECUTABLE} -python -c++ -small -O -templatereduce -naturalvar -I${openbabel_SOURCE_DIR}/include -I${openbabel_BINARY_DIR}/include -o ${openbabel_SOURCE_DIR}/scripts/python/openbabel-python.cpp ${eigen_define} -outdir ${openbabel_SOURCE_DIR}/scripts/python ${openbabel_SOURCE_DIR}/scripts/openbabel-python.i
-              COMMAND ${CMAKE_COMMAND} -E echo "import sys" > ob.py
-              COMMAND ${CMAKE_COMMAND} -E echo "if sys.platform.find('linux'\) != -1:" >> ob.py
-              COMMAND ${CMAKE_COMMAND} -E echo "  import ctypes" >> ob.py
-              COMMAND ${CMAKE_COMMAND} -E echo "  flags = sys.getdlopenflags()" >> ob.py
-              COMMAND ${CMAKE_COMMAND} -E echo "  sys.setdlopenflags(sys.getdlopenflags() | ctypes.RTLD_GLOBAL)" >> ob.py
-              COMMAND ${CMAKE_COMMAND} -E echo "  OBPlugin.LoadAllPlugins()" >> ob.py
-              COMMAND ${CMAKE_COMMAND} -E echo "  sys.setdlopenflags(flags)" >> ob.py
-              COMMAND cat ob.py >> ${openbabel_SOURCE_DIR}/scripts/python/openbabel.py
-              COMMAND ${CMAKE_COMMAND} -E remove ob.py
               MAIN_DEPENDENCY openbabel-python.i
               VERBATIM
               )

--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -64,6 +64,21 @@
 #include <openbabel/stereo/squareplanar.h>
 #include <openbabel/stereo/bindings.h>
 %}
+
+// Set and reset dlopenflags so that plugin loading works fine for "import _openbabel"
+%pythonbegin %{
+import sys
+if sys.platform.find("linux") != -1:
+    dlflags = sys.getdlopenflags()
+    import ctypes
+    sys.setdlopenflags(dlflags | ctypes.RTLD_GLOBAL)
+%}
+%pythoncode %{
+if sys.platform.find("linux") != -1:
+    sys.setdlopenflags(dlflags)
+%}
+
+
 // Ignore methods that require std::vector of OBAtom.
 %ignore OpenBabel::OBMol::FindChildren(std::vector< OBAtom * > &, OBAtom *, OBAtom *);
 %ignore OpenBabel::OBResidue::GetAtoms;


### PR DESCRIPTION
Should have fixed this a long time ago. The DL flags kludge was needed for some platforms or else the plugins didn't load. I can't say whether it's still needed but at least now the code resets the flag value after forcing the plugins to load with OBPlugin::LoadAllPlugins().

I believe this fixes #917, #1222, and #1702. I can't reproduce the original problems though.