### PR TITLE
Fix to CopySubstructure found when running over ChEMBL

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -4187,7 +4187,10 @@ namespace OpenBabel
 
         // Check that the entirety of this tet cfg occurs in this substructure
         OBAtom *center = GetAtomById(cfg.center);
-        if (AtomMap.find(center) == AtomMap.end())
+        std::map<OBAtom*, OBAtom*>::iterator centerit = AtomMap.find(center);
+        if (centerit == AtomMap.end())
+          continue;
+        if (cfg.from != OBStereo::ImplicitRef && AtomMap.find(GetAtomById(cfg.from)) == AtomMap.end())
           continue;
         bool skip_cfg = false;
         if (bonds_specified) {
@@ -4211,7 +4214,7 @@ namespace OpenBabel
 
         OBTetrahedralStereo::Config newcfg;
         newcfg.specified = cfg.specified;
-        newcfg.center = AtomMap[GetAtomById(cfg.center)]->GetId();
+        newcfg.center = centerit->second->GetId();
         newcfg.from = cfg.from == OBStereo::ImplicitRef ? OBStereo::ImplicitRef : AtomMap[GetAtomById(cfg.from)]->GetId();
         OBStereo::Refs refs;
         for (OBStereo::RefIter ri = cfg.refs.begin(); ri != cfg.refs.end(); ++ri) {

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -572,6 +572,9 @@ class OBMolCopySubstructure(PythonBindings):
                     [((1, 2, 3), None, "C(Br)Cl"),
                     ((1, 2, 3, 4), (2,), "C(Br)Cl.I")]
                 ),
+                ("C[C@@H]1CO1",
+                    [((2, 3, 4), None, "C1CO1"),]
+                ),
                 ("F/C=C/I",
                     [
                      ((1, 2, 3, 4), None, "F/C=C/I"),


### PR DESCRIPTION
Should have found this earlier...

When deciding whether or not to copy a tet stereo, I neglected to check whether the 'from' atom was copied. As a result, when I later tried to use it, it wasn't there and a segfault occurred.