### PR TITLE
Raise a warning when coordinate is NaN

### DIFF
--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -1188,6 +1188,17 @@ namespace OpenBabel
     mol.SetChiralityPerceived();
     mol.SetDimension(3);
 
+    bool isNanExist = false;
+    FOR_ATOMS_OF_MOL(a, mol) {
+      vector3 v = a->GetVector();
+      if(IsNan(v.x()) || IsNan(v.y()) || IsNan(v.z())) {
+          isNanExist = true;
+          break;
+       }
+    }
+    if(isNanExist)
+      obErrorLog.ThrowError(__FUNCTION__, "There exists NaN in calculated coordinates.", obWarning);
+
     return success;
   }
 


### PR DESCRIPTION
This pull request is related to #1662.

There is a case when the coordinates calculated by OBBuilder include NaN.
This PR raises a warning when there exists NaN in calculated coordinates.
This does not solve the issue completely, but raising a warning is necessary until it is fixed.

I show the result of the following code. 
```cpp
#include <iostream>
#include <string>
#include <sstream>

#include <openbabel/mol.h>
#include <openbabel/obconversion.h>
#include <openbabel/builder.h>

int main(int argc, char** argv){
  std::string smiles = "FCl(=O)=O";
  std::stringstream ss(smiles);
  OpenBabel::OBConversion conv(&ss, &std::cout);
  conv.SetInAndOutFormats("smi", "sdf");
  OpenBabel::OBMol mol;
  conv.Read(&mol);

  OpenBabel::OBBuilder builder;
  builder.Build(mol);

  conv.Write(&mol);
}
```
Current result:
```

 OpenBabel03161815293D

  4  3  0  0  0  0  0  0  0  0999 V2000
    1.0279    0.0888   -0.0365 F   0  0  0  0  0  0  0  0  0  0  0  0
    2.6179    0.0888   -0.0365 Cl  0  0  0  0  0  0  0  0  0  0  0  0
      -nan      -nan      -nan O   0  0  0  0  0  0  0  0  0  0  0  0
      -nan      -nan      -nan O   0  0  0  0  0  0  0  0  0  0  0  0
  1  2  1  0  0  0  0
  2  3  2  0  0  0  0
  2  4  2  0  0  0  0
M  END
$$$$
```

After merging this PR:
```
==============================
*** Open Babel Warning  in Build
  There exists NaN in calculated coordinates.

 OpenBabel03161815253D

  4  3  0  0  0  0  0  0  0  0999 V2000
    0.9442   -0.0573    0.0600 F   0  0  0  0  0  0  0  0  0  0  0  0
    2.5342   -0.0573    0.0600 Cl  0  0  0  0  0  0  0  0  0  0  0  0
      -nan      -nan      -nan O   0  0  0  0  0  0  0  0  0  0  0  0
      -nan      -nan      -nan O   0  0  0  0  0  0  0  0  0  0  0  0
  1  2  1  0  0  0  0
  2  3  2  0  0  0  0
  2  4  2  0  0  0  0
M  END
$$$$
```