### PR TITLE
Simplify/fix behavior of OBAtom::GetResidue so that it behaves like other lazy properties

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -272,9 +272,6 @@ namespace OpenBabel
       double     GetPartialCharge();
       //! \return the residue which contains this atom, or NULL if none exists
       OBResidue *GetResidue();
-      //! \param perception implies whether chain perception should occur
-      //! \return the residue which contains this atom, or NULL if none exists
-      OBResidue *GetResidue(bool perception);
       //! \return the molecule which contains this atom, or NULL if none exists
       OBMol     *GetParent()        {return((OBMol*)_parent);}
       //! Create a vector for a new bond from this atom, with length given by the supplied parameter

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -442,30 +442,11 @@ namespace OpenBabel
 
   OBResidue *OBAtom::GetResidue()
   {
-    return GetResidue(true); // default is to always perceive chains
-  }
+    OBMol *mol = this->GetParent();
+    if (!mol->HasChainsPerceived())
+      chainsparser.PerceiveChains(*mol);
 
-  OBResidue *OBAtom::GetResidue(bool perception)
-  {
-    if (_residue != NULL)
-      return _residue;
-    else if (perception && !((OBMol*)GetParent())->HasChainsPerceived())
-      {
-        ((OBMol*)GetParent())->SetChainsPerceived();
-        if ( chainsparser.PerceiveChains(*((OBMol*)GetParent())) )
-          return _residue;
-        else
-          {
-            if (_residue)
-              {
-                delete _residue;
-                _residue = NULL;
-              }
-            return NULL;
-          }
-      }
-    else
-      return NULL;
+    return _residue;
   }
 
   double OBAtom::GetAtomicMass() const

--- a/src/chains.cpp
+++ b/src/chains.cpp
@@ -1048,6 +1048,8 @@ namespace OpenBabel
     SetResidueInformation(mol, nukeSingleResidue);
     CleanupMol();
 
+    mol.SetChainsPerceived();
+
     obErrorLog.ThrowError(__FUNCTION__,
                           "Ran OpenBabel::PerceiveChains", obAuditMsg);
 

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -202,11 +202,11 @@ END
         pdbqt = '''REMARK  Name = 
 REMARK  5 active torsions:
 REMARK  status: ('A' for Active; 'I' for Inactive)
-REMARK    1  A    between atoms: _1  and  _2
-REMARK    2  A    between atoms: _2  and  _3
-REMARK    3  A    between atoms: _2  and  _5
-REMARK    4  A    between atoms: _5  and  _6
-REMARK    5  A    between atoms: _11  and  _12
+REMARK    1  A    between atoms: N_1  and  CA_2
+REMARK    2  A    between atoms: CA_2  and  C_3
+REMARK    3  A    between atoms: CA_2  and  CB_5
+REMARK    4  A    between atoms: CB_5  and  CG_6
+REMARK    5  A    between atoms: CZ_11  and  OH_12
 REMARK                            x       y       z     vdW  Elec       q    Type
 REMARK                         _______ _______ _______ _____ _____    ______ ____
 ROOT


### PR DESCRIPTION
There are a few related changes here:
1. Move the setting of the HasChainsPerceived() flag into the perception function itself, rather than out here in OBAtom::GetResidue(). What if someone calls the perception function directly? The new behavior is consistent with other perceived properties.
2. Rewrite the function so that it is driven by the HasChainsPerceived() flag, rather than first checking whether the atom has a _residue assigned. This is the behavior I've been fixing for other lazily perceived properties.
3. Remove the code to force (or avoid) perception added by @ghutchis 11 years ago to help Avogadro and others. This looks like a workaround because (2) was not done. How the lazily evaluated system is supposed to work is that you can force or avoid perception using the HasChainsPerceived() flag. Adding or removing an atom will call EndModify() and blow away this flag (I haven't changed this behavior but we could), but the user can store and reset the flag after edits if so desired.
4. Remove the code to wipe the existing _residue if the chains perception returns false. This code doesn't make any sense as it only wipes a single residue. If all of the residues should be wiped then this is the responsibility of the perception code, which is in charge of setting these.