### PR TITLE
Using pillow instead of PIL

### DIFF
--- a/scripts/python/pybel.py
+++ b/scripts/python/pybel.py
@@ -54,8 +54,8 @@ else:
     _obfuncs = _obconsts = ob
     try:
         import Tkinter as tk
-        import Image as PIL
-        import ImageTk as piltk
+        from PIL import Image as PIL
+        from PIL import ImageTk as piltk
     except ImportError:  # pragma: no cover
         tk = None
 


### PR DESCRIPTION
I'm using python2.7 and conda. Problem now: if i would install PIL (with conda), my versions of matplotlib and numpy would be downgaded. But for my project I need these new versions. I think the problem is that the latest version of PIL  is from 2009 and so there are these dependency problems.
I fixed that by using pillow (a PIL fork) instead of PIL. With pillow there are no dependency problems and so i can use the newest versions of matplotlib and pybel without to give up "the molecule drawing functionality".  :)