### PR TITLE
Allow public access to retrieve gradients

### DIFF
--- a/include/openbabel/forcefield.h
+++ b/include/openbabel/forcefield.h
@@ -503,21 +503,6 @@ namespace OpenBabel
       }
     }
 
-    /*! Get the pointer to the gradients
-     */
-    virtual vector3 GetGradient(OBAtom *a, int /*terms*/ = OBFF_ENERGY)
-    {
-      const int coordIdx = (a->GetIdx() - 1) * 3;
-      return _gradientPtr + coordIdx;
-    }
-
-    /*! Get the pointer to the gradients
-     */
-    double* GetGradientPtr()
-    {
-      return _gradientPtr;
-    }
-
     /*! Set all gradients to zero
      */
     virtual void ClearGradients()
@@ -880,6 +865,21 @@ namespace OpenBabel
       //_elepairs.SetRangeOn(0, _numpairs-1);
     }
     //@}
+
+    /*! Get the pointer to the gradients
+     */
+    virtual vector3 GetGradient(OBAtom *a, int /*terms*/ = OBFF_ENERGY)
+    {
+      const int coordIdx = (a->GetIdx() - 1) * 3;
+      return _gradientPtr + coordIdx;
+    }
+
+    /*! Get the pointer to the gradients
+     */
+    double* GetGradientPtr()
+    {
+      return _gradientPtr;
+    }
 
     /////////////////////////////////////////////////////////////////////////
     // Energy Evaluation                                                   //


### PR DESCRIPTION
Relocate GetGradientPtr() and GetGradient(atom) for public use, e.g., in Python:
https://gist.github.com/ghutchis/0ecd97aac76b1b3cf99d7113ffb9e376

```
    for atom in mol.atoms:
        # vector objects have to be de-referenced individually (sigh)
        grad = ff.GetGradient(atom.OBAtom)
        print(grad.GetX(), grad.GetY(), grad.GetZ(), sep=',')
```

