### PR TITLE
Add OBMol::CopySubstructure

### DIFF
--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -476,6 +476,11 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     std::vector<OBMol> Separate(int StartIndex=1);
     //! Iterative component of Separate to copy one fragment at a time
     bool GetNextFragment( OpenBabel::OBMolAtomDFSIter& iter, OBMol& newMol );
+    // docs in mol.cpp
+    bool CopySubstructure(OBMol& newmol, OBBitVec *includeatoms, OBBitVec *excludebonds = (OBBitVec*)0,
+      unsigned int correctvalence=1,
+      std::vector<unsigned int> *atomorder=(std::vector<unsigned int>*)0,
+      std::vector<unsigned int> *bondorder=(std::vector<unsigned int>*)0);
     //! Converts the charged form of coordinate bonds, e.g.[N+]([O-])=O to N(=O)=O
     bool ConvertDativeBonds();
     //! Converts 5-valent N and P only. Return true if conversion occurred.

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -3998,8 +3998,8 @@ namespace OpenBabel
   When an atom is copied, but not all of its bonds are, by default hydrogen counts are
   adjusted to account for the missing bonds. That is, given the SMILES "CF", if we
   copy the two atoms but exclude the bond, we will end up with "C.F". This behavior
-  can be changed by specifiying a value other than 1 for the \p option parameter.
-  A value of 0 will yield "[C].[F]" while 2 will yield "C*.F*" (see \p option below
+  can be changed by specifiying a value other than 1 for the \p correctvalence parameter.
+  A value of 0 will yield "[C].[F]" while 2 will yield "C*.F*" (see \p correctvalence below
   for more information).
 
   Aromaticity is preserved as present in the original OBMol. If this is not desired,

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -4043,7 +4043,8 @@ namespace OpenBabel
           -# Using the SMILES writer option -xf to specify fragment atom idxs
 
   \return A boolean indicating success or failure. Currently failure is only reported
-          if one of the specified atoms is not present.
+          if one of the specified atoms is not present, or \p atoms is a NULL
+          pointer.
 
   \param newmol   The molecule to which to add the substructure. Note that atoms are
                   appended to this molecule.
@@ -4233,11 +4234,9 @@ namespace OpenBabel
       bool skipping_bond = bonds_specified && excludebonds->BitIsOn(bond->GetIdx());
       map<OBAtom*, OBAtom*>::iterator posB = AtomMap.find(bond->GetBeginAtom());
       map<OBAtom*, OBAtom*>::iterator posE = AtomMap.find(bond->GetEndAtom());
-      if (posB == AtomMap.end() && posE == AtomMap.end()) {
-        if (bonds_specified)
-          return false;
+      if (posB == AtomMap.end() && posE == AtomMap.end())
         continue;
-      }
+
       if (posB == AtomMap.end() || posE == AtomMap.end() || skipping_bond) {
         switch(correctvalence) {
         case 1:

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -4011,7 +4011,7 @@ namespace OpenBabel
 
   Residue information is preserved if the original OBMol is marked as having
   its residues perceived. If this is not desired, either call
-  OBMol::UnsetChainsPerceived() in advance on the original OBMol to avoid copying
+  OBMol::SetChainsPerceived(false) in advance on the original OBMol to avoid copying
   the residues (and then reset it afterwards), or else call it on the new OBMol so
   that residue information will be reperceived (when requested).
 

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -4030,6 +4030,12 @@ namespace OpenBabel
   When used from Python, note that "None" may be used to specify an empty value for
   the \p excludebonds parameter.
 
+  \remark Some alternatives to using this function, which may be preferred in some
+          instances due to efficiency or convenience are:
+          -# Copying the entire OBMol, and then deleting the unwanted parts
+          -# Modifiying the original OBMol, and then restoring it
+          -# Using the SMILES writer option -xf to specify fragment atom idxs
+
   \return A boolean indicating success or failure. Currently failure is only reported
           if one of the specified atoms is not present.
 

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -610,12 +610,25 @@ class OBMolCopySubstructure(PythonBindings):
         nmol.Clear()
         mol.CopySubstructure(nmol, bv)
         self.assertEqual(len(list(ob.OBResidueIter(nmol))), 1)
+        pdb = pybel.Molecule(nmol).write("pdb")
+        atoms = [line for line in pdb.split("\n") if line.startswith("ATOM")]
+        self.assertEqual(len(atoms), 2)
+        self.assertTrue(atoms[0].startswith(cysN))
+        cysCa = "ATOM      2  CA  CYS A   2"
+        self.assertTrue(atoms[1].startswith(cysCa))
 
         # Copy the Ala C and Cys N
         bv = self.createBitVec(mol.NumAtoms() + 1, (3, 5))
         nmol.Clear()
         mol.CopySubstructure(nmol, bv)
         self.assertEqual(len(list(ob.OBResidueIter(nmol))), 2)
+        pdb = pybel.Molecule(nmol).write("pdb")
+        atoms = [line for line in pdb.split("\n") if line.startswith("ATOM")]
+        self.assertEqual(len(atoms), 2)
+        alaC = "ATOM      1  C   ALA A   1"
+        self.assertTrue(atoms[0].startswith(alaC))
+        cysN = "ATOM      2  N   CYS A   2"
+        self.assertTrue(atoms[1].startswith(cysN))
 
 class AtomClass(PythonBindings):
     """Tests to ensure that refactoring the atom class handling retains

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -485,6 +485,13 @@ class OBMolCopySubstructure(PythonBindings):
         self.assertTrue(ok)
         self.assertEqual(pybel.Molecule(nmol).write("smi").rstrip(), "[I].[Br].[CH2]")
 
+        mol = pybel.readstring("smi", "CCC")
+        bv = self.createBitVec(4, (1,))
+        bondv = self.createBitVec(2, (1,))
+        nmol = ob.OBMol()
+        ok = mol.OBMol.CopySubstructure(nmol, bv, bondv, 0)
+        self.assertTrue(ok)
+
     def testNonexistentAtom(self):
         mol = pybel.readstring("smi", "ICBr")
         bv = self.createBitVec(10, (9,))


### PR DESCRIPTION
Here is an implementation of OBMol::CopySubstructure. It copies a substructure of a molecule to another one, and has a bunch of optional parameters that hopefully cover every possible use case (or at least, make it possible for the user to do so). OBMol::NextFragment() already had some of this code; I've taken it out and expanded it, and now NextFragment() just calls this new function.

This is needed to implement reactions as OBMols - e.g. if someone wants reagent 1. Also, we really should have it in any case - I've missed it before, and it's not the sort of thing that's simple for the user to throw together. One use case is that it simplifies work with matched pairs, where you are chopping up molecules. 