### PR TITLE
Add OBMol::SetChainsPerceived(false)

### DIFF
--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -394,6 +394,8 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     void   SetFlags(int flags)       { _flags = flags;              }
 
     void   UnsetAromaticPerceived()  { _flags &= (~(OB_AROMATIC_MOL));   }
+    //! Mark that chains perception will need to be run again if required
+    void   UnsetChainsPerceived()    { _flags &= (~(OB_CHAINS_MOL));     }
     void   UnsetSSSRPerceived()  { _flags &= (~(OB_SSSR_MOL));   }
     //! Mark that Largest Set of Smallest Rings will need to be run again if required (see OBRing class)
     void   UnsetLSSRPerceived()  { _flags &= (~(OB_LSSR_MOL));   }

--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -378,7 +378,11 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     //! Mark that ring types have been perceived (see OBRingTyper for details)
     void   SetRingTypesPerceived()   { SetFlag(OB_RINGTYPES_MOL);   }
     //! Mark that chains and residues have been perceived (see OBChainsParser)
-    void   SetChainsPerceived()      { SetFlag(OB_CHAINS_MOL);      }
+    void   SetChainsPerceived(bool is_perceived=true)
+    {
+      if (is_perceived)      SetFlag(OB_CHAINS_MOL);
+      else                 UnsetFlag(OB_CHAINS_MOL);
+    }
     //! Mark that chirality has been perceived
     void   SetChiralityPerceived()   { SetFlag(OB_CHIRALITY_MOL);   }
     //! Mark that partial charges have been assigned
@@ -395,7 +399,6 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
 
     void   UnsetAromaticPerceived()  { _flags &= (~(OB_AROMATIC_MOL));   }
     //! Mark that chains perception will need to be run again if required
-    void   UnsetChainsPerceived()    { _flags &= (~(OB_CHAINS_MOL));     }
     void   UnsetSSSRPerceived()  { _flags &= (~(OB_SSSR_MOL));   }
     //! Mark that Largest Set of Smallest Rings will need to be run again if required (see OBRing class)
     void   UnsetLSSRPerceived()  { _flags &= (~(OB_LSSR_MOL));   }


### PR DESCRIPTION
Mark that chains perception will be required. Toggling this flag is useful if copying a portion of an OBMol with OBMol::CopySubstructure (see #1811).

Personally, I think that all of these perception get/set/has functions should be removed and replaced with an enum, so that it would be UnsetFlag(ChainsPerceived). Or at the least, don't have an unset function, instead have SetChainsPerceived(false). It's silly to have three functions for every bit in an int. In the meanwhile, here's another one...