### PR TITLE
Kekulize hypervalent aromatic N and S

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -577,7 +577,7 @@ namespace OpenBabel {
         errorMsg << " (title is " << title << ")";
       errorMsg << endl;
       obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
-      // return false; Should we return false for a kekulization failure?
+      // return false; // Should we return false for a kekulization failure?
     }
 
     // Add the data stored inside the _tetrahedralMap to the atoms now after end

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -66,24 +66,17 @@ namespace OpenBabel
     return atom->GetImplicitHCount() + atom->GetValence();
   }
 
-  static bool IsSpecialCase(OBAtom* atom, OBAtom* nbr)
+  static bool IsSpecialCase(OBAtom* atom)
   {
-    switch (nbr->GetAtomicNum()) {
-    case 8:
-      switch(atom->GetAtomicNum()) {
-      case 7: // e.g. pyridine N-oxide as the double bond form
-        if (TotalNumberOfBonds(atom) == 3 && atom->GetFormalCharge() == 0)
-          return true;
-        break;
-      case 16: // e.g. BIOVIA's Cs1(=O)ccccn1
-        if (TotalNumberOfBonds(atom) == 4 && atom->GetFormalCharge() == 0)
-          return true;
-        break;
-      }
+    switch(atom->GetAtomicNum()) {
+    case 7:
+      // Any exo-cyclic double bond from a N
+      // e.g. pyridine N-oxide as the double bond form
+      if (TotalNumberOfBonds(atom) == 3 && atom->GetFormalCharge() == 0)
+        return true;
       break;
-    case 16:
-      // ?? TODO ??
-      if (TotalNumberOfBonds(atom) == 4)
+    case 16: // e.g. Cs1(=O)ccccn1
+      if (TotalNumberOfBonds(atom) == 4 && atom->GetFormalCharge() == 0)
         return true;
       break;
     }
@@ -103,7 +96,7 @@ namespace OpenBabel
       case 0: case 1:
         continue;
       case 2:
-        if (IsSpecialCase(atom, nbr))
+        if (IsSpecialCase(atom))
           return true;
         return false;
       default: // bond order > 2

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -70,10 +70,16 @@ namespace OpenBabel
   {
     switch (nbr->GetAtomicNum()) {
     case 8:
-      // e.g. pyridine N-oxide as the double bond form
-      if (atom->GetAtomicNum() == 7 && TotalNumberOfBonds(atom) == 3 &&
-          atom->GetFormalCharge() == 0)
-        return true;
+      switch(atom->GetAtomicNum()) {
+      case 7: // e.g. pyridine N-oxide as the double bond form
+        if (TotalNumberOfBonds(atom) == 3 && atom->GetFormalCharge() == 0)
+          return true;
+        break;
+      case 16: // e.g. BIOVIA's Cs1(=O)ccccn1
+        if (TotalNumberOfBonds(atom) == 4 && atom->GetFormalCharge() == 0)
+          return true;
+        break;
+      }
       break;
     case 16:
       // ?? TODO ??

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -172,11 +172,16 @@ class TestSuite(PythonBindings):
         roundtrip = pybel.readstring("smi", ringsmi).write("smi")
         self.assertTrue("/" in roundtrip)
 
-    def testKekulizationOfHypervalentS(self):
-        """Having a hypervalent S as aromatic is totally bogus, but
-        BIOVIA produces them and we should read them."""
-        mol = pybel.readstring("smi", "Cs1(=O)ccccn1")
-        self.assertEqual("CS1(=O)=NC=CC=C1", mol.write("smi").rstrip())
+    def testKekulizationOfHypervalents(self):
+        # We should support hypervalent aromatic S and N (the latter
+        # as we write them)
+        data = [("Cs1(=O)ccccn1",
+                 "CS1(=O)=NC=CC=C1"),
+                ("n1c2-c(c3cccc4cccc2c34)n(=N)c2ccccc12",
+                 "n1c2-c(c3cccc4cccc2c34)n(=N)c2ccccc12")]
+        for inp, out in data:
+            mol = pybel.readstring("smi", inp)
+            self.assertEqual(out, mol.write("smi").rstrip())
 
     def testKekulizationOfcn(self):
         """We were previously not reading 'cn' correctly, or at least how

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -172,6 +172,12 @@ class TestSuite(PythonBindings):
         roundtrip = pybel.readstring("smi", ringsmi).write("smi")
         self.assertTrue("/" in roundtrip)
 
+    def testKekulizationOfHypervalentS(self):
+        """Having a hypervalent S as aromatic is totally bogus, but
+        BIOVIA produces them and we should read them."""
+        mol = pybel.readstring("smi", "Cs1(=O)ccccn1")
+        self.assertEqual("CS1(=O)=NC=CC=C1", mol.write("smi").rstrip())
+
     def testKekulizationOfcn(self):
         """We were previously not reading 'cn' correctly, or at least how
         Daylight would"""


### PR DESCRIPTION
We should kekulize hypervalent N and S, especially as we write out the first one, and the second one occurs in SMILES strings generated by another toolkit.

This is a minor tidy-up based on the SMILES reading benchmark I put together.