### PR TITLE
Fix 1786 by changing the return value of OBResidue::GetNum()

### DIFF
--- a/include/openbabel/residue.h
+++ b/include/openbabel/residue.h
@@ -103,7 +103,7 @@ namespace OpenBabel {
     //! \return The residue name
     std::string    GetName(void)                  const;
     //! \return The residue number (in the sequence)
-    unsigned int    GetNum(void);
+    int    GetNum(void);
     std::string     GetNumString(void);
     //! \return The number of atoms in this residue
     unsigned int   GetNumAtoms()                  const;

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -359,12 +359,12 @@ namespace OpenBabel
             OBResidue *res  = (mol.NumResidues() > 0) ?
               mol.GetResidue(mol.NumResidues()-1) : NULL;
             if (res == NULL || res->GetName() != resname ||
-                static_cast<int>(res->GetNum()) != resnum)
+                res->GetNum() != resnum)
               {
                 vector<OBResidue*>::iterator ri;
                 for (res = mol.BeginResidue(ri) ; res ; res = mol.NextResidue(ri))
                   if (res->GetName() == resname &&
-                      static_cast<int>(res->GetNum()) == resnum)
+                      res->GetNum() == resnum)
                     break;
 
                 if (res == NULL)

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -851,7 +851,7 @@ namespace OpenBabel
       bool residue=false;
       string res_name="";
       string res_chain="";
-      unsigned int res_num=1;
+      int res_num=1;
       if (pConv->IsOption("s",OBConversion::OUTOPTIONS))
       {
         residue=true;

--- a/src/residue.cpp
+++ b/src/residue.cpp
@@ -1041,7 +1041,7 @@ _insertioncode=src._insertioncode;
     return _resnum;
   }
 
-  unsigned int OBResidue::GetNum(void)
+  int OBResidue::GetNum(void)
   {
     return atoi(_resnum.c_str());
   }


### PR DESCRIPTION
API change: return value changed from unsigned int to int to allow handling of potential negative values.