### PR TITLE
Get ECFP working

### DIFF
--- a/src/fingerprints/fingerecfp.cpp
+++ b/src/fingerprints/fingerecfp.cpp
@@ -174,7 +174,7 @@ static void ECFPPass(OpenBabel::OBMol &mol,
     if (atom->GetAtomicNum() == OBElements::Hydrogen)
       continue;
     OpenBabel::OBAtom* aptr = &(*atom);
-    unsigned int idx = aptr->GetIdx()-1;
+    unsigned int idx = aptr->GetIdx();
     AtomInfo *ptr = &ainfo[idx];
 
     std::vector<NborInfo> nbrs;
@@ -192,6 +192,7 @@ static void ECFPPass(OpenBabel::OBMol &mol,
       } else order = 4;
 
       unsigned int nidx = nptr->GetIdx();
+
       nbrs.push_back(NborInfo(order,ainfo[nidx].e[pass-1]));
       // for duplicate removal as described in paper (?)
       if (pass == 1)
@@ -221,7 +222,7 @@ static void ECFPFirstPass(OpenBabel::OBMol &mol,
     if (atom->GetAtomicNum() == OBElements::Hydrogen)
       continue;
     OpenBabel::OBAtom* aptr = &(*atom);
-    unsigned int idx = aptr->GetIdx()-1;
+    unsigned int idx = aptr->GetIdx();
     buffer[0] = aptr->GetHvyValence(); // degree of heavy atom connections
     buffer[1] = aptr->BOSum() - aptr->ExplicitHydrogenCount(); // valence of heavy atom connections
     buffer[2] = aptr->GetAtomicNum();
@@ -243,18 +244,18 @@ bool fingerprintECFP::GetFingerprint(OBBase* pOb, vector<unsigned int>&fp, int n
 	if (nbits <= 0)
 	  nbits = 4096;
 
-	fp.resize(nbits/Getbitsperint());
+  fp.resize(0); // clear without deallocating memory
+  fp.resize(nbits/Getbitsperint());
 	
   _ss.str("");
 
   unsigned int pass;
 
-  fp.clear();
-
   unsigned int count = pmol->NumAtoms();
   if (count == 0) return true;
 
-  AtomInfo *ainfo = new AtomInfo[count];
+  // Access this using the Atom::Idx()
+  AtomInfo *ainfo = new AtomInfo[count+1];
 
   ECFPFirstPass(*pmol,ainfo);
   for (pass=1; pass<= _radius; pass++)
@@ -264,7 +265,7 @@ bool fingerprintECFP::GetFingerprint(OBBase* pOb, vector<unsigned int>&fp, int n
   FOR_ATOMS_OF_MOL(atom, pmol) {
     if (atom->GetAtomicNum() == OBElements::Hydrogen)
       continue;    
-    unsigned int idx = atom->GetIdx()-1;
+    unsigned int idx = atom->GetIdx();
     for (pass=0; pass <= _radius; pass++) {
       unsigned int bit = (ainfo[idx].e[pass] % nbits) & 0x7fffffff; 
       SetBit(fp, bit);

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -94,6 +94,22 @@ class TestSuite(PythonBindings):
         mol.write("can")
         self.assertFalse("SMILES Atom Order" in mol.data)
 
+    def testECFP(self):
+        data = [
+                ("CC", 1, 2),
+                ("CCC", 2, 4),
+                ("CC(C)C", 2, 4),
+                ("CC(C)(C)C", 2, 4),
+                ]
+        for smi, numA, numB in data:
+            mol = pybel.readstring("smi", smi)
+            ecfp0 = mol.calcfp("ecfp0").bits
+            self.assertEqual(len(ecfp0), numA)
+            ecfp2 = mol.calcfp("ecfp2").bits
+            self.assertEqual(len(ecfp2), numB)
+            for bit in ecfp0:
+                self.assertTrue(bit in ecfp2)
+
     def testOBMolSeparatePreservesAromaticity(self):
         """If the original molecule had aromaticity perceived,
         then the fragments should also.


### PR DESCRIPTION
I fixed two problems:
- the fingerprint was being resized to 0 with an initial Clear() so nothing was returned.
- there was an off-by-one when using the atom Idx() to address AtomInfo. This was in the code to handle the nbrs, and lead to an out-of-bounds memory access (with random values sometimes appearing in the fingerprint).

As a general principle, rather than subtracting one from atom indices, we should just use them as provided, and instead increase the size of the referenced data structures by 1. This avoids this sort of error, where you remember to subtract 1 in one place but not another.