### PR TITLE
Always ensure hybridization

### DIFF
--- a/src/typer.cpp
+++ b/src/typer.cpp
@@ -200,9 +200,25 @@ namespace OpenBabel
     }
 
     // check all atoms to make sure *some* hybridization is assigned
+    int valence;
     for (atom = mol.BeginAtom(k);atom;atom = mol.NextAtom(k))
-      if (atom->GetHyb() == 0)
-        atom->SetHyb(atom->GetValence());
+      if (atom->GetHyb() == 0) {
+        switch (atom->GetValence()) {
+          case 0:
+          case 1:
+          case 2:
+            atom->SetHyb(1);
+            break;
+          case 3:
+            atom->SetHyb(2);
+            break;
+          case 4:
+            atom->SetHyb(3);
+            break;
+          default:
+            atom->SetHyb(atom->GetValence());
+        }
+      }
   }
 
   /*! \class OBRingTyper typer.h <openbabel/typer.h>

--- a/src/typer.cpp
+++ b/src/typer.cpp
@@ -200,7 +200,6 @@ namespace OpenBabel
     }
 
     // check all atoms to make sure *some* hybridization is assigned
-    int valence;
     for (atom = mol.BeginAtom(k);atom;atom = mol.NextAtom(k))
       if (atom->GetHyb() == 0) {
         switch (atom->GetValence()) {

--- a/src/typer.cpp
+++ b/src/typer.cpp
@@ -198,6 +198,11 @@ namespace OpenBabel
           mol.GetAtom((*j)[0])->SetHyb(i->second);
       }
     }
+
+    // check all atoms to make sure *some* hybridization is assigned
+    for (atom = mol.BeginAtom(k);atom;atom = mol.NextAtom(k))
+      if (atom->GetHyb() == 0)
+        atom->SetHyb(atom->GetValence());
   }
 
   /*! \class OBRingTyper typer.h <openbabel/typer.h>
@@ -298,7 +303,7 @@ namespace OpenBabel
 
   // Start of helper functions for AssignOBAromaticityModel
   enum ExocyclicAtom { NO_EXOCYCLIC_ATOM, EXO_OXYGEN, EXO_NONOXYGEN };
-  
+
   static ExocyclicAtom FindExocyclicAtom(OBAtom *atm)
   {
     FOR_BONDS_OF_ATOM(bond, atm) {
@@ -326,7 +331,7 @@ namespace OpenBabel
     }
     return false;
   }
-  
+
   static bool HasExocyclicDblBondToOxygen(OBAtom *atm)
   {
     FOR_BONDS_OF_ATOM(bond, atm) {
@@ -549,7 +554,7 @@ namespace OpenBabel
 
     min = 0; max = 0; // nothing matched
     return false;
-  }  
+  }
 
   class OBAromaticTyperMolState
   {
@@ -600,7 +605,7 @@ namespace OpenBabel
     FOR_ATOMS_OF_MOL(atom, mol) {
       unsigned int idx = atom->GetIdx();
       _vpa[idx] = AssignOBAromaticityModel(&(*atom), _velec[idx].first, _velec[idx].second);
-    }    
+    }
 
     //propagate potentially aromatic atoms
     for (atom = mol.BeginAtom(i); atom; atom = mol.NextAtom(i))


### PR DESCRIPTION
This addresses the NaN occurring in OBBuilder (e.g., #1792)
because a hybridization might be 0 for a 'strange' atom, e.g.
FCl(=O)=O. As a fallback, assign a hybridization based on the
valence. Not sure it's ideal, but it's better than nothing.