### PR TITLE
Ring membership of atoms and bonds was not being reset during perception

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -102,6 +102,8 @@ namespace OpenBabel
       int  GetFlag() const    {  return(_flags);  }
       //! Sets the bitwise @p flag
       void SetFlag(int flag)  { _flags |= flag;   }
+      //! Unsets the bitwise @p flag
+      void UnsetFlag(int flag) { _flags &= (~(flag)); }
       //! \return True of the atom has the @p flag
       bool HasFlag(int flag)  {  return((_flags & flag) ? true : false); }
 
@@ -186,7 +188,7 @@ namespace OpenBabel
           _flags &= ~(OB_CHIRAL_ATOM);
         }
       //! Mark an atom as belonging to at least one ring
-      void SetInRing()         { SetFlag(OB_RING_ATOM); }
+      void SetInRing(bool set=true)         { if(set) SetFlag(OB_RING_ATOM); else UnsetFlag(OB_RING_ATOM); }
       //! Mark an atom as being chiral with unknown stereochemistry
       void SetChiral()         { SetFlag(OB_CHIRAL_ATOM); }
       //! Clear the internal coordinate pointer

--- a/include/openbabel/bond.h
+++ b/include/openbabel/bond.h
@@ -158,7 +158,7 @@ namespace OpenBabel
       /** \warning This is for internal use only. All closure bonds are marked
           automatically by lazy evaluation when requesting
           OBBond::IsClosure() **/
-      void SetClosure()     { SetFlag(OB_CLOSURE_BOND);  }
+      void SetClosure(bool set=true)     { if(set)SetFlag(OB_CLOSURE_BOND); else UnsetFlag(OB_CLOSURE_BOND);}
       //! Clear any indication of 2D "hash" notation from SetHash()
       void UnsetHash()      { UnsetFlag(OB_HASH_BOND);    }
       //! Clear any indication of 2D "wedge" notation from SetWedge()

--- a/src/ring.cpp
+++ b/src/ring.cpp
@@ -534,6 +534,13 @@ namespace OpenBabel
     mol.SetRingAtomsAndBondsPerceived(); // mol.SetFlag(OB_RINGFLAGS_MOL);
     mol.SetClosureBondsPerceived();      // mol.SetFlag(OB_CLOSURE_MOL);
 
+    FOR_ATOMS_OF_MOL(atom, mol)
+      atom->SetInRing(false);
+    FOR_BONDS_OF_MOL(bond, mol) {
+      bond->SetInRing(false);
+      bond->SetClosure(false);
+    }
+
     unsigned int bsize = mol.NumBonds()+1;
     unsigned char *bvisit = (unsigned char*)malloc(bsize);
     memset(bvisit,0,bsize);

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -110,6 +110,17 @@ class TestSuite(PythonBindings):
             for bit in ecfp0:
                 self.assertTrue(bit in ecfp2)
 
+    def testOldRingInformationIsWipedOnReperception(self):
+        """Previously, the code that identified ring atoms and bonds
+        did not set the flags of non-ring atoms. This meant that no
+        matter what you did to the structure, once a ring-atom, always a
+        ring atom."""
+        mol = pybel.readstring("smi", "c1ccccc1")
+        atom = mol.atoms[0].OBAtom
+        self.assertTrue(atom.IsInRing()) # trigger perception
+        mol.OBMol.DeleteAtom(mol.atoms[-1].OBAtom)
+        self.assertFalse(atom.IsInRing()) # this used to return True
+
     def testOBMolSeparatePreservesAromaticity(self):
         """If the original molecule had aromaticity perceived,
         then the fragments should also.


### PR DESCRIPTION
Previously, the code that identified ring atoms and bonds did not (un)set the flags of non-ring atoms. This meant that no matter the value of the molecule's ring perception flag, once a ring atom, always a ring atom. The included test case used to fail - it shows that even after deleting an atom from benzene, every atom thinks it's still in a ring.

Part of the problem may have been that there was no way through the public API to reset ring information, so I've had to add the relevant function to OBAtom/OBBond.