### PR TITLE
Fix#1331: avoid crash with Q-Chem fragment

### DIFF
--- a/src/formats/qchemformat.cpp
+++ b/src/formats/qchemformat.cpp
@@ -13,6 +13,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 ***********************************************************************/
 #include <openbabel/babelconfig.h>
+#include <iostream>
 
 #include <openbabel/obmolecformat.h>
 
@@ -172,15 +173,23 @@ namespace OpenBabel
             ifs.getline(buffer,BUFF_SIZE);	// -----------------
             ifs.getline(buffer,BUFF_SIZE);
             tokenize(vs,buffer);
+            int nbAtomRead = 0;
             while (vs.size() >= 3)
               {
                 atom = mol.GetAtom(atoi(vs[0].c_str()));
-                atom->SetPartialCharge(atof(vs[2].c_str()));
-
+                ++nbAtomRead;
+                if (atom)
+                  atom->SetPartialCharge(atof(vs[2].c_str()));
                 if (!ifs.getline(buffer,BUFF_SIZE))
                   break;
                 tokenize(vs,buffer);
               }
+            if (nbAtomRead != mol.NumAtoms())
+            {
+              std::cerr << "Error: a Standard Nuclear Orientation paragraph contains " << mol.NumAtoms()
+                 << " whereas the following Mulliken paragraph contains " << nbAtomRead << " atoms\n";
+              return false;
+            }
           }
         else if (strstr(buffer, "ISOTROPIC") != NULL
                  && strstr(buffer, "ATOM") != NULL) // NMR summary


### PR DESCRIPTION
Test if an atom has been retrieved before calling SetPartialCharge
+ test if the number of atoms expected by Mulliken paragraph corresponds
to the number of atoms retrieved in the previous Standard Nuclear Orientation paragraph