### PR TITLE
fix cdxml stereo bonds

### DIFF
--- a/src/formats/xml/cdxmlformat.cpp
+++ b/src/formats/xml/cdxmlformat.cpp
@@ -371,7 +371,7 @@ bool ChemDrawXMLFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
     if (pbond->IsHash())
       xmlTextWriterWriteFormatAttribute(writer(), C_DISPLAY , "WedgeBegin");
     else if (pbond->IsWedge())
-      xmlTextWriterWriteFormatAttribute(writer(), C_DISPLAY , "WedgedHashEnd");
+      xmlTextWriterWriteFormatAttribute(writer(), C_DISPLAY , "WedgedHashBegin");
     xmlTextWriterEndElement(writer());
   }
   _offset += mol.NumAtoms ();


### PR DESCRIPTION
When converting from molfile to cdxml, stereo bonds conversion is in-correct.

This pull request fixes cdxml stereo bonds.

For example, `alanine.mol` is my source file; `alanine_ori.cdxml` is the conversion result from the current master; `alanine_fix.cdxml`  is the conversion result from the pull request.



[alanine.zip](https://github.com/openbabel/openbabel/files/1720262/alanine.zip)



