### PR TITLE
Re-enable vector.clear() to allow wrapped std::vectors to be reused

### DIFF
--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -107,7 +107,6 @@ namespace std {
 %feature("ignore") vector< vector<T> >::back;
 %feature("ignore") vector< vector<T> >::begin;
 %feature("ignore") vector< vector<T> >::capacity;
-%feature("ignore") vector< vector<T> >::clear;
 %feature("ignore") vector< vector<T> >::empty;
 %feature("ignore") vector< vector<T> >::end;
 %feature("ignore") vector< vector<T> >::erase;
@@ -132,7 +131,6 @@ namespace std {
 %feature("ignore") vector<T>::back;
 %feature("ignore") vector<T>::begin;
 %feature("ignore") vector<T>::capacity;
-%feature("ignore") vector<T>::clear;
 %feature("ignore") vector<T>::empty;
 %feature("ignore") vector<T>::end;
 %feature("ignore") vector<T>::erase;
@@ -157,7 +155,6 @@ namespace std {
 %feature("ignore") vector< pair<T1, T2> >::back;
 %feature("ignore") vector< pair<T1, T2> >::begin;
 %feature("ignore") vector< pair<T1, T2> >::capacity;
-%feature("ignore") vector< pair<T1, T2> >::clear;
 %feature("ignore") vector< pair<T1, T2> >::empty;
 %feature("ignore") vector< pair<T1, T2> >::end;
 %feature("ignore") vector< pair<T1, T2> >::erase;


### PR DESCRIPTION
Just like you can re-use an OBMol, it would be nice to be able to reuse a std::vector as there might be some performance benefit both from avoiding creating the variable again in Python, and from avoiding some mallocs on the C++ side. With this in mind, I've commented out the SWIG directive to ignore the .clear() method.