### PR TITLE
Keep aromaticity in EndModify()

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -1517,13 +1517,7 @@ namespace OpenBabel
       return;
 
     if (nukePerceivedData)
-      {
-        _flags = 0;
-        OBBond *bond;
-        vector<OBBond*>::iterator k;
-        for (bond = BeginBond(k);bond;bond = NextBond(k))
-          bond->SetInRing(false);
-      }
+      _flags = _flags & OB_AROMATIC_MOL; // wipe all but whether it has aromaticity perceived
     _c = NULL;
 
     if (Empty())

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -81,6 +81,14 @@ class TestSuite(PythonBindings):
             hasbracket = "[" in roundtrip
             self.assertEqual(hasbracket, needsbracket)
 
+    def testAromaticityPreservedOnAtomDeletion(self):
+        """Ensure that aromaticity is preserved on atom deleteion"""
+        mol = pybel.readstring("smi", "c1ccccc1").OBMol
+        mol.DeleteAtom(mol.GetFirstAtom())
+        self.assertTrue(mol.GetFirstAtom().IsAromatic())
+        mol.UnsetAromaticPerceived()
+        self.assertFalse(mol.GetFirstAtom().IsAromatic())
+
     def testSmilesAtomOrder(self):
         """Ensure that SMILES atom order is written correctly"""
         data = [("CC", "1 2"),


### PR DESCRIPTION
This PR has two changes:
1. Keep aromaticity in EndModify()
2. A drive-by removal of code in EndModify() that I recognise as a workaround for the problem fixed in #1724

I know that there's an idea that all lazily perceived flags should be blown away in EndModify(), but I think this is going too far - we should try as far as possible to avoid blowing away information that has been perceived. Here I make a minor change so that aromaticity perception is preserved even when, for example, an atom is deleted (which triggers this code).

IMO, this keeps things simpler and more understandable. Aromaticity will only be reperceived when the user directly unsets the aromaticity flag of the OBMol. Until then, they can delete all they want and nothing will change. If the user deletes an atom from benzene and writes it out as SMILES and sees that it is aromatic, they will soon realise what's going on. This is easier to understand than the current situation, where if you want to preserve the aromatic flags then you need to set the molecule as having aromaticity perceived after deleting an atom. To a user, it wouldn't be at all obvious that this is possible.