### PR TITLE
 Modify cleaning blank line behaviors

### DIFF
--- a/src/formats/alchemyformat.cpp
+++ b/src/formats/alchemyformat.cpp
@@ -140,9 +140,15 @@ namespace OpenBabel
       }
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
+
 
     mol.EndModify();
     mol.SetTitle(title);

--- a/src/formats/balstformat.cpp
+++ b/src/formats/balstformat.cpp
@@ -107,9 +107,14 @@ namespace OpenBabel
       }
 
     // clean out any remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     mol.SetTitle(title);

--- a/src/formats/cacaoformat.cpp
+++ b/src/formats/cacaoformat.cpp
@@ -138,9 +138,14 @@ namespace OpenBabel
       mol.PerceiveBondOrders();
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     return(true);

--- a/src/formats/chem3dformat.cpp
+++ b/src/formats/chem3dformat.cpp
@@ -254,9 +254,14 @@ namespace OpenBabel
       }
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.PerceiveBondOrders();
 

--- a/src/formats/chemdrawct.cpp
+++ b/src/formats/chemdrawct.cpp
@@ -164,7 +164,6 @@ namespace OpenBabel
     while(strlen(buffer) == 0 && !ifs.eof() );
     ifs.seekg(ipos);
 
-
     mol.EndModify();
     return(true);
   }

--- a/src/formats/chemdrawct.cpp
+++ b/src/formats/chemdrawct.cpp
@@ -155,9 +155,15 @@ namespace OpenBabel
         }
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
+
 
     mol.EndModify();
     return(true);

--- a/src/formats/dmolformat.cpp
+++ b/src/formats/dmolformat.cpp
@@ -148,9 +148,14 @@ namespace OpenBabel
       mol.PerceiveBondOrders();
 
     // clean out any remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     mol.SetTitle(title);

--- a/src/formats/exyzformat.cpp
+++ b/src/formats/exyzformat.cpp
@@ -401,9 +401,14 @@ namespace OpenBabel
 
 
     // clean out any remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     if (!pConv->IsOption("b",OBConversion::INOPTIONS))
       mol.ConnectTheDots();

--- a/src/formats/featformat.cpp
+++ b/src/formats/featformat.cpp
@@ -104,9 +104,14 @@ namespace OpenBabel
       }
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     if (!pConv->IsOption("b",OBConversion::INOPTIONS))
       mol.ConnectTheDots();

--- a/src/formats/fhiaimsformat.cpp
+++ b/src/formats/fhiaimsformat.cpp
@@ -117,9 +117,14 @@ bool FHIaimsFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
       mol.PerceiveBondOrders();
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-	  (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     // Check if there are lattice vectors and add them

--- a/src/formats/freefracformat.cpp
+++ b/src/formats/freefracformat.cpp
@@ -205,9 +205,14 @@ namespace OpenBabel
       }
 
     // clean out any remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     if (!pConv->IsOption("b",OBConversion::INOPTIONS))
       mol.ConnectTheDots();

--- a/src/formats/gausscubeformat.cpp
+++ b/src/formats/gausscubeformat.cpp
@@ -525,9 +525,14 @@ bool OBGaussianCubeFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
     pmol->EndModify();
 
     // clean out any remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     // Connect the dots and guess bond orders
     if (!pConv->IsOption("b", OBConversion::INOPTIONS))

--- a/src/formats/ghemicalformat.cpp
+++ b/src/formats/ghemicalformat.cpp
@@ -176,9 +176,14 @@ namespace OpenBabel
     }
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-        (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     if (hasPartialCharges)

--- a/src/formats/mmodformat.cpp
+++ b/src/formats/mmodformat.cpp
@@ -184,9 +184,14 @@ namespace OpenBabel
       return(false);
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     return(true);
   }

--- a/src/formats/msiformat.cpp
+++ b/src/formats/msiformat.cpp
@@ -244,9 +244,14 @@ namespace OpenBabel
     mol.EndModify();
 
     // clean out any remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     /*
     if (!pConv->IsOption("b",OBConversion::INOPTIONS))

--- a/src/formats/opendxformat.cpp
+++ b/src/formats/opendxformat.cpp
@@ -221,9 +221,14 @@ bool OBOpenDXCubeFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
       return false;
 
     // clean out any remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     return true;
   }

--- a/src/formats/pcmodelformat.cpp
+++ b/src/formats/pcmodelformat.cpp
@@ -155,9 +155,14 @@ namespace OpenBabel
       } // end reading
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     if (hasPartialCharges)

--- a/src/formats/pdbformat.cpp
+++ b/src/formats/pdbformat.cpp
@@ -235,9 +235,14 @@ namespace OpenBabel
       OBAtomAssignTypicalImplicitHydrogens(&*matom);
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     return(true);
   }

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -297,11 +297,15 @@ namespace OpenBabel
     if (!pConv->IsOption("b",OBConversion::INOPTIONS)) {mol.ConnectTheDots(); mol.PerceiveBondOrders();}
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-      (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
     {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
     }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
+
     mol.SetPartialChargesPerceived();
     return(true);
   }

--- a/src/formats/pqrformat.cpp
+++ b/src/formats/pqrformat.cpp
@@ -172,9 +172,14 @@ namespace OpenBabel
     mol.SetPartialChargesPerceived();
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     return(true);
   }

--- a/src/formats/tinkerformat.cpp
+++ b/src/formats/tinkerformat.cpp
@@ -131,9 +131,14 @@ namespace OpenBabel
       mol.PerceiveBondOrders();
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-	  (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     mol.SetTitle(title);

--- a/src/formats/turbomoleformat.cpp
+++ b/src/formats/turbomoleformat.cpp
@@ -121,9 +121,14 @@ bool TurbomoleFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
       mol.PerceiveBondOrders();
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-	  (ifs.peek() == '\n' || ifs.peek() == '\r'))
-      ifs.getline(buff,BUFF_SIZE);
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
+      ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     return true;

--- a/src/formats/turbomoleformat.cpp
+++ b/src/formats/turbomoleformat.cpp
@@ -81,27 +81,27 @@ bool TurbomoleFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
       UnitConv=1;
 
 
-    char buff[BUFF_SIZE];
+    char buffer[BUFF_SIZE];
     do
     {
-        ifs.getline(buff,BUFF_SIZE);
+        ifs.getline(buffer,BUFF_SIZE);
 	if (ifs.peek() == EOF || !ifs.good())
 	  return false;
     }
-    while(strncmp(buff,"$coord",6));
+    while(strncmp(buffer,"$coord",6));
 
     mol.BeginModify();
     OBAtom atom;
     while(!(!ifs))
     {
-        ifs.getline(buff,BUFF_SIZE);
-        if(*buff=='$')
+        ifs.getline(buffer,BUFF_SIZE);
+        if(*buffer=='$')
             break;
-        if(*buff=='#')
+        if(*buffer=='#')
             continue;
         float x,y,z;
         char atomtype[8];
-        if(sscanf(buff,"%f %f %f %7s",&x,&y,&z,atomtype)!=4)
+        if(sscanf(buffer,"%f %f %f %7s",&x,&y,&z,atomtype)!=4)
             return false;
 
         atom.SetVector(x*UnitConv, y*UnitConv, z*UnitConv);
@@ -112,8 +112,8 @@ bool TurbomoleFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
             return false;
         atom.Clear();
     }
-    while(!(!ifs) && strncmp(buff,"$end",4))
-        ifs.getline(buff,BUFF_SIZE);
+    while(!(!ifs) && strncmp(buffer,"$end",4))
+        ifs.getline(buffer,BUFF_SIZE);
 
     if (!pConv->IsOption("b",OBConversion::INOPTIONS))
       mol.ConnectTheDots();
@@ -163,19 +163,19 @@ bool TurbomoleFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
 
     ofs << "$coord" <<endl;
 
-    char buff[BUFF_SIZE];
+    char buffer[BUFF_SIZE];
     OBAtom *atom;
     vector<OBAtom*>::iterator i;
     for (atom = mol.BeginAtom(i);atom;atom = mol.NextAtom(i))
     {
       char symb[8];
       strcpy(symb,OBElements::GetSymbol(atom->GetAtomicNum()));
-        snprintf(buff, BUFF_SIZE, "%20.14f  %20.14f  %20.14f      %s",
+        snprintf(buffer, BUFF_SIZE, "%20.14f  %20.14f  %20.14f      %s",
                 atom->GetX()/UnitConv,
                 atom->GetY()/UnitConv,
                 atom->GetZ()/UnitConv,
                 strlwr(symb) );
-        ofs << buff << endl;
+        ofs << buffer << endl;
     }
     ofs << "$end" << endl;
 

--- a/src/formats/unichemformat.cpp
+++ b/src/formats/unichemformat.cpp
@@ -112,9 +112,14 @@ bool UniChemFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
       mol.PerceiveBondOrders();
 
     // clean out remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-	  (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     mol.EndModify();
     mol.SetTitle(title);

--- a/src/formats/xyzformat.cpp
+++ b/src/formats/xyzformat.cpp
@@ -258,9 +258,14 @@ namespace OpenBabel
       }
 
     // clean out any remaining blank lines
-    while(ifs.peek() != EOF && ifs.good() &&
-          (ifs.peek() == '\n' || ifs.peek() == '\r'))
+    std::streampos ipos;
+    do
+    {
+      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
+    }
+    while(strlen(buffer) == 0 && !ifs.eof() );
+    ifs.seekg(ipos);
 
     if (!pConv->IsOption("b",OBConversion::INOPTIONS))
       mol.ConnectTheDots();


### PR DESCRIPTION
The same problems of #1569 and #1755 with peek() and tellg() bugs were observed not only in reading molecules in HIN formats, but also in most text-based molecule formats.
This PR modify the blank line cleaning behaviors with the same way of #1755 did.