### PR TITLE
Ensure that the check for OBBond::IsInRing obeys the OBMol perception flags

### DIFF
--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -518,18 +518,14 @@ namespace OpenBabel
 
   bool OBBond::IsInRing() const
   {
-    if (((OBBond*)this)->HasFlag(OB_RING_BOND))
-      return(true);
-
-    OBMol *mol = (OBMol*)((OBBond*)this)->GetParent();
+    OBMol *mol = ((OBAtom*)this)->GetParent();
     if (!mol->HasRingAtomsAndBondsPerceived())
-      {
-        mol->FindRingAtomsAndBonds();
-        if (((OBBond*)this)->HasFlag(OB_RING_BOND))
-          return(true);
-      }
+      mol->FindRingAtomsAndBonds();
 
-    return(false);
+    if (((OBBond*)this)->HasFlag(OB_RING_BOND))
+      return true;
+
+    return false;
   }
 
   // Adapted from OBAtom::IsInRingSize()

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -518,7 +518,7 @@ namespace OpenBabel
 
   bool OBBond::IsInRing() const
   {
-    OBMol *mol = ((OBAtom*)this)->GetParent();
+    OBMol *mol = this->GetParent();
     if (!mol->HasRingAtomsAndBondsPerceived())
       mol->FindRingAtomsAndBonds();
 

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -518,7 +518,7 @@ namespace OpenBabel
 
   bool OBBond::IsInRing() const
   {
-    OBMol *mol = this->GetParent();
+    OBMol *mol = ((OBBond*)this)->GetParent();
     if (!mol->HasRingAtomsAndBondsPerceived())
       mol->FindRingAtomsAndBonds();
 


### PR DESCRIPTION
This is the same as #1724 but for OBBond rather than OBAtom.