### PR TITLE
Fix#1768: Segfault upon reading GAMESS outputs of DFTB3 calculations

### DIFF
--- a/src/formats/gamessformat.cpp
+++ b/src/formats/gamessformat.cpp
@@ -474,7 +474,10 @@ namespace OpenBabel {
         tokenize(vs, buffer);
         // atom number, atomic symbol, mulliken pop, charge
         while (vs.size() >= 4) {
-          atom = mol.GetAtom(atoi(vs[0].c_str()));
+          int atomNb = atoi(vs[0].c_str());
+          if (!atomNb)
+            break;
+          atom = mol.GetAtom(atomNb);
           atom->SetPartialCharge(atof(vs[3].c_str()));
 
           if (!ifs.getline(buffer, BUFF_SIZE))


### PR DESCRIPTION
See https://github.com/openbabel/openbabel/issues/1768#issuecomment-374051555
for bt and some explanations