### PR TITLE
Apply fixes from Benoit Leblanc to address int/double type warnings.

### DIFF
--- a/include/openbabel/conformersearch.h
+++ b/include/openbabel/conformersearch.h
@@ -369,10 +369,10 @@ namespace OpenBabel {
       void SetNbNiches (int value) {nb_niches = value;}
       
       /* @brief Get niches radius, for dynamic niche sharing.*/
-      int GetNicheRadius () {return niche_radius;}
+      double GetNicheRadius () {return niche_radius;}
       
       /* @brief Set niches radius, for dynamic niche sharing.*/
-      void SetNicheRadius (int value) {niche_radius = value;}
+      void SetNicheRadius (double value) {niche_radius = value;}
       
       /* @brief Get the alpha sharing parameter */
       double GetAlphaSharing () {return alpha_share;}
@@ -448,9 +448,9 @@ namespace OpenBabel {
       OBRandom unique_generator; //!< A unique random number generator for the whole algo
       bool use_sharing;		//!< Wether to use sharing or not.
       double alpha_share;	//!< The alpha parameter in sharing function
-      int sigma_share;		//!< The sigma parameter in sharing function
+      double sigma_share;		//!< The sigma parameter in sharing function
       int nb_niches;		//!< The number of dynamic niches to be found
-      int niche_radius;		//!< A pre-determined niche radius, for dynamic niche sharing.
+      double niche_radius;		//!< A pre-determined niche radius, for dynamic niche sharing.
       double p_crossover;	//!< Crossover probability
       double niche_mating;	//!< Probability of forcing the second parent in the first parent
       int local_opt_rate;       //!< Perform a random local optimization every local_opt_rate generations. Disabled if set to 

--- a/src/conformersearch.cpp
+++ b/src/conformersearch.cpp
@@ -436,12 +436,12 @@ namespace OpenBabel {
     nb_niches = (m_rotorKeys.size()) / 10;
     if (nb_niches < 3)
       nb_niches = 3;
-    sigma_share = nb_rotors / 3;
-    if (sigma_share < 1)
-      sigma_share ++;
-    niche_radius =  nb_rotors / 4;
-    if (niche_radius < 1)
-      niche_radius++;
+    sigma_share = (double)nb_rotors / 3.0;
+    if (sigma_share < 1.0)
+      sigma_share = 1.0;
+    niche_radius =  (double)nb_rotors / 4.0;
+    if (niche_radius < 1.0)
+      niche_radius = 1.0;
 
     return true;
   }
@@ -1031,7 +1031,8 @@ namespace OpenBabel {
         for (iniche = 0; iniche < dynamic_niches.size (); iniche++)
           {
             j = dynamic_niches[iniche][0];
-            if (key_distance (m_rotorKeys[j], m_rotorKeys[i]) <= niche_radius)
+            dist = key_distance(m_rotorKeys[j], m_rotorKeys[i]);
+            if ((double)dist <= niche_radius)
               {
                 dynamic_niches[iniche].push_back (i);
                 break;
@@ -1051,7 +1052,7 @@ namespace OpenBabel {
                 for (j = 0; j < pop_size; j++)
                   {
                     dist = key_distance (m_rotorKeys[i], m_rotorKeys[j]);
-                    if (dist < sigma_share)
+                    if ((double)dist < sigma_share)
                       {
                         sh_ij = 1.0 - pow (((double) dist) / ((double ) sigma_share), alpha_share);
                         sh_count += sh_ij;


### PR DESCRIPTION
Fixes #1761. See #1761 for background and the fix. Essentially the variables niche_radius and sigma_share in the GA are both supposed to be doubles and this fixes that.