### PR TITLE
Coulomb overlap integrals for Gaussian and Slater-type charges

### DIFF
--- a/include/openbabel/gaussian_integrals.h
+++ b/include/openbabel/gaussian_integrals.h
@@ -1,0 +1,71 @@
+/**********************************************************************************
+gaussian_integrals.h - coulombintegrals for Gaussian s-type orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#ifndef GAUSSIAN_INTEGRALS_H
+#define GAUSSIAN_INTEGRALS_H
+
+#include <cmath>
+
+/*! \brief 
+ * Compute the Coulomb overlap integral between two gaussian distributed charges.
+ * The widths xi and xj may both be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi gaussian width in 1/nm 
+ * \param[in] xj gaussian width in 1/nm 
+ * \return    Integral value
+ */  
+double Coulomb_GG(double r,double xi,double xj);
+
+/*! \brief 
+ * Compute the derivative of the Coulomb overlap integral between two gaussian 
+ * distributed charges with respect to the distance.
+ * The widths xi and xj may both be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi gaussian width in 1/nm 
+ * \param[in] xj gaussian width in 1/nm 
+ * \return    Integral value
+ */    
+double DCoulomb_GG(double r,double xi,double xj);
+
+
+/*! \brief 
+ * Compute the Coulomb overlap integral between a gaussian distributed charge
+ * and a point charge. The width xi may be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi gaussian width in 1/nm 
+ * \return    Integral value
+ */  
+double Nuclear_GG(double r,double xi);
+
+/*! \brief 
+ * Compute the derivative of the Coulomb overlap integral between a gaussian 
+ * distributed charge and a point charge. The width xi may be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi gaussian width in 1/nm 
+ * \return    Integral value
+ */   
+double DNuclear_GG(double r,double xi);
+
+
+#endif /*GAUSSIAN_INTEGRALS_H*/

--- a/include/openbabel/slater_integrals.h
+++ b/include/openbabel/slater_integrals.h
@@ -1,0 +1,304 @@
+/**********************************************************************************
+slater_integrals.h - coulombintegrals for Slater s-type orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+ 
+#ifndef SLATER_INTEGRALS_H
+#define SLATER_INTEGRALS_H
+
+#include <cmath>
+
+/*! \brief 
+ * Compute the Slater overlap integral between two 1S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */ 
+double Slater_1S_1S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Slater overlap integral between 1S and 2S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Slater_1S_2S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Slater overlap integral between 1S and 2S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Slater_2S_1S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Slater overlap integral between 1S and 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Slater_1S_3S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Slater overlap integral between 1S and 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Slater_3S_1S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Slater overlap integral two 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Slater_2S_2S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Slater overlap integral between 2S and 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Slater_2S_3S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Slater overlap integral between 2S and 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Slater_3S_2S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Slater overlap integral between two 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Slater_3S_3S(double r, double xi, double xj);
+
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between two 1S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_1S_1S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between 1S and 2S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_1S_2S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between 1S and 2S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_2S_1S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between 1S and 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_1S_3S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between 1S and 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_3S_1S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between two 2S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_2S_2S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between 2S and 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_2S_3S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between 2S and 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_3S_2S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the derivative of Slater overlap integral between two 3S Slater Orbitals.
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DSlater_3S_3S(double r, double xi, double xj);
+
+/*! \brief 
+ * Compute the Coulomb overlap integral between 1S Slater orbital
+ * and a point charge. The width xi may be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Nuclear_1S(double r, double xi);
+
+/*! \brief 
+ * Compute the Coulomb overlap integral between 2S Slater orbital
+ * and a point charge. The width xi may be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Nuclear_2S(double r, double xi);
+
+/*! \brief 
+ * Compute the Coulomb overlap integral between 3S Slater orbital
+ * and a point charge. The width xi may be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double Nuclear_3S(double r, double xi);
+
+/*! \brief 
+ * Compute the derivative of Coulomb overlap integral between 1S Slater orbital
+ * and a point charge. The width xi may be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DNuclear_1S(double r, double xi);
+
+/*! \brief 
+ * Compute the derivative of Coulomb overlap integral between 2S Slater orbital
+ * and a point charge. The width xi may be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DNuclear_2S(double r, double xi);
+
+/*! \brief 
+ * Compute the derivative of Coulomb overlap integral between 2S Slater orbital
+ * and a point charge. The width xi may be zero.
+ *
+ * \param[in] r  distance in nm
+ * \param[in] xi orbital exponent in 1/nm 
+ * \return    Integral value
+ */
+double DNuclear_3S(double r, double xi);
+
+/*! \brief 
+ * Compute the Slater overlap integral between two Slater distributed charges.
+ * The widths xi and xj may both be zero. The Slater function types i and j
+ * should be in the range 1 .. SLATER_MAX
+ *
+ * \param[in] r  distance in nm
+ * \param[in] i  Slater function type
+ * \param[in] j  Slater function type
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */    
+double Coulomb_SS(double r,int i,int j,double xi,double xj);
+
+/*! \brief 
+ * Compute the derivative of the Slater overlap integral between two Slater 
+ * distributed charges with respect to r.
+ * The widths xi and xj may both be zero. The Slater function types i and j
+ * should be in the range 1 .. SLATER_MAX
+ *
+ * \param[in] r  distance in nm
+ * \param[in] i  Slater function type
+ * \param[in] j  Slater function type
+ * \param[in] xi orbital exponent in 1/nm 
+ * \param[in] xj orbital exponent in 1/nm 
+ * \return    Integral value
+ */    
+double DCoulomb_SS(double r,int i,int j,double xi,double xj);
+
+
+/*! \brief 
+ * Compute the Slater overlap integral between a Slater distributed charge and a
+ * point charge. The width xi may be zero. The Slater function type i should be in the
+ * range 1 .. SLATER_MAX
+ *
+ * \param[in] r  distance in nm
+ * \param[in] i  Slater function type
+ * \param[in] xi orbital exponent in 1/nm 
+ * \return    Integral value
+ */   
+double Nuclear_SS(double r,int i, double xi);
+
+/*! \brief 
+ * Compute the derivative of the Slater overlap integral between a Slater 
+ * distributed charge and a point charge with respect to r.
+ * The width xi may be zero. The Slater function type i should be in the
+ * range 1 .. SLATER_MAX
+ *
+ * \param[in] r  distance in nm
+ * \param[in] i  Slater function type
+ * \param[in] xi orbital exponent in 1/nm 
+ * \return    Integral value
+ */  
+double DNuclear_SS(double r,int i, double xi);
+
+#endif /*SLATER_INTEGRALS_H*/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,23 @@ set(charges ${charges}
 )
 endif()
 
+set(coulombintegrals_srcs
+  coulombintegrals/slater_integrals.cpp
+  coulombintegrals/gaussian_integrals.cpp
+  coulombintegrals/Slater_1S_1S.cpp
+  coulombintegrals/Slater_1S_2S.cpp
+  coulombintegrals/Slater_1S_3S.cpp
+  coulombintegrals/Slater_2S_2S.cpp
+  coulombintegrals/Slater_2S_3S.cpp
+  coulombintegrals/Slater_3S_3S.cpp
+  coulombintegrals/DSlater_1S_1S.cpp
+  coulombintegrals/DSlater_1S_2S.cpp
+  coulombintegrals/DSlater_1S_3S.cpp
+  coulombintegrals/DSlater_2S_2S.cpp
+  coulombintegrals/DSlater_2S_3S.cpp
+  coulombintegrals/DSlater_3S_3S.cpp
+)
+
 set(depict_srcs
   depict/depict.cpp
   depict/svgpainter.cpp
@@ -207,6 +224,7 @@ set(openbabel_library_srcs
   ${math_srcs}
   ${stereo_srcs}
   ${headers}
+  ${coulombintegrals_srcs}
   "${openbabel_BINARY_DIR}/include/openbabel/babelconfig.h"
   )
 

--- a/src/coulombintegrals/DSlater_1S_1S.cpp
+++ b/src/coulombintegrals/DSlater_1S_1S.cpp
@@ -1,0 +1,113 @@
+/**********************************************************************************
+DSlater_1S_1S.cpp - Compute electrostatic force between two 1S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+
+#include <openbabel/slater_integrals.h>
+
+double DSlater_1S_1S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = -(-33*xi + 48*exp(2*r*xi)*xi - 36*r*pow(xi, 2) -
+
+                  12*pow(r, 2)*pow(xi, 3))/(24*exp(2*r*xi)*r) +
+
+                (-24 + 24*exp(2*r*xi) - 33*r*xi - 18*pow(r, 2)*pow(xi, 2) -
+
+                 4*pow(r, 3)*pow(xi, 3))/(24*exp(2*r*xi)*pow(r, 2)) +
+
+                (xi*(-24 + 24*exp(2*r*xi) - 33*r*xi - 18*pow(r, 2)*pow(xi, 2) -
+
+                     4*pow(r, 3)*pow(xi, 3)))/(12*exp(2*r*xi)*r)
+
+            ;
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = (exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 3) +
+
+                 exp(2*r*xj)*pow(xj, 4)*
+
+                 (-3*pow(xi, 2) - r*pow(xi, 3) + pow(xj, 2) + r*xi*pow(xj, 2)) -
+
+                 exp(2*r*xi)*pow(xi, 4)*
+
+                 (pow(xi, 2)*(1 + r*xj) - pow(xj, 2)*(3 + r*xj)))/
+
+                (exp(2*r*(xi + xj))*pow(r, 2)*pow(xi - xj, 3)*pow(xi + xj, 3)) +
+
+                (2*(exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 3) +
+
+                      exp(2*r*xj)*pow(xj, 4)*
+
+                      (-3*pow(xi, 2) - r*pow(xi, 3) + pow(xj, 2) + r*xi*pow(xj, 2)) -
+
+                      exp(2*r*xi)*pow(xi, 4)*
+
+                      (pow(xi, 2)*(1 + r*xj) - pow(xj, 2)*(3 + r*xj))))/
+
+                (exp(2*r*(xi + xj))*r*pow(xi - xj, 3)*pow(xi + xj, 2)) -
+
+                (2*exp(2*r*(xi + xj))*(xi + xj)*pow(pow(xi, 2) - pow(xj, 2), 3) +
+
+                 exp(2*r*xj)*pow(xj, 4)*(-pow(xi, 3) + xi*pow(xj, 2)) +
+
+                 2*exp(2*r*xj)*pow(xj, 5)*
+
+                 (-3*pow(xi, 2) - r*pow(xi, 3) + pow(xj, 2) + r*xi*pow(xj, 2)) -
+
+                 exp(2*r*xi)*pow(xi, 4)*(pow(xi, 2)*xj - pow(xj, 3)) -
+
+                 2*exp(2*r*xi)*pow(xi, 5)*
+
+                 (pow(xi, 2)*(1 + r*xj) - pow(xj, 2)*(3 + r*xj)))/
+
+                (exp(2*r*(xi + xj))*r*pow(xi - xj, 3)*pow(xi + xj, 3))
+
+            ;
+        }
+
+    }
+    return S;
+}
+

--- a/src/coulombintegrals/DSlater_1S_2S.cpp
+++ b/src/coulombintegrals/DSlater_1S_2S.cpp
@@ -1,0 +1,197 @@
+/**********************************************************************************
+DSlater_1S_2S.cpp - Compute electrostatic force between 1S and 2S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+
+#include <openbabel/slater_integrals.h>
+
+double DSlater_1S_2S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = -(-375*xi + 480*exp(2*r*xi)*xi - 540*r*pow(xi, 2) -
+
+                  345*pow(r, 2)*pow(xi, 3) - 120*pow(r, 3)*pow(xi, 4) -
+
+                  20*pow(r, 4)*pow(xi, 5))/(240*exp(2*r*xi)*r) +
+
+                (-240 + 240*exp(2*r*xi) - 375*r*xi - 270*pow(r, 2)*pow(xi, 2) -
+
+                 115*pow(r, 3)*pow(xi, 3) - 30*pow(r, 4)*pow(xi, 4) -
+
+                 4*pow(r, 5)*pow(xi, 5))/(240*exp(2*r*xi)*pow(r, 2)) +
+
+                (xi*(-240 + 240*exp(2*r*xi) - 375*r*xi - 270*pow(r, 2)*pow(xi, 2) -
+
+                     115*pow(r, 3)*pow(xi, 3) - 30*pow(r, 4)*pow(xi, 4) -
+
+                     4*pow(r, 5)*pow(xi, 5)))/(120*exp(2*r*xi)*r)
+
+            ;
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = (6*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 5) +
+
+                 6*exp(2*r*xj)*pow(xj, 6)*
+
+                 (-4*pow(xi, 4) - r*pow(xi, 5) - 5*pow(xi, 2)*pow(xj, 2) +
+
+                  pow(xj, 4) + r*xi*pow(xj, 4)) -
+
+                 exp(2*r*xi)*pow(xi, 4)*
+
+                 (pow(xi, 6)*(6 + 9*r*xj + 6*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3)) -
+
+                  3*pow(xi, 4)*pow(xj, 2)*
+
+                  (10 + 15*r*xj + 10*pow(r, 2)*pow(xj, 2) +
+
+                   2*pow(r, 3)*pow(xj, 3)) +
+
+                  3*pow(xi, 2)*pow(xj, 4)*
+
+                  (20 + 33*r*xj + 14*pow(r, 2)*pow(xj, 2) +
+
+                   2*pow(r, 3)*pow(xj, 3)) -
+
+                  pow(xj, 6)*(84 + 63*r*xj + 18*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3))))/
+
+                (6*exp(2*r*(xi + xj))*pow(r, 2)*pow(xi - xj, 5)*pow(xi + xj, 5)) +
+
+                (6*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 5) +
+
+                 6*exp(2*r*xj)*pow(xj, 6)*
+
+                 (-4*pow(xi, 4) - r*pow(xi, 5) - 5*pow(xi, 2)*pow(xj, 2) +
+
+                  pow(xj, 4) + r*xi*pow(xj, 4)) -
+
+                 exp(2*r*xi)*pow(xi, 4)*
+
+                 (pow(xi, 6)*(6 + 9*r*xj + 6*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3)) -
+
+                  3*pow(xi, 4)*pow(xj, 2)*
+
+                  (10 + 15*r*xj + 10*pow(r, 2)*pow(xj, 2) +
+
+                   2*pow(r, 3)*pow(xj, 3)) +
+
+                  3*pow(xi, 2)*pow(xj, 4)*
+
+                  (20 + 33*r*xj + 14*pow(r, 2)*pow(xj, 2) +
+
+                   2*pow(r, 3)*pow(xj, 3)) -
+
+                  pow(xj, 6)*(84 + 63*r*xj + 18*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3))))/
+
+                (3*exp(2*r*(xi + xj))*r*pow(xi - xj, 5)*pow(xi + xj, 4)) -
+
+                (12*exp(2*r*(xi + xj))*(xi + xj)*pow(pow(xi, 2) - pow(xj, 2), 5) +
+
+                 6*exp(2*r*xj)*pow(xj, 6)*(-pow(xi, 5) + xi*pow(xj, 4)) +
+
+                 12*exp(2*r*xj)*pow(xj, 7)*
+
+                 (-4*pow(xi, 4) - r*pow(xi, 5) - 5*pow(xi, 2)*pow(xj, 2) +
+
+                  pow(xj, 4) + r*xi*pow(xj, 4)) -
+
+                 exp(2*r*xi)*pow(xi, 4)*
+
+                 (pow(xi, 6)*(9*xj + 12*r*pow(xj, 2) + 6*pow(r, 2)*pow(xj, 3)) -
+
+                  3*pow(xi, 4)*pow(xj, 2)*
+
+                  (15*xj + 20*r*pow(xj, 2) + 6*pow(r, 2)*pow(xj, 3)) +
+
+                  3*pow(xi, 2)*pow(xj, 4)*
+
+                  (33*xj + 28*r*pow(xj, 2) + 6*pow(r, 2)*pow(xj, 3)) -
+
+                  pow(xj, 6)*(63*xj + 36*r*pow(xj, 2) + 6*pow(r, 2)*pow(xj, 3))) -
+
+                 2*exp(2*r*xi)*pow(xi, 5)*
+
+                 (pow(xi, 6)*(6 + 9*r*xj + 6*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3)) -
+
+                  3*pow(xi, 4)*pow(xj, 2)*
+
+                  (10 + 15*r*xj + 10*pow(r, 2)*pow(xj, 2) +
+
+                   2*pow(r, 3)*pow(xj, 3)) +
+
+                  3*pow(xi, 2)*pow(xj, 4)*
+
+                  (20 + 33*r*xj + 14*pow(r, 2)*pow(xj, 2) +
+
+                   2*pow(r, 3)*pow(xj, 3)) -
+
+                  pow(xj, 6)*(84 + 63*r*xj + 18*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3))))/
+
+                (6*exp(2*r*(xi + xj))*r*pow(xi - xj, 5)*pow(xi + xj, 5))
+
+            ;
+        }
+
+    }
+    return S;
+}
+
+
+double DSlater_2S_1S(double r, double xi, double xj)
+{
+    return DSlater_1S_2S(r, xj, xi);
+}
+

--- a/src/coulombintegrals/DSlater_1S_3S.cpp
+++ b/src/coulombintegrals/DSlater_1S_3S.cpp
@@ -1,0 +1,310 @@
+/**********************************************************************************
+DSlater_1S_3S.cpp - Compute electrostatic force between 1S and 3S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#include <openbabel/slater_integrals.h>
+
+double DSlater_1S_3S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = -(-203175*xi + 241920*exp(2*r*xi)*xi - 328860*r*pow(xi, 2) -
+
+                  253260*pow(r, 2)*pow(xi, 3) - 120960*pow(r, 3)*pow(xi, 4) -
+
+                  38640*pow(r, 4)*pow(xi, 5) - 8064*pow(r, 5)*pow(xi, 6) -
+
+                  896*pow(r, 6)*pow(xi, 7))/(120960*exp(2*r*xi)*r) +
+
+                (-120960 + 120960*exp(2*r*xi) - 203175*r*xi -
+
+                 164430*pow(r, 2)*pow(xi, 2) - 84420*pow(r, 3)*pow(xi, 3) -
+
+                 30240*pow(r, 4)*pow(xi, 4) - 7728*pow(r, 5)*pow(xi, 5) -
+
+                 1344*pow(r, 6)*pow(xi, 6) - 128*pow(r, 7)*pow(xi, 7))/
+
+                (120960*exp(2*r*xi)*pow(r, 2)) +
+
+                (xi*(-120960 + 120960*exp(2*r*xi) - 203175*r*xi -
+
+                     164430*pow(r, 2)*pow(xi, 2) - 84420*pow(r, 3)*pow(xi, 3) -
+
+                     30240*pow(r, 4)*pow(xi, 4) - 7728*pow(r, 5)*pow(xi, 5) -
+
+                     1344*pow(r, 6)*pow(xi, 6) - 128*pow(r, 7)*pow(xi, 7)))/
+
+                (60480*exp(2*r*xi)*r)
+
+            ;
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = (45*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 7) +
+
+                 15*exp(2*r*xj)*pow(xj, 8)*
+
+                 (-15*pow(xi, 6) - 3*r*pow(xi, 7) - 63*pow(xi, 4)*pow(xj, 2) -
+
+                  7*r*pow(xi, 5)*pow(xj, 2) - 21*pow(xi, 2)*pow(xj, 4) +
+
+                  7*r*pow(xi, 3)*pow(xj, 4) + 3*pow(xj, 6) + 3*r*xi*pow(xj, 6)) +
+
+                 exp(2*r*xi)*pow(xi, 4)*
+
+                 (-10*pow(xi, 2)*pow(xj, 8)*
+
+                  (135 + 333*r*xj + 228*pow(r, 2)*pow(xj, 2) +
+
+                   75*pow(r, 3)*pow(xj, 3) + 13*pow(r, 4)*pow(xj, 4) +
+
+                   pow(r, 5)*pow(xj, 5)) +
+
+                  2*pow(xj, 10)*(945 + 945*r*xj + 420*pow(r, 2)*pow(xj, 2) +
+
+                                       105*pow(r, 3)*pow(xj, 3) + 15*pow(r, 4)*pow(xj, 4) +
+
+                                       pow(r, 5)*pow(xj, 5)) -
+
+                  pow(xi, 10)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                   30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  5*pow(xi, 8)*pow(xj, 2)*
+
+                  (63 + 105*r*xj + 84*pow(r, 2)*pow(xj, 2) +
+
+                   42*pow(r, 3)*pow(xj, 3) + 14*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) -
+
+                  5*pow(xi, 6)*pow(xj, 4)*
+
+                  (189 + 315*r*xj + 252*pow(r, 2)*pow(xj, 2) +
+
+                   132*pow(r, 3)*pow(xj, 3) + 36*pow(r, 4)*pow(xj, 4) +
+
+                   4*pow(r, 5)*pow(xj, 5)) +
+
+                  5*pow(xi, 4)*pow(xj, 6)*
+
+                  (315 + 513*r*xj + 468*pow(r, 2)*pow(xj, 2) +
+
+                   204*pow(r, 3)*pow(xj, 3) + 44*pow(r, 4)*pow(xj, 4) +
+
+                   4*pow(r, 5)*pow(xj, 5))))/
+
+                (45*exp(2*r*(xi + xj))*pow(r, 2)*pow(xi - xj, 7)*pow(xi + xj, 7))
+
+                + (2*(45*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 7) +
+
+                        15*exp(2*r*xj)*pow(xj, 8)*
+
+                        (-15*pow(xi, 6) - 3*r*pow(xi, 7) - 63*pow(xi, 4)*pow(xj, 2) -
+
+                         7*r*pow(xi, 5)*pow(xj, 2) - 21*pow(xi, 2)*pow(xj, 4) +
+
+                         7*r*pow(xi, 3)*pow(xj, 4) + 3*pow(xj, 6) + 3*r*xi*pow(xj, 6))
+
+                        + exp(2*r*xi)*pow(xi, 4)*(-10*pow(xi, 2)*pow(xj, 8)*
+
+                                                        (135 + 333*r*xj + 228*pow(r, 2)*pow(xj, 2) +
+
+                                                         75*pow(r, 3)*pow(xj, 3) + 13*pow(r, 4)*pow(xj, 4) +
+
+                                                         pow(r, 5)*pow(xj, 5)) +
+
+                                                        2*pow(xj, 10)*(945 + 945*r*xj + 420*pow(r, 2)*pow(xj, 2) +
+
+                                                                             105*pow(r, 3)*pow(xj, 3) + 15*pow(r, 4)*pow(xj, 4) +
+
+                                                                             pow(r, 5)*pow(xj, 5)) -
+
+                                                        pow(xi, 10)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                                                         30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                                                         2*pow(r, 5)*pow(xj, 5)) +
+
+                                                        5*pow(xi, 8)*pow(xj, 2)*
+
+                                                        (63 + 105*r*xj + 84*pow(r, 2)*pow(xj, 2) +
+
+                                                         42*pow(r, 3)*pow(xj, 3) + 14*pow(r, 4)*pow(xj, 4) +
+
+                                                         2*pow(r, 5)*pow(xj, 5)) -
+
+                                                        5*pow(xi, 6)*pow(xj, 4)*
+
+                                                        (189 + 315*r*xj + 252*pow(r, 2)*pow(xj, 2) +
+
+                                                         132*pow(r, 3)*pow(xj, 3) + 36*pow(r, 4)*pow(xj, 4) +
+
+                                                         4*pow(r, 5)*pow(xj, 5)) +
+
+                                                        5*pow(xi, 4)*pow(xj, 6)*
+
+                                                        (315 + 513*r*xj + 468*pow(r, 2)*pow(xj, 2) +
+
+                                                         204*pow(r, 3)*pow(xj, 3) + 44*pow(r, 4)*pow(xj, 4) +
+
+                                                         4*pow(r, 5)*pow(xj, 5)))))/
+
+                (45*exp(2*r*(xi + xj))*r*pow(xi - xj, 7)*pow(xi + xj, 6)) -
+
+                (90*exp(2*r*(xi + xj))*(xi + xj)*pow(pow(xi, 2) - pow(xj, 2), 7) +
+
+                 15*exp(2*r*xj)*pow(xj, 8)*
+
+                 (-3*pow(xi, 7) - 7*pow(xi, 5)*pow(xj, 2) +
+
+                  7*pow(xi, 3)*pow(xj, 4) + 3*xi*pow(xj, 6)) +
+
+                 30*exp(2*r*xj)*pow(xj, 9)*
+
+                 (-15*pow(xi, 6) - 3*r*pow(xi, 7) - 63*pow(xi, 4)*pow(xj, 2) -
+
+                  7*r*pow(xi, 5)*pow(xj, 2) - 21*pow(xi, 2)*pow(xj, 4) +
+
+                  7*r*pow(xi, 3)*pow(xj, 4) + 3*pow(xj, 6) + 3*r*xi*pow(xj, 6)) +
+
+                 exp(2*r*xi)*pow(xi, 4)*
+
+                 (-10*pow(xi, 2)*pow(xj, 8)*
+
+                  (333*xj + 456*r*pow(xj, 2) + 225*pow(r, 2)*pow(xj, 3) +
+
+                   52*pow(r, 3)*pow(xj, 4) + 5*pow(r, 4)*pow(xj, 5)) +
+
+                  2*pow(xj, 10)*(945*xj + 840*r*pow(xj, 2) +
+
+                                       315*pow(r, 2)*pow(xj, 3) + 60*pow(r, 3)*pow(xj, 4) +
+
+                                       5*pow(r, 4)*pow(xj, 5)) -
+
+                  pow(xi, 10)*(75*xj + 120*r*pow(xj, 2) +
+
+                                   90*pow(r, 2)*pow(xj, 3) + 40*pow(r, 3)*pow(xj, 4) +
+
+                                   10*pow(r, 4)*pow(xj, 5)) +
+
+                  5*pow(xi, 8)*pow(xj, 2)*
+
+                  (105*xj + 168*r*pow(xj, 2) + 126*pow(r, 2)*pow(xj, 3) +
+
+                   56*pow(r, 3)*pow(xj, 4) + 10*pow(r, 4)*pow(xj, 5)) -
+
+                  5*pow(xi, 6)*pow(xj, 4)*
+
+                  (315*xj + 504*r*pow(xj, 2) + 396*pow(r, 2)*pow(xj, 3) +
+
+                   144*pow(r, 3)*pow(xj, 4) + 20*pow(r, 4)*pow(xj, 5)) +
+
+                  5*pow(xi, 4)*pow(xj, 6)*
+
+                  (513*xj + 936*r*pow(xj, 2) + 612*pow(r, 2)*pow(xj, 3) +
+
+                   176*pow(r, 3)*pow(xj, 4) + 20*pow(r, 4)*pow(xj, 5))) +
+
+                 2*exp(2*r*xi)*pow(xi, 5)*
+
+                 (-10*pow(xi, 2)*pow(xj, 8)*
+
+                  (135 + 333*r*xj + 228*pow(r, 2)*pow(xj, 2) +
+
+                   75*pow(r, 3)*pow(xj, 3) + 13*pow(r, 4)*pow(xj, 4) +
+
+                   pow(r, 5)*pow(xj, 5)) +
+
+                  2*pow(xj, 10)*(945 + 945*r*xj + 420*pow(r, 2)*pow(xj, 2) +
+
+                                       105*pow(r, 3)*pow(xj, 3) + 15*pow(r, 4)*pow(xj, 4) +
+
+                                       pow(r, 5)*pow(xj, 5)) -
+
+                  pow(xi, 10)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                   30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  5*pow(xi, 8)*pow(xj, 2)*
+
+                  (63 + 105*r*xj + 84*pow(r, 2)*pow(xj, 2) +
+
+                   42*pow(r, 3)*pow(xj, 3) + 14*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) -
+
+                  5*pow(xi, 6)*pow(xj, 4)*
+
+                  (189 + 315*r*xj + 252*pow(r, 2)*pow(xj, 2) +
+
+                   132*pow(r, 3)*pow(xj, 3) + 36*pow(r, 4)*pow(xj, 4) +
+
+                   4*pow(r, 5)*pow(xj, 5)) +
+
+                  5*pow(xi, 4)*pow(xj, 6)*
+
+                  (315 + 513*r*xj + 468*pow(r, 2)*pow(xj, 2) +
+
+                   204*pow(r, 3)*pow(xj, 3) + 44*pow(r, 4)*pow(xj, 4) +
+
+                   4*pow(r, 5)*pow(xj, 5))))/
+
+                (45*exp(2*r*(xi + xj))*r*pow(xi - xj, 7)*pow(xi + xj, 7))
+
+            ;
+        }
+
+    }
+    return S;
+}
+
+
+double DSlater_3S_1S(double r, double xi, double xj)
+{
+    return DSlater_1S_3S(r, xj, xi);
+}
+

--- a/src/coulombintegrals/DSlater_2S_2S.cpp
+++ b/src/coulombintegrals/DSlater_2S_2S.cpp
@@ -1,0 +1,277 @@
+/**********************************************************************************
+DSlater_2S_2S.cpp - Compute electrostatic force two 2S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+
+#include <openbabel/slater_integrals.h>
+
+double DSlater_2S_2S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = -(-131985*xi + 161280*exp(2*r*xi)*xi - 205380*r*pow(xi, 2) -
+
+                  149940*pow(r, 2)*pow(xi, 3) - 67200*pow(r, 3)*pow(xi, 4) -
+
+                  20160*pow(r, 4)*pow(xi, 5) - 4032*pow(r, 5)*pow(xi, 6) -
+
+                  448*pow(r, 6)*pow(xi, 7))/(80640*exp(2*r*xi)*r) +
+
+                (-80640 + 80640*exp(2*r*xi) - 131985*r*xi -
+
+                 102690*pow(r, 2)*pow(xi, 2) - 49980*pow(r, 3)*pow(xi, 3) -
+
+                 16800*pow(r, 4)*pow(xi, 4) - 4032*pow(r, 5)*pow(xi, 5) -
+
+                 672*pow(r, 6)*pow(xi, 6) - 64*pow(r, 7)*pow(xi, 7))/
+
+                (80640*exp(2*r*xi)*pow(r, 2)) +
+
+                (xi*(-80640 + 80640*exp(2*r*xi) - 131985*r*xi -
+
+                     102690*pow(r, 2)*pow(xi, 2) - 49980*pow(r, 3)*pow(xi, 3) -
+
+                     16800*pow(r, 4)*pow(xi, 4) - 4032*pow(r, 5)*pow(xi, 5) -
+
+                     672*pow(r, 6)*pow(xi, 6) - 64*pow(r, 7)*pow(xi, 7)))/
+
+                (40320*exp(2*r*xi)*r)
+
+            ;
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = (6*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 7) -
+
+                 exp(2*r*xi)*pow(xi, 6)*
+
+                 (21*pow(xi, 4)*pow(xj, 4)*
+
+                  (6 + 11*r*xj + 2*pow(r, 2)*pow(xj, 2)) -
+
+                  2*pow(xj, 8)*(90 + 54*r*xj + 12*pow(r, 2)*pow(xj, 2) +
+
+                                      pow(r, 3)*pow(xj, 3)) +
+
+                  pow(xi, 8)*(6 + 9*r*xj + 6*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3)) +
+
+                  pow(xi, 2)*pow(xj, 6)*
+
+                  (-390 - 69*r*xj + 18*pow(r, 2)*pow(xj, 2) +
+
+                   4*pow(r, 3)*pow(xj, 3)) -
+
+                  pow(xi, 6)*pow(xj, 2)*
+
+                  (42 + 63*r*xj + 42*pow(r, 2)*pow(xj, 2) +
+
+                   4*pow(r, 3)*pow(xj, 3))) +
+
+                 exp(2*r*xj)*pow(xj, 6)*
+
+                 (-24*pow(r, 2)*pow(xi, 10) - 2*pow(r, 3)*pow(xi, 11) -
+
+                  69*r*pow(xi, 7)*pow(xj, 2) + 6*pow(xj, 8) + 9*r*xi*pow(xj, 8) +
+
+                  4*r*pow(xi, 9)*(-27 + pow(r, 2)*pow(xj, 2)) +
+
+                  18*pow(xi, 8)*(-10 + pow(r, 2)*pow(xj, 2)) +
+
+                  6*pow(xi, 2)*pow(xj, 6)*(-7 + pow(r, 2)*pow(xj, 2)) -
+
+                  42*pow(xi, 4)*pow(xj, 4)*(-3 + pow(r, 2)*pow(xj, 2)) +
+
+                  r*pow(xi, 3)*pow(xj, 6)*(-63 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  6*pow(xi, 6)*pow(xj, 2)*(-65 + 7*pow(r, 2)*pow(xj, 2)) +
+
+                  pow(xi, 5)*(231*r*pow(xj, 4) - 4*pow(r, 3)*pow(xj, 6))))/
+
+                (6*exp(2*r*(xi + xj))*pow(r, 2)*pow(xi - xj, 7)*pow(xi + xj, 7)) +
+
+                (6*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 7) -
+
+                 exp(2*r*xi)*pow(xi, 6)*
+
+                 (21*pow(xi, 4)*pow(xj, 4)*
+
+                  (6 + 11*r*xj + 2*pow(r, 2)*pow(xj, 2)) -
+
+                  2*pow(xj, 8)*(90 + 54*r*xj + 12*pow(r, 2)*pow(xj, 2) +
+
+                                      pow(r, 3)*pow(xj, 3)) +
+
+                  pow(xi, 8)*(6 + 9*r*xj + 6*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3)) +
+
+                  pow(xi, 2)*pow(xj, 6)*
+
+                  (-390 - 69*r*xj + 18*pow(r, 2)*pow(xj, 2) +
+
+                   4*pow(r, 3)*pow(xj, 3)) -
+
+                  pow(xi, 6)*pow(xj, 2)*
+
+                  (42 + 63*r*xj + 42*pow(r, 2)*pow(xj, 2) +
+
+                   4*pow(r, 3)*pow(xj, 3))) +
+
+                 exp(2*r*xj)*pow(xj, 6)*
+
+                 (-24*pow(r, 2)*pow(xi, 10) - 2*pow(r, 3)*pow(xi, 11) -
+
+                  69*r*pow(xi, 7)*pow(xj, 2) + 6*pow(xj, 8) + 9*r*xi*pow(xj, 8) +
+
+                  4*r*pow(xi, 9)*(-27 + pow(r, 2)*pow(xj, 2)) +
+
+                  18*pow(xi, 8)*(-10 + pow(r, 2)*pow(xj, 2)) +
+
+                  6*pow(xi, 2)*pow(xj, 6)*(-7 + pow(r, 2)*pow(xj, 2)) -
+
+                  42*pow(xi, 4)*pow(xj, 4)*(-3 + pow(r, 2)*pow(xj, 2)) +
+
+                  r*pow(xi, 3)*pow(xj, 6)*(-63 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  6*pow(xi, 6)*pow(xj, 2)*(-65 + 7*pow(r, 2)*pow(xj, 2)) +
+
+                  pow(xi, 5)*(231*r*pow(xj, 4) - 4*pow(r, 3)*pow(xj, 6))))/
+
+                (3*exp(2*r*(xi + xj))*r*pow(xi - xj, 7)*pow(xi + xj, 6)) -
+
+                (12*exp(2*r*(xi + xj))*(xi + xj)*pow(pow(xi, 2) - pow(xj, 2), 7) -
+
+                 exp(2*r*xi)*pow(xi, 6)*
+
+                 (21*pow(xi, 4)*pow(xj, 4)*(11*xj + 4*r*pow(xj, 2)) -
+
+                  2*pow(xj, 8)*(54*xj + 24*r*pow(xj, 2) +
+
+                                      3*pow(r, 2)*pow(xj, 3)) +
+
+                  pow(xi, 8)*(9*xj + 12*r*pow(xj, 2) + 6*pow(r, 2)*pow(xj, 3)) +
+
+                  pow(xi, 2)*pow(xj, 6)*
+
+                  (-69*xj + 36*r*pow(xj, 2) + 12*pow(r, 2)*pow(xj, 3)) -
+
+                  pow(xi, 6)*pow(xj, 2)*
+
+                  (63*xj + 84*r*pow(xj, 2) + 12*pow(r, 2)*pow(xj, 3))) -
+
+                 2*exp(2*r*xi)*pow(xi, 7)*
+
+                 (21*pow(xi, 4)*pow(xj, 4)*
+
+                  (6 + 11*r*xj + 2*pow(r, 2)*pow(xj, 2)) -
+
+                  2*pow(xj, 8)*(90 + 54*r*xj + 12*pow(r, 2)*pow(xj, 2) +
+
+                                      pow(r, 3)*pow(xj, 3)) +
+
+                  pow(xi, 8)*(6 + 9*r*xj + 6*pow(r, 2)*pow(xj, 2) +
+
+                                  2*pow(r, 3)*pow(xj, 3)) +
+
+                  pow(xi, 2)*pow(xj, 6)*
+
+                  (-390 - 69*r*xj + 18*pow(r, 2)*pow(xj, 2) +
+
+                   4*pow(r, 3)*pow(xj, 3)) -
+
+                  pow(xi, 6)*pow(xj, 2)*
+
+                  (42 + 63*r*xj + 42*pow(r, 2)*pow(xj, 2) +
+
+                   4*pow(r, 3)*pow(xj, 3))) +
+
+                 exp(2*r*xj)*pow(xj, 6)*
+
+                 (-48*r*pow(xi, 10) - 6*pow(r, 2)*pow(xi, 11) -
+
+                  69*pow(xi, 7)*pow(xj, 2) + 36*r*pow(xi, 8)*pow(xj, 2) +
+
+                  8*pow(r, 2)*pow(xi, 9)*pow(xj, 2) +
+
+                  84*r*pow(xi, 6)*pow(xj, 4) - 84*r*pow(xi, 4)*pow(xj, 6) +
+
+                  9*xi*pow(xj, 8) + 12*r*pow(xi, 2)*pow(xj, 8) +
+
+                  4*pow(r, 2)*pow(xi, 3)*pow(xj, 8) +
+
+                  4*pow(xi, 9)*(-27 + pow(r, 2)*pow(xj, 2)) +
+
+                  pow(xi, 3)*pow(xj, 6)*(-63 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  pow(xi, 5)*(231*pow(xj, 4) - 12*pow(r, 2)*pow(xj, 6))) +
+
+                 2*exp(2*r*xj)*pow(xj, 7)*
+
+                 (-24*pow(r, 2)*pow(xi, 10) - 2*pow(r, 3)*pow(xi, 11) -
+
+                  69*r*pow(xi, 7)*pow(xj, 2) + 6*pow(xj, 8) + 9*r*xi*pow(xj, 8) +
+
+                  4*r*pow(xi, 9)*(-27 + pow(r, 2)*pow(xj, 2)) +
+
+                  18*pow(xi, 8)*(-10 + pow(r, 2)*pow(xj, 2)) +
+
+                  6*pow(xi, 2)*pow(xj, 6)*(-7 + pow(r, 2)*pow(xj, 2)) -
+
+                  42*pow(xi, 4)*pow(xj, 4)*(-3 + pow(r, 2)*pow(xj, 2)) +
+
+                  r*pow(xi, 3)*pow(xj, 6)*(-63 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  6*pow(xi, 6)*pow(xj, 2)*(-65 + 7*pow(r, 2)*pow(xj, 2)) +
+
+                  pow(xi, 5)*(231*r*pow(xj, 4) - 4*pow(r, 3)*pow(xj, 6))))/
+
+                (6*exp(2*r*(xi + xj))*r*pow(xi - xj, 7)*pow(xi + xj, 7))
+
+            ;
+        }
+
+    }
+    return S;
+}
+

--- a/src/coulombintegrals/DSlater_2S_3S.cpp
+++ b/src/coulombintegrals/DSlater_2S_3S.cpp
@@ -1,0 +1,425 @@
+/**********************************************************************************
+DSlater_2S_3S.cpp - Compute electrostatic force between 2S and 3S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+
+#include <openbabel/slater_integrals.h>
+
+double DSlater_2S_3S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = -(-7430535*xi + 8709120*exp(2*r*xi)*xi - 12303900*r*pow(xi, 2) -
+
+                  9826110*pow(r, 2)*pow(xi, 3) - 5004720*pow(r, 3)*pow(xi, 4) -
+
+                  1806840*pow(r, 4)*pow(xi, 5) - 483840*pow(r, 5)*pow(xi, 6) -
+
+                  96768*pow(r, 6)*pow(xi, 7) - 13824*pow(r, 7)*pow(xi, 8) -
+
+                  1152*pow(r, 8)*pow(xi, 9))/(4.35456e6*exp(2*r*xi)*r) +
+
+                (-4354560 + 4354560*exp(2*r*xi) - 7430535*r*xi -
+
+                 6151950*pow(r, 2)*pow(xi, 2) - 3275370*pow(r, 3)*pow(xi, 3) -
+
+                 1251180*pow(r, 4)*pow(xi, 4) - 361368*pow(r, 5)*pow(xi, 5) -
+
+                 80640*pow(r, 6)*pow(xi, 6) - 13824*pow(r, 7)*pow(xi, 7) -
+
+                 1728*pow(r, 8)*pow(xi, 8) - 128*pow(r, 9)*pow(xi, 9))/
+
+                (4.35456e6*exp(2*r*xi)*pow(r, 2)) +
+
+                (xi*(-4354560 + 4354560*exp(2*r*xi) - 7430535*r*xi -
+
+                     6151950*pow(r, 2)*pow(xi, 2) - 3275370*pow(r, 3)*pow(xi, 3) -
+
+                     1251180*pow(r, 4)*pow(xi, 4) - 361368*pow(r, 5)*pow(xi, 5) -
+
+                     80640*pow(r, 6)*pow(xi, 6) - 13824*pow(r, 7)*pow(xi, 7) -
+
+                     1728*pow(r, 8)*pow(xi, 8) - 128*pow(r, 9)*pow(xi, 9)))/
+
+                (2.17728e6*exp(2*r*xi)*r)
+
+            ;
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = (90*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 9) +
+
+                 5*exp(2*r*xj)*pow(xj, 8)*
+
+                 (-90*pow(r, 2)*pow(xi, 12) - 6*pow(r, 3)*pow(xi, 13) +
+
+                  18*pow(xj, 10) + 27*r*xi*pow(xj, 10) +
+
+                  18*pow(xi, 2)*pow(xj, 8)*(-9 + pow(r, 2)*pow(xj, 2)) -
+
+                  162*pow(xi, 4)*pow(xj, 6)*(-4 + pow(r, 2)*pow(xj, 2)) -
+
+                  198*pow(xi, 10)*(5 + pow(r, 2)*pow(xj, 2)) -
+
+                  108*pow(xi, 6)*pow(xj, 4)*(36 + pow(r, 2)*pow(xj, 2)) +
+
+                  2*r*pow(xi, 5)*pow(xj, 6)*(675 + pow(r, 2)*pow(xj, 2)) -
+
+                  18*r*pow(xi, 7)*pow(xj, 4)*(-81 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  3*r*pow(xi, 3)*pow(xj, 8)*(-81 + 2*pow(r, 2)*pow(xj, 2)) -
+
+                  r*pow(xi, 11)*(495 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  9*r*pow(xi, 9)*pow(xj, 2)*(-233 + 4*pow(r, 2)*pow(xj, 2)) +
+
+                  6*pow(xi, 8)*pow(xj, 2)*(-1063 + 90*pow(r, 2)*pow(xj, 2))) -
+
+                 2*exp(2*r*xi)*pow(xi, 6)*
+
+                 (-90*pow(xi, 6)*pow(xj, 6)*
+
+                  (42 + 65*r*xj + 76*pow(r, 2)*pow(xj, 2) +
+
+                   22*pow(r, 3)*pow(xj, 3) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                  2*pow(xj, 12)*(2970 + 2475*r*xj + 900*pow(r, 2)*pow(xj, 2) +
+
+                                       180*pow(r, 3)*pow(xj, 3) + 20*pow(r, 4)*pow(xj, 4) +
+
+                                       pow(r, 5)*pow(xj, 5)) +
+
+                  10*pow(xi, 8)*pow(xj, 4)*
+
+                  (162 + 270*r*xj + 216*pow(r, 2)*pow(xj, 2) +
+
+                   122*pow(r, 3)*pow(xj, 3) + 22*pow(r, 4)*pow(xj, 4) +
+
+                   pow(r, 5)*pow(xj, 5)) -
+
+                  5*pow(xi, 4)*pow(xj, 8)*
+
+                  (-639 - 3555*r*xj - 1452*pow(r, 2)*pow(xj, 2) -
+
+                   174*pow(r, 3)*pow(xj, 3) + 6*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  pow(xi, 12)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                   30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                   2*pow(r, 5)*pow(xj, 5)) -
+
+                  pow(xi, 10)*pow(xj, 2)*
+
+                  (405 + 675*r*xj + 540*pow(r, 2)*pow(xj, 2) +
+
+                   270*pow(r, 3)*pow(xj, 3) + 90*pow(r, 4)*pow(xj, 4) +
+
+                   8*pow(r, 5)*pow(xj, 5)) +
+
+                  pow(xi, 2)*pow(xj, 10)*
+
+                  (-21615 - 9075*r*xj - 300*pow(r, 2)*pow(xj, 2) +
+
+                   490*pow(r, 3)*pow(xj, 3) + 110*pow(r, 4)*pow(xj, 4) +
+
+                   8*pow(r, 5)*pow(xj, 5))))/
+
+                (90*exp(2*r*(xi + xj))*pow(r, 2)*pow(xi - xj, 9)*pow(xi + xj, 9))
+
+                + (90*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 9) +
+
+                   5*exp(2*r*xj)*pow(xj, 8)*
+
+                   (-90*pow(r, 2)*pow(xi, 12) - 6*pow(r, 3)*pow(xi, 13) +
+
+                    18*pow(xj, 10) + 27*r*xi*pow(xj, 10) +
+
+                    18*pow(xi, 2)*pow(xj, 8)*(-9 + pow(r, 2)*pow(xj, 2)) -
+
+                    162*pow(xi, 4)*pow(xj, 6)*(-4 + pow(r, 2)*pow(xj, 2)) -
+
+                    198*pow(xi, 10)*(5 + pow(r, 2)*pow(xj, 2)) -
+
+                    108*pow(xi, 6)*pow(xj, 4)*(36 + pow(r, 2)*pow(xj, 2)) +
+
+                    2*r*pow(xi, 5)*pow(xj, 6)*(675 + pow(r, 2)*pow(xj, 2)) -
+
+                    18*r*pow(xi, 7)*pow(xj, 4)*(-81 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                    3*r*pow(xi, 3)*pow(xj, 8)*(-81 + 2*pow(r, 2)*pow(xj, 2)) -
+
+                    r*pow(xi, 11)*(495 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                    9*r*pow(xi, 9)*pow(xj, 2)*(-233 + 4*pow(r, 2)*pow(xj, 2)) +
+
+                    6*pow(xi, 8)*pow(xj, 2)*(-1063 + 90*pow(r, 2)*pow(xj, 2))) -
+
+                   2*exp(2*r*xi)*pow(xi, 6)*
+
+                   (-90*pow(xi, 6)*pow(xj, 6)*
+
+                    (42 + 65*r*xj + 76*pow(r, 2)*pow(xj, 2) +
+
+                     22*pow(r, 3)*pow(xj, 3) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                    2*pow(xj, 12)*(2970 + 2475*r*xj + 900*pow(r, 2)*pow(xj, 2) +
+
+                                         180*pow(r, 3)*pow(xj, 3) + 20*pow(r, 4)*pow(xj, 4) +
+
+                                         pow(r, 5)*pow(xj, 5)) +
+
+                    10*pow(xi, 8)*pow(xj, 4)*
+
+                    (162 + 270*r*xj + 216*pow(r, 2)*pow(xj, 2) +
+
+                     122*pow(r, 3)*pow(xj, 3) + 22*pow(r, 4)*pow(xj, 4) +
+
+                     pow(r, 5)*pow(xj, 5)) -
+
+                    5*pow(xi, 4)*pow(xj, 8)*
+
+                    (-639 - 3555*r*xj - 1452*pow(r, 2)*pow(xj, 2) -
+
+                     174*pow(r, 3)*pow(xj, 3) + 6*pow(r, 4)*pow(xj, 4) +
+
+                     2*pow(r, 5)*pow(xj, 5)) +
+
+                    pow(xi, 12)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                     30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                     2*pow(r, 5)*pow(xj, 5)) -
+
+                    pow(xi, 10)*pow(xj, 2)*
+
+                    (405 + 675*r*xj + 540*pow(r, 2)*pow(xj, 2) +
+
+                     270*pow(r, 3)*pow(xj, 3) + 90*pow(r, 4)*pow(xj, 4) +
+
+                     8*pow(r, 5)*pow(xj, 5)) +
+
+                    pow(xi, 2)*pow(xj, 10)*
+
+                    (-21615 - 9075*r*xj - 300*pow(r, 2)*pow(xj, 2) +
+
+                     490*pow(r, 3)*pow(xj, 3) + 110*pow(r, 4)*pow(xj, 4) +
+
+                     8*pow(r, 5)*pow(xj, 5))))/
+
+                (45*exp(2*r*(xi + xj))*r*pow(xi - xj, 9)*pow(xi + xj, 8)) -
+
+                (180*exp(2*r*(xi + xj))*(xi + xj)*pow(pow(xi, 2) - pow(xj, 2), 9) +
+
+                 5*exp(2*r*xj)*pow(xj, 8)*
+
+                 (-180*r*pow(xi, 12) - 18*pow(r, 2)*pow(xi, 13) -
+
+                  396*r*pow(xi, 10)*pow(xj, 2) -
+
+                  4*pow(r, 2)*pow(xi, 11)*pow(xj, 2) +
+
+                  1080*r*pow(xi, 8)*pow(xj, 4) +
+
+                  72*pow(r, 2)*pow(xi, 9)*pow(xj, 4) -
+
+                  216*r*pow(xi, 6)*pow(xj, 6) -
+
+                  72*pow(r, 2)*pow(xi, 7)*pow(xj, 6) -
+
+                  324*r*pow(xi, 4)*pow(xj, 8) +
+
+                  4*pow(r, 2)*pow(xi, 5)*pow(xj, 8) + 27*xi*pow(xj, 10) +
+
+                  36*r*pow(xi, 2)*pow(xj, 10) +
+
+                  12*pow(r, 2)*pow(xi, 3)*pow(xj, 10) +
+
+                  2*pow(xi, 5)*pow(xj, 6)*(675 + pow(r, 2)*pow(xj, 2)) -
+
+                  18*pow(xi, 7)*pow(xj, 4)*(-81 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  3*pow(xi, 3)*pow(xj, 8)*(-81 + 2*pow(r, 2)*pow(xj, 2)) -
+
+                  pow(xi, 11)*(495 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  9*pow(xi, 9)*pow(xj, 2)*(-233 + 4*pow(r, 2)*pow(xj, 2))) +
+
+                 10*exp(2*r*xj)*pow(xj, 9)*
+
+                 (-90*pow(r, 2)*pow(xi, 12) - 6*pow(r, 3)*pow(xi, 13) +
+
+                  18*pow(xj, 10) + 27*r*xi*pow(xj, 10) +
+
+                  18*pow(xi, 2)*pow(xj, 8)*(-9 + pow(r, 2)*pow(xj, 2)) -
+
+                  162*pow(xi, 4)*pow(xj, 6)*(-4 + pow(r, 2)*pow(xj, 2)) -
+
+                  198*pow(xi, 10)*(5 + pow(r, 2)*pow(xj, 2)) -
+
+                  108*pow(xi, 6)*pow(xj, 4)*(36 + pow(r, 2)*pow(xj, 2)) +
+
+                  2*r*pow(xi, 5)*pow(xj, 6)*(675 + pow(r, 2)*pow(xj, 2)) -
+
+                  18*r*pow(xi, 7)*pow(xj, 4)*(-81 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  3*r*pow(xi, 3)*pow(xj, 8)*(-81 + 2*pow(r, 2)*pow(xj, 2)) -
+
+                  r*pow(xi, 11)*(495 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  9*r*pow(xi, 9)*pow(xj, 2)*(-233 + 4*pow(r, 2)*pow(xj, 2)) +
+
+                  6*pow(xi, 8)*pow(xj, 2)*(-1063 + 90*pow(r, 2)*pow(xj, 2))) -
+
+                 2*exp(2*r*xi)*pow(xi, 6)*
+
+                 (-90*pow(xi, 6)*pow(xj, 6)*
+
+                  (65*xj + 152*r*pow(xj, 2) + 66*pow(r, 2)*pow(xj, 3) +
+
+                   8*pow(r, 3)*pow(xj, 4)) -
+
+                  2*pow(xj, 12)*(2475*xj + 1800*r*pow(xj, 2) +
+
+                                       540*pow(r, 2)*pow(xj, 3) + 80*pow(r, 3)*pow(xj, 4) +
+
+                                       5*pow(r, 4)*pow(xj, 5)) +
+
+                  10*pow(xi, 8)*pow(xj, 4)*
+
+                  (270*xj + 432*r*pow(xj, 2) + 366*pow(r, 2)*pow(xj, 3) +
+
+                   88*pow(r, 3)*pow(xj, 4) + 5*pow(r, 4)*pow(xj, 5)) -
+
+                  5*pow(xi, 4)*pow(xj, 8)*
+
+                  (-3555*xj - 2904*r*pow(xj, 2) - 522*pow(r, 2)*pow(xj, 3) +
+
+                   24*pow(r, 3)*pow(xj, 4) + 10*pow(r, 4)*pow(xj, 5)) +
+
+                  pow(xi, 12)*(75*xj + 120*r*pow(xj, 2) +
+
+                                   90*pow(r, 2)*pow(xj, 3) + 40*pow(r, 3)*pow(xj, 4) +
+
+                                   10*pow(r, 4)*pow(xj, 5)) -
+
+                  pow(xi, 10)*pow(xj, 2)*
+
+                  (675*xj + 1080*r*pow(xj, 2) + 810*pow(r, 2)*pow(xj, 3) +
+
+                   360*pow(r, 3)*pow(xj, 4) + 40*pow(r, 4)*pow(xj, 5)) +
+
+                  pow(xi, 2)*pow(xj, 10)*
+
+                  (-9075*xj - 600*r*pow(xj, 2) + 1470*pow(r, 2)*pow(xj, 3) +
+
+                   440*pow(r, 3)*pow(xj, 4) + 40*pow(r, 4)*pow(xj, 5))) -
+
+                 4*exp(2*r*xi)*pow(xi, 7)*
+
+                 (-90*pow(xi, 6)*pow(xj, 6)*
+
+                  (42 + 65*r*xj + 76*pow(r, 2)*pow(xj, 2) +
+
+                   22*pow(r, 3)*pow(xj, 3) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                  2*pow(xj, 12)*(2970 + 2475*r*xj + 900*pow(r, 2)*pow(xj, 2) +
+
+                                       180*pow(r, 3)*pow(xj, 3) + 20*pow(r, 4)*pow(xj, 4) +
+
+                                       pow(r, 5)*pow(xj, 5)) +
+
+                  10*pow(xi, 8)*pow(xj, 4)*
+
+                  (162 + 270*r*xj + 216*pow(r, 2)*pow(xj, 2) +
+
+                   122*pow(r, 3)*pow(xj, 3) + 22*pow(r, 4)*pow(xj, 4) +
+
+                   pow(r, 5)*pow(xj, 5)) -
+
+                  5*pow(xi, 4)*pow(xj, 8)*
+
+                  (-639 - 3555*r*xj - 1452*pow(r, 2)*pow(xj, 2) -
+
+                   174*pow(r, 3)*pow(xj, 3) + 6*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  pow(xi, 12)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                   30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                   2*pow(r, 5)*pow(xj, 5)) -
+
+                  pow(xi, 10)*pow(xj, 2)*
+
+                  (405 + 675*r*xj + 540*pow(r, 2)*pow(xj, 2) +
+
+                   270*pow(r, 3)*pow(xj, 3) + 90*pow(r, 4)*pow(xj, 4) +
+
+                   8*pow(r, 5)*pow(xj, 5)) +
+
+                  pow(xi, 2)*pow(xj, 10)*
+
+                  (-21615 - 9075*r*xj - 300*pow(r, 2)*pow(xj, 2) +
+
+                   490*pow(r, 3)*pow(xj, 3) + 110*pow(r, 4)*pow(xj, 4) +
+
+                   8*pow(r, 5)*pow(xj, 5))))/
+
+                (90*exp(2*r*(xi + xj))*r*pow(xi - xj, 9)*pow(xi + xj, 9))
+
+            ;
+        }
+
+    }
+    return S;
+}
+
+
+double DSlater_3S_2S(double r, double xi, double xj)
+{
+    return DSlater_2S_3S(r, xj, xi);
+}
+

--- a/src/coulombintegrals/DSlater_3S_3S.cpp
+++ b/src/coulombintegrals/DSlater_3S_3S.cpp
@@ -1,0 +1,643 @@
+/**********************************************************************************
+DSlater_3S_3S.cpp - Compute electrostatic force two 3S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+
+#include <openbabel/slater_integrals.h>
+
+double DSlater_3S_3S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = -(-2503064025*xi + 2874009600*exp(2*r*xi)*xi -
+
+                  4264236900*r*pow(xi, 2) - 3541992300*pow(r, 2)*pow(xi, 3) -
+
+                  1906027200*pow(r, 3)*pow(xi, 4) -
+
+                  744282000*pow(r, 4)*pow(xi, 5) - 223534080*pow(r, 5)*pow(xi, 6) -
+
+                  53222400*pow(r, 6)*pow(xi, 7) - 10137600*pow(r, 7)*pow(xi, 8) -
+
+                  1520640*pow(r, 8)*pow(xi, 9) - 168960*pow(r, 9)*pow(xi, 10) -
+
+                  11264*pow(r, 10)*pow(xi, 11))/(1.4370048e9*exp(2*r*xi)*r) +
+
+                (-1437004800 + 1437004800*exp(2*r*xi) - 2503064025*r*xi -
+
+                 2132118450*pow(r, 2)*pow(xi, 2) -
+
+                 1180664100*pow(r, 3)*pow(xi, 3) - 476506800*pow(r, 4)*pow(xi, 4) -
+
+                 148856400*pow(r, 5)*pow(xi, 5) - 37255680*pow(r, 6)*pow(xi, 6) -
+
+                 7603200*pow(r, 7)*pow(xi, 7) - 1267200*pow(r, 8)*pow(xi, 8) -
+
+                 168960*pow(r, 9)*pow(xi, 9) - 16896*pow(r, 10)*pow(xi, 10) -
+
+                 1024*pow(r, 11)*pow(xi, 11))/(1.4370048e9*exp(2*r*xi)*pow(r, 2))
+
+                + (xi*(-1437004800 + 1437004800*exp(2*r*xi) - 2503064025*r*xi -
+
+                       2132118450*pow(r, 2)*pow(xi, 2) -
+
+                       1180664100*pow(r, 3)*pow(xi, 3) -
+
+                       476506800*pow(r, 4)*pow(xi, 4) - 148856400*pow(r, 5)*pow(xi, 5) -
+
+                       37255680*pow(r, 6)*pow(xi, 6) - 7603200*pow(r, 7)*pow(xi, 7) -
+
+                       1267200*pow(r, 8)*pow(xi, 8) - 168960*pow(r, 9)*pow(xi, 9) -
+
+                       16896*pow(r, 10)*pow(xi, 10) - 1024*pow(r, 11)*pow(xi, 11)))/
+
+                (7.185024e8*exp(2*r*xi)*r)
+
+            ;
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = 0
+
+            ;
+        }
+        else
+        {
+            S = (135*exp(2*r*(xi + xj))*pow(pow(xi, 2) - pow(xj, 2), 11) +
+
+                 exp(2*r*xj)*pow(xj, 8)*
+
+                 (-150*pow(r, 4)*pow(xi, 18) - 6*pow(r, 5)*pow(xi, 19) +
+
+                  135*pow(xj, 14) + 225*r*xi*pow(xj, 14) +
+
+                  10*pow(r, 3)*pow(xi, 17)*(-165 + pow(r, 2)*pow(xj, 2)) -
+
+                  30*pow(r, 2)*pow(xi, 16)*(330 + pow(r, 2)*pow(xj, 2)) +
+
+                  45*r*pow(xi, 3)*pow(xj, 12)*(-55 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  45*pow(xi, 2)*pow(xj, 12)*(-33 + 4*pow(r, 2)*pow(xj, 2)) +
+
+                  r*pow(xi, 9)*pow(xj, 6)*
+
+                  (234135 - 4950*pow(r, 2)*pow(xj, 2) -
+
+                   34*pow(r, 4)*pow(xj, 4)) -
+
+                  5*r*pow(xi, 7)*pow(xj, 8)*
+
+                  (6237 - 1242*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) +
+
+                  3*r*pow(xi, 5)*pow(xj, 10)*
+
+                  (4125 - 330*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) +
+
+                  15*pow(xi, 4)*pow(xj, 10)*
+
+                  (495 - 132*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                  165*pow(xi, 6)*pow(xj, 8)*
+
+                  (135 - 60*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                  5*r*pow(xi, 13)*pow(xj, 2)*
+
+                  (43875 - 3438*pow(r, 2)*pow(xj, 2) + 22*pow(r, 4)*pow(xj, 4))
+
+                  + 5*r*pow(xi, 11)*pow(xj, 4)*
+
+                  (7695 - 2442*pow(r, 2)*pow(xj, 2) + 22*pow(r, 4)*pow(xj, 4))
+
+                  + 15*pow(xi, 8)*pow(xj, 6)*(-33 - 3564*pow(r, 2)*pow(xj, 2) +
+
+                                                        26*pow(r, 4)*pow(xj, 4)) +
+
+                  r*pow(xi, 15)*(-32175 - 3690*pow(r, 2)*pow(xj, 2) +
+
+                                     34*pow(r, 4)*pow(xj, 4)) +
+
+                  15*pow(xi, 10)*pow(xj, 4)*
+
+                  (-32277 + 1364*pow(r, 2)*pow(xj, 2) +
+
+                   66*pow(r, 4)*pow(xj, 4)) +
+
+                  15*pow(xi, 14)*(-3003 - 2932*pow(r, 2)*pow(xj, 2) +
+
+                                        94*pow(r, 4)*pow(xj, 4)) -
+
+                  15*pow(xi, 12)*pow(xj, 2)*
+
+                  (28119 - 5252*pow(r, 2)*pow(xj, 2) + 154*pow(r, 4)*pow(xj, 4))
+
+                 ) + exp(2*r*xi)*pow(xi, 8)*
+
+                 (-5*pow(xi, 2)*pow(xj, 12)*
+
+                  (-84357 - 43875*r*xj - 8796*pow(r, 2)*pow(xj, 2) -
+
+                   738*pow(r, 3)*pow(xj, 3) - 6*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) -
+
+                  3*pow(xi, 14)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                       30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                       2*pow(r, 5)*pow(xj, 5)) -
+
+                  55*pow(xi, 8)*pow(xj, 6)*
+
+                  (-405 - 567*r*xj - 972*pow(r, 2)*pow(xj, 2) -
+
+                   90*pow(r, 3)*pow(xj, 3) + 18*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  55*pow(xi, 6)*pow(xj, 8)*
+
+                  (9 - 4257*r*xj - 372*pow(r, 2)*pow(xj, 2) +
+
+                   222*pow(r, 3)*pow(xj, 3) + 42*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  3*pow(xj, 14)*(15015 + 10725*r*xj + 3300*pow(r, 2)*pow(xj, 2) +
+
+                                       550*pow(r, 3)*pow(xj, 3) + 50*pow(r, 4)*pow(xj, 4) +
+
+                                       2*pow(r, 5)*pow(xj, 5)) +
+
+                  5*pow(xi, 12)*pow(xj, 2)*
+
+                  (297 + 495*r*xj + 396*pow(r, 2)*pow(xj, 2) +
+
+                   198*pow(r, 3)*pow(xj, 3) + 66*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  pow(xi, 10)*pow(xj, 4)*
+
+                  (-7425 - 12375*r*xj - 9900*pow(r, 2)*pow(xj, 2) -
+
+                   6210*pow(r, 3)*pow(xj, 3) - 390*pow(r, 4)*pow(xj, 4) +
+
+                   34*pow(r, 5)*pow(xj, 5)) -
+
+                  pow(xi, 4)*pow(xj, 10)*
+
+                  (-484155 + 38475*r*xj + 78780*pow(r, 2)*pow(xj, 2) +
+
+                   17190*pow(r, 3)*pow(xj, 3) + 1410*pow(r, 4)*pow(xj, 4) +
+
+                   34*pow(r, 5)*pow(xj, 5))))/
+
+                (135*exp(2*r*(xi + xj))*pow(r, 2)*pow(xi - xj, 11)*
+
+                 pow(xi + xj, 11)) + (2*(135*exp(2*r*(xi + xj))*
+
+                                               pow(pow(xi, 2) - pow(xj, 2), 11) +
+
+                                               exp(2*r*xj)*pow(xj, 8)*
+
+                                               (-150*pow(r, 4)*pow(xi, 18) - 6*pow(r, 5)*pow(xi, 19) +
+
+                                                135*pow(xj, 14) + 225*r*xi*pow(xj, 14) +
+
+                                                10*pow(r, 3)*pow(xi, 17)*(-165 + pow(r, 2)*pow(xj, 2)) -
+
+                                                30*pow(r, 2)*pow(xi, 16)*(330 + pow(r, 2)*pow(xj, 2)) +
+
+                                                45*r*pow(xi, 3)*pow(xj, 12)*(-55 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                                                45*pow(xi, 2)*pow(xj, 12)*(-33 + 4*pow(r, 2)*pow(xj, 2)) +
+
+                                                r*pow(xi, 9)*pow(xj, 6)*
+
+                                                (234135 - 4950*pow(r, 2)*pow(xj, 2) -
+
+                                                 34*pow(r, 4)*pow(xj, 4)) -
+
+                                                5*r*pow(xi, 7)*pow(xj, 8)*
+
+                                                (6237 - 1242*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4))
+
+                                                + 3*r*pow(xi, 5)*pow(xj, 10)*
+
+                                                (4125 - 330*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4))
+
+                                                + 15*pow(xi, 4)*pow(xj, 10)*
+
+                                                (495 - 132*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                                                165*pow(xi, 6)*pow(xj, 8)*
+
+                                                (135 - 60*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                                                5*r*pow(xi, 13)*pow(xj, 2)*
+
+                                                (43875 - 3438*pow(r, 2)*pow(xj, 2) +
+
+                                                 22*pow(r, 4)*pow(xj, 4)) +
+
+                                                5*r*pow(xi, 11)*pow(xj, 4)*
+
+                                                (7695 - 2442*pow(r, 2)*pow(xj, 2) +
+
+                                                 22*pow(r, 4)*pow(xj, 4)) +
+
+                                                15*pow(xi, 8)*pow(xj, 6)*
+
+                                                (-33 - 3564*pow(r, 2)*pow(xj, 2) + 26*pow(r, 4)*pow(xj, 4))
+
+                                                + r*pow(xi, 15)*(-32175 - 3690*pow(r, 2)*pow(xj, 2) +
+
+                                                                     34*pow(r, 4)*pow(xj, 4)) +
+
+                                                15*pow(xi, 10)*pow(xj, 4)*
+
+                                                (-32277 + 1364*pow(r, 2)*pow(xj, 2) +
+
+                                                 66*pow(r, 4)*pow(xj, 4)) +
+
+                                                15*pow(xi, 14)*(-3003 - 2932*pow(r, 2)*pow(xj, 2) +
+
+                                                                      94*pow(r, 4)*pow(xj, 4)) -
+
+                                                15*pow(xi, 12)*pow(xj, 2)*
+
+                                                (28119 - 5252*pow(r, 2)*pow(xj, 2) +
+
+                                                 154*pow(r, 4)*pow(xj, 4))) +
+
+                                               exp(2*r*xi)*pow(xi, 8)*
+
+                                               (-5*pow(xi, 2)*pow(xj, 12)*
+
+                                                (-84357 - 43875*r*xj - 8796*pow(r, 2)*pow(xj, 2) -
+
+                                                 738*pow(r, 3)*pow(xj, 3) - 6*pow(r, 4)*pow(xj, 4) +
+
+                                                 2*pow(r, 5)*pow(xj, 5)) -
+
+                                                3*pow(xi, 14)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                                                     30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                                                     2*pow(r, 5)*pow(xj, 5)) -
+
+                                                55*pow(xi, 8)*pow(xj, 6)*
+
+                                                (-405 - 567*r*xj - 972*pow(r, 2)*pow(xj, 2) -
+
+                                                 90*pow(r, 3)*pow(xj, 3) + 18*pow(r, 4)*pow(xj, 4) +
+
+                                                 2*pow(r, 5)*pow(xj, 5)) +
+
+                                                55*pow(xi, 6)*pow(xj, 8)*
+
+                                                (9 - 4257*r*xj - 372*pow(r, 2)*pow(xj, 2) +
+
+                                                 222*pow(r, 3)*pow(xj, 3) + 42*pow(r, 4)*pow(xj, 4) +
+
+                                                 2*pow(r, 5)*pow(xj, 5)) +
+
+                                                3*pow(xj, 14)*(15015 + 10725*r*xj +
+
+                                                                     3300*pow(r, 2)*pow(xj, 2) + 550*pow(r, 3)*pow(xj, 3) +
+
+                                                                     50*pow(r, 4)*pow(xj, 4) + 2*pow(r, 5)*pow(xj, 5)) +
+
+                                                5*pow(xi, 12)*pow(xj, 2)*
+
+                                                (297 + 495*r*xj + 396*pow(r, 2)*pow(xj, 2) +
+
+                                                 198*pow(r, 3)*pow(xj, 3) + 66*pow(r, 4)*pow(xj, 4) +
+
+                                                 2*pow(r, 5)*pow(xj, 5)) +
+
+                                                pow(xi, 10)*pow(xj, 4)*
+
+                                                (-7425 - 12375*r*xj - 9900*pow(r, 2)*pow(xj, 2) -
+
+                                                 6210*pow(r, 3)*pow(xj, 3) - 390*pow(r, 4)*pow(xj, 4) +
+
+                                                 34*pow(r, 5)*pow(xj, 5)) -
+
+                                                pow(xi, 4)*pow(xj, 10)*
+
+                                                (-484155 + 38475*r*xj + 78780*pow(r, 2)*pow(xj, 2) +
+
+                                                 17190*pow(r, 3)*pow(xj, 3) + 1410*pow(r, 4)*pow(xj, 4) +
+
+                                                 34*pow(r, 5)*pow(xj, 5)))))/
+
+                (135*exp(2*r*(xi + xj))*r*pow(xi - xj, 11)*pow(xi + xj, 10)) -
+
+                (270*exp(2*r*(xi + xj))*(xi + xj)*
+
+                 pow(pow(xi, 2) - pow(xj, 2), 11) +
+
+                 exp(2*r*xj)*pow(xj, 8)*
+
+                 (-600*pow(r, 3)*pow(xi, 18) - 30*pow(r, 4)*pow(xi, 19) -
+
+                  60*pow(r, 3)*pow(xi, 16)*pow(xj, 2) +
+
+                  20*pow(r, 4)*pow(xi, 17)*pow(xj, 2) + 225*xi*pow(xj, 14) +
+
+                  360*r*pow(xi, 2)*pow(xj, 14) +
+
+                  180*pow(r, 2)*pow(xi, 3)*pow(xj, 14) +
+
+                  30*pow(r, 2)*pow(xi, 17)*(-165 + pow(r, 2)*pow(xj, 2)) -
+
+                  60*r*pow(xi, 16)*(330 + pow(r, 2)*pow(xj, 2)) +
+
+                  45*pow(xi, 3)*pow(xj, 12)*(-55 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  r*pow(xi, 9)*pow(xj, 6)*
+
+                  (-9900*r*pow(xj, 2) - 136*pow(r, 3)*pow(xj, 4)) -
+
+                  5*r*pow(xi, 7)*pow(xj, 8)*
+
+                  (-2484*r*pow(xj, 2) + 8*pow(r, 3)*pow(xj, 4)) +
+
+                  3*r*pow(xi, 5)*pow(xj, 10)*
+
+                  (-660*r*pow(xj, 2) + 8*pow(r, 3)*pow(xj, 4)) +
+
+                  15*pow(xi, 4)*pow(xj, 10)*
+
+                  (-264*r*pow(xj, 2) + 8*pow(r, 3)*pow(xj, 4)) -
+
+                  165*pow(xi, 6)*pow(xj, 8)*
+
+                  (-120*r*pow(xj, 2) + 8*pow(r, 3)*pow(xj, 4)) -
+
+                  5*r*pow(xi, 13)*pow(xj, 2)*
+
+                  (-6876*r*pow(xj, 2) + 88*pow(r, 3)*pow(xj, 4)) +
+
+                  5*r*pow(xi, 11)*pow(xj, 4)*
+
+                  (-4884*r*pow(xj, 2) + 88*pow(r, 3)*pow(xj, 4)) +
+
+                  15*pow(xi, 8)*pow(xj, 6)*
+
+                  (-7128*r*pow(xj, 2) + 104*pow(r, 3)*pow(xj, 4)) +
+
+                  r*pow(xi, 15)*(-7380*r*pow(xj, 2) + 136*pow(r, 3)*pow(xj, 4)) +
+
+                  15*pow(xi, 10)*pow(xj, 4)*
+
+                  (2728*r*pow(xj, 2) + 264*pow(r, 3)*pow(xj, 4)) +
+
+                  15*pow(xi, 14)*(-5864*r*pow(xj, 2) +
+
+                                        376*pow(r, 3)*pow(xj, 4)) -
+
+                  15*pow(xi, 12)*pow(xj, 2)*
+
+                  (-10504*r*pow(xj, 2) + 616*pow(r, 3)*pow(xj, 4)) +
+
+                  pow(xi, 9)*pow(xj, 6)*
+
+                  (234135 - 4950*pow(r, 2)*pow(xj, 2) - 34*pow(r, 4)*pow(xj, 4))
+
+                  - 5*pow(xi, 7)*pow(xj, 8)*(6237 - 1242*pow(r, 2)*pow(xj, 2) +
+
+                                                       2*pow(r, 4)*pow(xj, 4)) +
+
+                  3*pow(xi, 5)*pow(xj, 10)*
+
+                  (4125 - 330*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                  5*pow(xi, 13)*pow(xj, 2)*
+
+                  (43875 - 3438*pow(r, 2)*pow(xj, 2) + 22*pow(r, 4)*pow(xj, 4))
+
+                  + 5*pow(xi, 11)*pow(xj, 4)*(7695 - 2442*pow(r, 2)*pow(xj, 2) +
+
+                                                        22*pow(r, 4)*pow(xj, 4)) +
+
+                  pow(xi, 15)*(-32175 - 3690*pow(r, 2)*pow(xj, 2) +
+
+                                   34*pow(r, 4)*pow(xj, 4))) +
+
+                 2*exp(2*r*xj)*pow(xj, 9)*
+
+                 (-150*pow(r, 4)*pow(xi, 18) - 6*pow(r, 5)*pow(xi, 19) +
+
+                  135*pow(xj, 14) + 225*r*xi*pow(xj, 14) +
+
+                  10*pow(r, 3)*pow(xi, 17)*(-165 + pow(r, 2)*pow(xj, 2)) -
+
+                  30*pow(r, 2)*pow(xi, 16)*(330 + pow(r, 2)*pow(xj, 2)) +
+
+                  45*r*pow(xi, 3)*pow(xj, 12)*(-55 + 2*pow(r, 2)*pow(xj, 2)) +
+
+                  45*pow(xi, 2)*pow(xj, 12)*(-33 + 4*pow(r, 2)*pow(xj, 2)) +
+
+                  r*pow(xi, 9)*pow(xj, 6)*
+
+                  (234135 - 4950*pow(r, 2)*pow(xj, 2) - 34*pow(r, 4)*pow(xj, 4))
+
+                  - 5*r*pow(xi, 7)*pow(xj, 8)*(6237 - 1242*pow(r, 2)*pow(xj, 2) +
+
+                                                         2*pow(r, 4)*pow(xj, 4)) +
+
+                  3*r*pow(xi, 5)*pow(xj, 10)*
+
+                  (4125 - 330*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) +
+
+                  15*pow(xi, 4)*pow(xj, 10)*
+
+                  (495 - 132*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                  165*pow(xi, 6)*pow(xj, 8)*
+
+                  (135 - 60*pow(r, 2)*pow(xj, 2) + 2*pow(r, 4)*pow(xj, 4)) -
+
+                  5*r*pow(xi, 13)*pow(xj, 2)*
+
+                  (43875 - 3438*pow(r, 2)*pow(xj, 2) + 22*pow(r, 4)*pow(xj, 4))
+
+                  + 5*r*pow(xi, 11)*pow(xj, 4)*
+
+                  (7695 - 2442*pow(r, 2)*pow(xj, 2) + 22*pow(r, 4)*pow(xj, 4)) +
+
+                  15*pow(xi, 8)*pow(xj, 6)*
+
+                  (-33 - 3564*pow(r, 2)*pow(xj, 2) + 26*pow(r, 4)*pow(xj, 4)) +
+
+                  r*pow(xi, 15)*(-32175 - 3690*pow(r, 2)*pow(xj, 2) +
+
+                                     34*pow(r, 4)*pow(xj, 4)) +
+
+                  15*pow(xi, 10)*pow(xj, 4)*
+
+                  (-32277 + 1364*pow(r, 2)*pow(xj, 2) + 66*pow(r, 4)*pow(xj, 4))
+
+                  + 15*pow(xi, 14)*(-3003 - 2932*pow(r, 2)*pow(xj, 2) +
+
+                                          94*pow(r, 4)*pow(xj, 4)) -
+
+                  15*pow(xi, 12)*pow(xj, 2)*
+
+                  (28119 - 5252*pow(r, 2)*pow(xj, 2) + 154*pow(r, 4)*pow(xj, 4)))
+
+                 + exp(2*r*xi)*pow(xi, 8)*(-5*pow(xi, 2)*pow(xj, 12)*
+
+                                                 (-43875*xj - 17592*r*pow(xj, 2) - 2214*pow(r, 2)*pow(xj, 3) -
+
+                                                  24*pow(r, 3)*pow(xj, 4) + 10*pow(r, 4)*pow(xj, 5)) -
+
+                                                 3*pow(xi, 14)*(75*xj + 120*r*pow(xj, 2) +
+
+                                                                      90*pow(r, 2)*pow(xj, 3) + 40*pow(r, 3)*pow(xj, 4) +
+
+                                                                      10*pow(r, 4)*pow(xj, 5)) -
+
+                                                 55*pow(xi, 8)*pow(xj, 6)*
+
+                                                 (-567*xj - 1944*r*pow(xj, 2) - 270*pow(r, 2)*pow(xj, 3) +
+
+                                                  72*pow(r, 3)*pow(xj, 4) + 10*pow(r, 4)*pow(xj, 5)) +
+
+                                                 55*pow(xi, 6)*pow(xj, 8)*
+
+                                                 (-4257*xj - 744*r*pow(xj, 2) + 666*pow(r, 2)*pow(xj, 3) +
+
+                                                  168*pow(r, 3)*pow(xj, 4) + 10*pow(r, 4)*pow(xj, 5)) +
+
+                                                 3*pow(xj, 14)*(10725*xj + 6600*r*pow(xj, 2) +
+
+                                                                      1650*pow(r, 2)*pow(xj, 3) + 200*pow(r, 3)*pow(xj, 4) +
+
+                                                                      10*pow(r, 4)*pow(xj, 5)) +
+
+                                                 5*pow(xi, 12)*pow(xj, 2)*
+
+                                                 (495*xj + 792*r*pow(xj, 2) + 594*pow(r, 2)*pow(xj, 3) +
+
+                                                  264*pow(r, 3)*pow(xj, 4) + 10*pow(r, 4)*pow(xj, 5)) +
+
+                                                 pow(xi, 10)*pow(xj, 4)*
+
+                                                 (-12375*xj - 19800*r*pow(xj, 2) - 18630*pow(r, 2)*pow(xj, 3) -
+
+                                                  1560*pow(r, 3)*pow(xj, 4) + 170*pow(r, 4)*pow(xj, 5)) -
+
+                                                 pow(xi, 4)*pow(xj, 10)*
+
+                                                 (38475*xj + 157560*r*pow(xj, 2) + 51570*pow(r, 2)*pow(xj, 3) +
+
+                                                  5640*pow(r, 3)*pow(xj, 4) + 170*pow(r, 4)*pow(xj, 5))) +
+
+                 2*exp(2*r*xi)*pow(xi, 9)*
+
+                 (-5*pow(xi, 2)*pow(xj, 12)*
+
+                  (-84357 - 43875*r*xj - 8796*pow(r, 2)*pow(xj, 2) -
+
+                   738*pow(r, 3)*pow(xj, 3) - 6*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) -
+
+                  3*pow(xi, 14)*(45 + 75*r*xj + 60*pow(r, 2)*pow(xj, 2) +
+
+                                       30*pow(r, 3)*pow(xj, 3) + 10*pow(r, 4)*pow(xj, 4) +
+
+                                       2*pow(r, 5)*pow(xj, 5)) -
+
+                  55*pow(xi, 8)*pow(xj, 6)*
+
+                  (-405 - 567*r*xj - 972*pow(r, 2)*pow(xj, 2) -
+
+                   90*pow(r, 3)*pow(xj, 3) + 18*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  55*pow(xi, 6)*pow(xj, 8)*
+
+                  (9 - 4257*r*xj - 372*pow(r, 2)*pow(xj, 2) +
+
+                   222*pow(r, 3)*pow(xj, 3) + 42*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  3*pow(xj, 14)*(15015 + 10725*r*xj + 3300*pow(r, 2)*pow(xj, 2) +
+
+                                       550*pow(r, 3)*pow(xj, 3) + 50*pow(r, 4)*pow(xj, 4) +
+
+                                       2*pow(r, 5)*pow(xj, 5)) +
+
+                  5*pow(xi, 12)*pow(xj, 2)*
+
+                  (297 + 495*r*xj + 396*pow(r, 2)*pow(xj, 2) +
+
+                   198*pow(r, 3)*pow(xj, 3) + 66*pow(r, 4)*pow(xj, 4) +
+
+                   2*pow(r, 5)*pow(xj, 5)) +
+
+                  pow(xi, 10)*pow(xj, 4)*
+
+                  (-7425 - 12375*r*xj - 9900*pow(r, 2)*pow(xj, 2) -
+
+                   6210*pow(r, 3)*pow(xj, 3) - 390*pow(r, 4)*pow(xj, 4) +
+
+                   34*pow(r, 5)*pow(xj, 5)) -
+
+                  pow(xi, 4)*pow(xj, 10)*
+
+                  (-484155 + 38475*r*xj + 78780*pow(r, 2)*pow(xj, 2) +
+
+                   17190*pow(r, 3)*pow(xj, 3) + 1410*pow(r, 4)*pow(xj, 4) +
+
+                   34*pow(r, 5)*pow(xj, 5))))/
+
+                (135*exp(2*r*(xi + xj))*r*pow(xi - xj, 11)*pow(xi + xj, 11))
+
+            ;
+        }
+
+    }
+    return S;
+}
+

--- a/src/coulombintegrals/Slater_1S_1S.cpp
+++ b/src/coulombintegrals/Slater_1S_1S.cpp
@@ -1,0 +1,76 @@
+/**********************************************************************************
+Slater_1S_1S.cpp - Compute electrostatic energy between two 1S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#include <openbabel/slater_integrals.h>
+
+
+double Slater_1S_1S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = (5*xi)/8
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((-24 + 24*exp(2*rxi) - 33*rxi - 18*pow(rxi, 2) - 4*pow(rxi, 3))/
+
+                         (24*exp(2*rxi))
+
+                         );
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = (xi*xj*(pow(xi, 2) + 3*xi*xj + pow(xj, 2)))/pow(xi + xj, 3)
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((exp(2*(rxi + rxj))*pow(pow(rxi, 2) - pow(rxj, 2), 3) +
+
+                          exp(2*rxj)*pow(rxj, 4)*
+
+                          (-3*pow(rxi, 2) - pow(rxi, 3) + pow(rxj, 2) + rxi*pow(rxj, 2)) -
+
+                          exp(2*rxi)*pow(rxi, 4)*
+
+                          (pow(rxi, 2)*(1 + rxj) - pow(rxj, 2)*(3 + rxj)))/
+
+                         (exp(2*(rxi + rxj))*pow(rxi - rxj, 3)*pow(rxi + rxj, 3))
+
+                         );
+        }
+
+    }
+    return S;
+}

--- a/src/coulombintegrals/Slater_1S_2S.cpp
+++ b/src/coulombintegrals/Slater_1S_2S.cpp
@@ -1,0 +1,97 @@
+/**********************************************************************************
+Slater_1S_2S.cpp - Compute electrostatic energy between 1S and 2S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#include <openbabel/slater_integrals.h>
+
+
+double Slater_1S_2S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = (7*xi)/16
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((-240 + 240*exp(2*rxi) - 375*rxi - 270*pow(rxi, 2) - 115*pow(rxi, 3) -
+
+                          30*pow(rxi, 4) - 4*pow(rxi, 5))/(240*exp(2*rxi))
+
+                         );
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = (xi*xj*(pow(xi, 4) + 5*pow(xi, 3)*xj + 10*pow(xi, 2)*pow(xj, 2) +
+
+                        10*xi*pow(xj, 3) + 2*pow(xj, 4)))/(2*pow(xi + xj, 5))
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((6*exp(2*(rxi + rxj))*pow(pow(rxi, 2) - pow(rxj, 2), 5) +
+
+                          6*exp(2*rxj)*pow(rxj, 6)*
+
+                          (-4*pow(rxi, 4) - pow(rxi, 5) - 5*pow(rxi, 2)*pow(rxj, 2) +
+
+                           pow(rxj, 4) + rxi*pow(rxj, 4)) -
+
+                          exp(2*rxi)*pow(rxi, 4)*
+
+                          (pow(rxi, 6)*(6 + 9*rxj + 6*pow(rxj, 2) + 2*pow(rxj, 3)) -
+
+                           3*pow(rxi, 4)*pow(rxj, 2)*
+
+                           (10 + 15*rxj + 10*pow(rxj, 2) + 2*pow(rxj, 3)) +
+
+                           3*pow(rxi, 2)*pow(rxj, 4)*
+
+                           (20 + 33*rxj + 14*pow(rxj, 2) + 2*pow(rxj, 3)) -
+
+                           pow(rxj, 6)*(84 + 63*rxj + 18*pow(rxj, 2) + 2*pow(rxj, 3))))/
+
+                         (6*exp(2*(rxi + rxj))*pow(rxi - rxj, 5)*pow(rxi + rxj, 5))
+
+                         );
+        }
+
+    }
+    return S;
+}
+
+
+double Slater_2S_1S(double r, double xi, double xj)
+{
+    return Slater_1S_2S(r, xj, xi);
+}
+

--- a/src/coulombintegrals/Slater_1S_3S.cpp
+++ b/src/coulombintegrals/Slater_1S_3S.cpp
@@ -1,0 +1,123 @@
+/**********************************************************************************
+Slater_1S_3S.cpp - Compute electrostatic energy between 1S and 3S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+
+#include <openbabel/slater_integrals.h>
+
+double Slater_1S_3S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = (41*xi)/128
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((-120960 + 120960*exp(2*rxi) - 203175*rxi - 164430*pow(rxi, 2) -
+
+                          84420*pow(rxi, 3) - 30240*pow(rxi, 4) - 7728*pow(rxi, 5) -
+
+                          1344*pow(rxi, 6) - 128*pow(rxi, 7))/(120960*exp(2*rxi))
+
+                         );
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = (xi*xj*(pow(xi, 6) + 7*pow(xi, 5)*xj + 21*pow(xi, 4)*pow(xj, 2) +
+
+                        35*pow(xi, 3)*pow(xj, 3) + 35*pow(xi, 2)*pow(xj, 4) +
+
+                        21*xi*pow(xj, 5) + 3*pow(xj, 6)))/(3*pow(xi + xj, 7))
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((45*exp(2*(rxi + rxj))*pow(pow(rxi, 2) - pow(rxj, 2), 7) +
+
+                          15*exp(2*rxj)*pow(rxj, 8)*
+
+                          (-15*pow(rxi, 6) - 3*pow(rxi, 7) - 63*pow(rxi, 4)*pow(rxj, 2) -
+
+                           7*pow(rxi, 5)*pow(rxj, 2) - 21*pow(rxi, 2)*pow(rxj, 4) +
+
+                           7*pow(rxi, 3)*pow(rxj, 4) + 3*pow(rxj, 6) + 3*rxi*pow(rxj, 6)) +
+
+                          exp(2*rxi)*pow(rxi, 4)*
+
+                          (-10*pow(rxi, 2)*pow(rxj, 8)*
+
+                           (135 + 333*rxj + 228*pow(rxj, 2) + 75*pow(rxj, 3) +
+
+                            13*pow(rxj, 4) + pow(rxj, 5)) +
+
+                           2*pow(rxj, 10)*(945 + 945*rxj + 420*pow(rxj, 2) +
+
+                                                 105*pow(rxj, 3) + 15*pow(rxj, 4) + pow(rxj, 5)) -
+
+                           pow(rxi, 10)*(45 + 75*rxj + 60*pow(rxj, 2) + 30*pow(rxj, 3) +
+
+                                             10*pow(rxj, 4) + 2*pow(rxj, 5)) +
+
+                           5*pow(rxi, 8)*pow(rxj, 2)*
+
+                           (63 + 105*rxj + 84*pow(rxj, 2) + 42*pow(rxj, 3) +
+
+                            14*pow(rxj, 4) + 2*pow(rxj, 5)) -
+
+                           5*pow(rxi, 6)*pow(rxj, 4)*
+
+                           (189 + 315*rxj + 252*pow(rxj, 2) + 132*pow(rxj, 3) +
+
+                            36*pow(rxj, 4) + 4*pow(rxj, 5)) +
+
+                           5*pow(rxi, 4)*pow(rxj, 6)*
+
+                           (315 + 513*rxj + 468*pow(rxj, 2) + 204*pow(rxj, 3) +
+
+                            44*pow(rxj, 4) + 4*pow(rxj, 5))))/
+
+                         (45*exp(2*(rxi + rxj))*pow(rxi - rxj, 7)*pow(rxi + rxj, 7))
+
+                         );
+        }
+
+    }
+    return S;
+}
+
+
+double Slater_3S_1S(double r, double xi, double xj)
+{
+    return Slater_1S_3S(r, xj, xi);
+}
+

--- a/src/coulombintegrals/Slater_2S_2S.cpp
+++ b/src/coulombintegrals/Slater_2S_2S.cpp
@@ -1,0 +1,109 @@
+/**********************************************************************************
+Slater_2S_2S.cpp - Compute electrostatic energy between two 2S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#include <openbabel/slater_integrals.h>
+
+double Slater_2S_2S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = (93*xi)/256
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((-80640 + 80640*exp(2*rxi) - 131985*rxi - 102690*pow(rxi, 2) -
+
+                          49980*pow(rxi, 3) - 16800*pow(rxi, 4) - 4032*pow(rxi, 5) -
+
+                          672*pow(rxi, 6) - 64*pow(rxi, 7))/(80640*exp(2*rxi))
+
+                         );
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = (xi*xj*(pow(xi, 6) + 7*pow(xi, 5)*xj + 21*pow(xi, 4)*pow(xj, 2) +
+
+                        35*pow(xi, 3)*pow(xj, 3) + 21*pow(xi, 2)*pow(xj, 4) +
+
+                        7*xi*pow(xj, 5) + pow(xj, 6)))/(2*pow(xi + xj, 7))
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((6*exp(2*(rxi + rxj))*pow(pow(rxi, 2) - pow(rxj, 2), 7) -
+
+                          exp(2*rxi)*pow(rxi, 6)*
+
+                          (21*pow(rxi, 4)*pow(rxj, 4)*(6 + 11*rxj + 2*pow(rxj, 2)) -
+
+                           2*pow(rxj, 8)*(90 + 54*rxj + 12*pow(rxj, 2) + pow(rxj, 3)) +
+
+                           pow(rxi, 8)*(6 + 9*rxj + 6*pow(rxj, 2) + 2*pow(rxj, 3)) +
+
+                           pow(rxi, 2)*pow(rxj, 6)*
+
+                           (-390 - 69*rxj + 18*pow(rxj, 2) + 4*pow(rxj, 3)) -
+
+                           pow(rxi, 6)*pow(rxj, 2)*
+
+                           (42 + 63*rxj + 42*pow(rxj, 2) + 4*pow(rxj, 3))) +
+
+                          exp(2*rxj)*pow(rxj, 6)*
+
+                          (-24*pow(rxi, 10) - 2*pow(rxi, 11) - 69*pow(rxi, 7)*pow(rxj, 2) +
+
+                           6*pow(rxj, 8) + 9*rxi*pow(rxj, 8) +
+
+                           4*pow(rxi, 9)*(-27 + pow(rxj, 2)) +
+
+                           18*pow(rxi, 8)*(-10 + pow(rxj, 2)) +
+
+                           6*pow(rxi, 2)*pow(rxj, 6)*(-7 + pow(rxj, 2)) -
+
+                           42*pow(rxi, 4)*pow(rxj, 4)*(-3 + pow(rxj, 2)) +
+
+                           pow(rxi, 3)*pow(rxj, 6)*(-63 + 2*pow(rxj, 2)) +
+
+                           6*pow(rxi, 6)*pow(rxj, 2)*(-65 + 7*pow(rxj, 2)) +
+
+                           pow(rxi, 5)*(231*pow(rxj, 4) - 4*pow(rxj, 6))))/
+
+                         (6*exp(2*(rxi + rxj))*pow(rxi - rxj, 7)*pow(rxi + rxj, 7))
+
+                         );
+        }
+
+    }
+    return S;
+}

--- a/src/coulombintegrals/Slater_2S_3S.cpp
+++ b/src/coulombintegrals/Slater_2S_3S.cpp
@@ -1,0 +1,146 @@
+/**********************************************************************************
+Slater_2S_3S.cpp - Compute electrostatic energy between 2S and 3S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#include <openbabel/slater_integrals.h>
+
+double Slater_2S_3S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = (451*xi)/1536
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((-4354560 + 4354560*exp(2*rxi) - 7430535*rxi - 6151950*pow(rxi, 2) -
+
+                          3275370*pow(rxi, 3) - 1251180*pow(rxi, 4) - 361368*pow(rxi, 5) -
+
+                          80640*pow(rxi, 6) - 13824*pow(rxi, 7) - 1728*pow(rxi, 8) -
+
+                          128*pow(rxi, 9))/(4.35456e6*exp(2*rxi))
+
+                         );
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = (xi*xj*(2*pow(xi, 8) + 18*pow(xi, 7)*xj + 72*pow(xi, 6)*pow(xj, 2) +
+
+                        168*pow(xi, 5)*pow(xj, 3) + 252*pow(xi, 4)*pow(xj, 4) +
+
+                        252*pow(xi, 3)*pow(xj, 5) + 108*pow(xi, 2)*pow(xj, 6) +
+
+                        27*xi*pow(xj, 7) + 3*pow(xj, 8)))/(6*pow(xi + xj, 9))
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((90*exp(2*(rxi + rxj))*pow(pow(rxi, 2) - pow(rxj, 2), 9) +
+
+                          5*exp(2*rxj)*pow(rxj, 8)*
+
+                          (-90*pow(rxi, 12) - 6*pow(rxi, 13) + 18*pow(rxj, 10) +
+
+                           27*rxi*pow(rxj, 10) + 18*pow(rxi, 2)*pow(rxj, 8)*
+
+                           (-9 + pow(rxj, 2)) - 162*pow(rxi, 4)*pow(rxj, 6)*
+
+                           (-4 + pow(rxj, 2)) - 198*pow(rxi, 10)*(5 + pow(rxj, 2)) -
+
+                           108*pow(rxi, 6)*pow(rxj, 4)*(36 + pow(rxj, 2)) +
+
+                           2*pow(rxi, 5)*pow(rxj, 6)*(675 + pow(rxj, 2)) -
+
+                           18*pow(rxi, 7)*pow(rxj, 4)*(-81 + 2*pow(rxj, 2)) +
+
+                           3*pow(rxi, 3)*pow(rxj, 8)*(-81 + 2*pow(rxj, 2)) -
+
+                           pow(rxi, 11)*(495 + 2*pow(rxj, 2)) +
+
+                           9*pow(rxi, 9)*pow(rxj, 2)*(-233 + 4*pow(rxj, 2)) +
+
+                           6*pow(rxi, 8)*pow(rxj, 2)*(-1063 + 90*pow(rxj, 2))) -
+
+                          2*exp(2*rxi)*pow(rxi, 6)*
+
+                          (-90*pow(rxi, 6)*pow(rxj, 6)*
+
+                           (42 + 65*rxj + 76*pow(rxj, 2) + 22*pow(rxj, 3) + 2*pow(rxj, 4)) -
+
+                           2*pow(rxj, 12)*(2970 + 2475*rxj + 900*pow(rxj, 2) +
+
+                                                 180*pow(rxj, 3) + 20*pow(rxj, 4) + pow(rxj, 5)) +
+
+                           10*pow(rxi, 8)*pow(rxj, 4)*
+
+                           (162 + 270*rxj + 216*pow(rxj, 2) + 122*pow(rxj, 3) +
+
+                            22*pow(rxj, 4) + pow(rxj, 5)) -
+
+                           5*pow(rxi, 4)*pow(rxj, 8)*
+
+                           (-639 - 3555*rxj - 1452*pow(rxj, 2) - 174*pow(rxj, 3) +
+
+                            6*pow(rxj, 4) + 2*pow(rxj, 5)) +
+
+                           pow(rxi, 12)*(45 + 75*rxj + 60*pow(rxj, 2) + 30*pow(rxj, 3) +
+
+                                             10*pow(rxj, 4) + 2*pow(rxj, 5)) -
+
+                           pow(rxi, 10)*pow(rxj, 2)*
+
+                           (405 + 675*rxj + 540*pow(rxj, 2) + 270*pow(rxj, 3) +
+
+                            90*pow(rxj, 4) + 8*pow(rxj, 5)) +
+
+                           pow(rxi, 2)*pow(rxj, 10)*
+
+                           (-21615 - 9075*rxj - 300*pow(rxj, 2) + 490*pow(rxj, 3) +
+
+                            110*pow(rxj, 4) + 8*pow(rxj, 5))))/
+
+                         (90*exp(2*(rxi + rxj))*pow(rxi - rxj, 9)*pow(rxi + rxj, 9))
+
+                         );
+        }
+
+    }
+    return S;
+}
+
+
+double Slater_3S_2S(double r, double xi, double xj)
+{
+    return Slater_2S_3S(r, xj, xi);
+}
+

--- a/src/coulombintegrals/Slater_3S_3S.cpp
+++ b/src/coulombintegrals/Slater_3S_3S.cpp
@@ -1,0 +1,185 @@
+/**********************************************************************************
+Slater_3S_3S.cpp - Compute electrostatic energy between two 3S Slater orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#include <openbabel/slater_integrals.h>
+
+double Slater_3S_3S(double r, double xi, double xj)
+{
+    double S, rxi, rxj;
+
+    rxi = rxj = S = 0;
+    rxi = r*xi;
+    rxj = r*xj;
+    if (xi == xj)
+    {
+        if (r == 0)
+        {
+            S = (793*xi)/3072
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((-1437004800 + 1437004800*exp(2*rxi) - 2503064025*rxi -
+
+                          2132118450*pow(rxi, 2) - 1180664100*pow(rxi, 3) -
+
+                          476506800*pow(rxi, 4) - 148856400*pow(rxi, 5) -
+
+                          37255680*pow(rxi, 6) - 7603200*pow(rxi, 7) - 1267200*pow(rxi, 8) -
+
+                          168960*pow(rxi, 9) - 16896*pow(rxi, 10) - 1024*pow(rxi, 11))/
+
+                         (1.4370048e9*exp(2*rxi))
+
+                         );
+        }
+
+    }
+    else
+    {
+        if (r == 0)
+        {
+            S = (xi*xj*(pow(xi, 10) + 11*pow(xi, 9)*xj + 55*pow(xi, 8)*pow(xj, 2) +
+
+                        165*pow(xi, 7)*pow(xj, 3) + 330*pow(xi, 6)*pow(xj, 4) +
+
+                        462*pow(xi, 5)*pow(xj, 5) + 330*pow(xi, 4)*pow(xj, 6) +
+
+                        165*pow(xi, 3)*pow(xj, 7) + 55*pow(xi, 2)*pow(xj, 8) +
+
+                        11*xi*pow(xj, 9) + pow(xj, 10)))/(3*pow(xi + xj, 11))
+
+            ;
+        }
+        else
+        {
+            S = (1/r)*((135*exp(2*(rxi + rxj))*pow(pow(rxi, 2) - pow(rxj, 2), 11) +
+
+                          exp(2*rxj)*pow(rxj, 8)*
+
+                          (-150*pow(rxi, 18) - 6*pow(rxi, 19) + 135*pow(rxj, 14) +
+
+                           225*rxi*pow(rxj, 14) + 10*pow(rxi, 17)*(-165 + pow(rxj, 2)) -
+
+                           30*pow(rxi, 16)*(330 + pow(rxj, 2)) +
+
+                           45*pow(rxi, 3)*pow(rxj, 12)*(-55 + 2*pow(rxj, 2)) +
+
+                           45*pow(rxi, 2)*pow(rxj, 12)*(-33 + 4*pow(rxj, 2)) +
+
+                           pow(rxi, 9)*pow(rxj, 6)*
+
+                           (234135 - 4950*pow(rxj, 2) - 34*pow(rxj, 4)) -
+
+                           5*pow(rxi, 7)*pow(rxj, 8)*
+
+                           (6237 - 1242*pow(rxj, 2) + 2*pow(rxj, 4)) +
+
+                           3*pow(rxi, 5)*pow(rxj, 10)*
+
+                           (4125 - 330*pow(rxj, 2) + 2*pow(rxj, 4)) +
+
+                           15*pow(rxi, 4)*pow(rxj, 10)*
+
+                           (495 - 132*pow(rxj, 2) + 2*pow(rxj, 4)) -
+
+                           165*pow(rxi, 6)*pow(rxj, 8)*
+
+                           (135 - 60*pow(rxj, 2) + 2*pow(rxj, 4)) -
+
+                           5*pow(rxi, 13)*pow(rxj, 2)*
+
+                           (43875 - 3438*pow(rxj, 2) + 22*pow(rxj, 4)) +
+
+                           5*pow(rxi, 11)*pow(rxj, 4)*
+
+                           (7695 - 2442*pow(rxj, 2) + 22*pow(rxj, 4)) +
+
+                           15*pow(rxi, 8)*pow(rxj, 6)*
+
+                           (-33 - 3564*pow(rxj, 2) + 26*pow(rxj, 4)) +
+
+                           pow(rxi, 15)*(-32175 - 3690*pow(rxj, 2) + 34*pow(rxj, 4)) +
+
+                           15*pow(rxi, 10)*pow(rxj, 4)*
+
+                           (-32277 + 1364*pow(rxj, 2) + 66*pow(rxj, 4)) +
+
+                           15*pow(rxi, 14)*(-3003 - 2932*pow(rxj, 2) + 94*pow(rxj, 4)) -
+
+                           15*pow(rxi, 12)*pow(rxj, 2)*
+
+                           (28119 - 5252*pow(rxj, 2) + 154*pow(rxj, 4))) +
+
+                          exp(2*rxi)*pow(rxi, 8)*
+
+                          (-5*pow(rxi, 2)*pow(rxj, 12)*
+
+                           (-84357 - 43875*rxj - 8796*pow(rxj, 2) - 738*pow(rxj, 3) -
+
+                            6*pow(rxj, 4) + 2*pow(rxj, 5)) -
+
+                           3*pow(rxi, 14)*(45 + 75*rxj + 60*pow(rxj, 2) + 30*pow(rxj, 3) +
+
+                                                 10*pow(rxj, 4) + 2*pow(rxj, 5)) -
+
+                           55*pow(rxi, 8)*pow(rxj, 6)*
+
+                           (-405 - 567*rxj - 972*pow(rxj, 2) - 90*pow(rxj, 3) +
+
+                            18*pow(rxj, 4) + 2*pow(rxj, 5)) +
+
+                           55*pow(rxi, 6)*pow(rxj, 8)*
+
+                           (9 - 4257*rxj - 372*pow(rxj, 2) + 222*pow(rxj, 3) +
+
+                            42*pow(rxj, 4) + 2*pow(rxj, 5)) +
+
+                           3*pow(rxj, 14)*(15015 + 10725*rxj + 3300*pow(rxj, 2) +
+
+                                                 550*pow(rxj, 3) + 50*pow(rxj, 4) + 2*pow(rxj, 5)) +
+
+                           5*pow(rxi, 12)*pow(rxj, 2)*
+
+                           (297 + 495*rxj + 396*pow(rxj, 2) + 198*pow(rxj, 3) +
+
+                            66*pow(rxj, 4) + 2*pow(rxj, 5)) +
+
+                           pow(rxi, 10)*pow(rxj, 4)*
+
+                           (-7425 - 12375*rxj - 9900*pow(rxj, 2) - 6210*pow(rxj, 3) -
+
+                            390*pow(rxj, 4) + 34*pow(rxj, 5)) -
+
+                           pow(rxi, 4)*pow(rxj, 10)*
+
+                           (-484155 + 38475*rxj + 78780*pow(rxj, 2) + 17190*pow(rxj, 3) +
+
+                            1410*pow(rxj, 4) + 34*pow(rxj, 5))))/
+
+                         (135*exp(2*(rxi + rxj))*pow(rxi - rxj, 11)*pow(rxi + rxj, 11))
+
+                         );
+        }
+
+    }
+    return S;
+}

--- a/src/coulombintegrals/gaussian_integrals.cpp
+++ b/src/coulombintegrals/gaussian_integrals.cpp
@@ -1,0 +1,154 @@
+/**********************************************************************************
+gaussian_integrals.cpp - coulombintegrals for Gaussian s-type orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#include <math.h>
+#include <stdio.h>
+
+#include <openbabel/gaussian_integrals.h>
+
+static double sqr(double x)
+{
+    return x*x;
+}
+
+double Nuclear_GG(double r, double zeta)
+{
+    /* This routine may be called with zeta 0.
+     * In that case it is a simple 1/r interaction.
+     */
+    if (zeta == 0)
+    {
+        if (r == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1.0/r;
+        }
+    }
+    else if (r == 0)
+    {
+        return 2.0*zeta/sqrt(M_PI);
+    }
+    else
+    {
+        return erf(zeta*r)/r;
+    }
+}
+
+double Coulomb_GG(double r, double zi, double zj)
+{
+    double zeff;
+
+    /* This routine may be called with one or both zeta 0.
+     * In that case it is either a Nuclear_GG or simple 1/r interaction.
+     */
+    if ((zi == 0) && (zj == 0))
+    {
+        if (r == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1/r;
+        }
+    }
+    else
+    {
+        if (zi == 0)
+        {
+            zeff = zj;
+        }
+        else if (zj == 0)
+        {
+            zeff = zi;
+        }
+        else
+        {
+            zeff = zi*zj/sqrt(sqr(zi)+sqr(zj));
+        }
+
+        return Nuclear_GG(r, zeff);
+    }
+}
+
+double DNuclear_GG(double r, double z)
+{
+    double rz = r * z;
+    double dngg;
+
+    if (z == 0)
+    {
+        if (r == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return -1.0/sqr(r);
+        }
+    }
+    else if (r == 0)
+    {
+        dngg = 0;
+    }
+    else
+    {
+        dngg = (-1)*((2.0/sqrt(M_PI))*exp(-sqr(rz))*(z/r) - erf(rz)/sqr(r));
+    }
+
+    return dngg;
+}
+
+double DCoulomb_GG(double r, double zi, double zj)
+{
+    double zeff;
+
+    if ((zi == 0) && (zj == 0))
+    {
+        if (r == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return -1/sqr(r);
+        }
+    }
+    else
+    {
+        if (zi == 0)
+        {
+            zeff = zj;
+        }
+        else if (zj == 0)
+        {
+            zeff = zi;
+        }
+        else
+        {
+            zeff = zi*zj/sqrt(sqr(zi)+sqr(zj));
+        }
+
+        return DNuclear_GG(r, zeff);
+    }
+}

--- a/src/coulombintegrals/slater_integrals.cpp
+++ b/src/coulombintegrals/slater_integrals.cpp
@@ -1,0 +1,295 @@
+/**********************************************************************************
+gaussian_integrals.cpp - coulombintegrals for Slater s-type orbitals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+
+#include <stdio.h>
+#include <cmath>
+#include <iostream>
+
+#include <openbabel/slater_integrals.h>
+
+using namespace std;
+
+#define SLATER_MAX 3
+
+typedef double t_slater_SS_func (double r, double xi, double xj);
+typedef double t_slater_NS_func (double r, double xi);
+
+t_slater_SS_func (*Slater_SS[SLATER_MAX][SLATER_MAX]) = {
+    {  Slater_1S_1S,  Slater_1S_2S,  Slater_1S_3S},
+    {  Slater_2S_1S,  Slater_2S_2S,  Slater_2S_3S},
+    {  Slater_3S_1S,  Slater_3S_2S,  Slater_3S_3S}
+};
+
+t_slater_SS_func (*DSlater_SS[SLATER_MAX][SLATER_MAX]) = {
+    {  DSlater_1S_1S,  DSlater_1S_2S,  DSlater_1S_3S},
+    {  DSlater_2S_1S,  DSlater_2S_2S,  DSlater_2S_3S},
+    {  DSlater_3S_1S,  DSlater_3S_2S,  DSlater_3S_3S}
+};
+
+t_slater_NS_func (*Slater_NS[SLATER_MAX])  = {Nuclear_1S,  Nuclear_2S,  Nuclear_3S};
+
+t_slater_NS_func (*DSlater_NS[SLATER_MAX]) = {DNuclear_1S,  DNuclear_2S,  DNuclear_3S};
+
+
+double Nuclear_1S(double r, double xi)
+{
+    double S = 0;
+    S = 1/r - (1 + r*xi)/(exp(2*r*xi)*r)
+
+    ;
+
+    return S;
+}
+
+double Nuclear_2S(double r, double xi)
+{
+    double S = 0;
+    S = 1/r - (6 + 9*r*xi + 6*pow(r, 2)*pow(xi, 2) + 2*pow(r, 3)*pow(xi, 3))/
+
+        (6*exp(2*r*xi)*r)
+
+    ;
+
+    return S;
+}
+
+double Nuclear_3S(double r, double xi)
+{
+    double S = 0;
+    S = 1/r - (45 + 75*r*xi + 60*pow(r, 2)*pow(xi, 2) +
+
+                 30*pow(r, 3)*pow(xi, 3) + 10*pow(r, 4)*pow(xi, 4) +
+
+                 2*pow(r, 5)*pow(xi, 5))/(45*exp(2*r*xi)*r)
+
+    ;
+
+    return S;
+}
+
+double DNuclear_1S(double r, double xi)
+{
+    double S = 0;
+    S = pow(r, -2) - (1 + 2*r*xi + 2*pow(r, 2)*pow(xi, 2))/
+
+        (exp(2*r*xi)*pow(r, 2))
+
+    ;
+
+    return S;
+}
+
+double DNuclear_2S(double r, double xi)
+{
+    double S = 0;
+    S = pow(r, -2) - (3 + 6*r*xi + 6*pow(r, 2)*pow(xi, 2) +
+
+                          4*pow(r, 3)*pow(xi, 3) + 2*pow(r, 4)*pow(xi, 4))/
+
+        (3*exp(2*r*xi)*pow(r, 2))
+
+    ;
+
+    return S;
+}
+
+double DNuclear_3S(double r, double xi)
+{
+    double S = 0;
+    S = pow(r, -2) - (45 + 90*r*xi + 90*pow(r, 2)*pow(xi, 2) +
+
+                          60*pow(r, 3)*pow(xi, 3) + 30*pow(r, 4)*pow(xi, 4) +
+
+                          12*pow(r, 5)*pow(xi, 5) + 4*pow(r, 6)*pow(xi, 6))/
+
+        (45*exp(2*r*xi)*pow(r, 2))
+
+    ;
+
+    return S;
+}
+
+double Coulomb_SS(double r, int i, int j, double xi, double xj)
+{   
+    double S = 0;
+    if ((i > SLATER_MAX) || (j > SLATER_MAX))
+    {
+        cout << "Slater-Slater integral" << i << j << "not supported. Thus, they will reduce to the SLATER_MAX" << SLATER_MAX << endl;
+    }    
+    if (i > SLATER_MAX)
+    {
+        i = SLATER_MAX;
+    }
+    if (j > SLATER_MAX)
+    {
+        j = SLATER_MAX;
+    }    
+    if ((i > 0) && (j > 0))
+    {
+        S = Slater_SS[i-1][j-1](r, xi, xj);
+    }
+    else if (j > 0)
+    {
+        if (r == 0)
+        {
+            S = xj/j;
+        }
+        else
+        {
+            S = Slater_NS[j-1](r, xj);
+        }
+    }
+    else if (i > 0)
+    {
+        if (r == 0)
+        {
+            S = xi/i;
+        }
+        else
+        {
+            S = Slater_NS[i-1](r, xi);
+        }
+    }
+    else
+    {
+        if (r == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1/r;
+        }
+    }
+    return S;
+}
+
+double Nuclear_SS(double r, int i, double xi)
+{
+    double S = 0;
+    if (xi == 0)
+    {
+        if (r == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1/r;
+        }
+    }
+    else if (r == 0)
+    {
+        return xi/i;
+    }
+    else if (i <= 0)
+    {
+        return 1/r;
+    }
+    else
+    {
+        S  = Slater_NS[i-1](r, xi);
+        return S;
+    }
+}
+
+double DCoulomb_SS(double r, int i, int j, double xi, double xj)
+{
+    double S = 0;    
+    if ((i > SLATER_MAX) || (j > SLATER_MAX))
+    {
+        cout << "Slater-Slater integral" << i << j << "not supported. Thus, they will reduce to the SLATER_MAX" << SLATER_MAX << endl;
+    }    
+    if (i > SLATER_MAX)
+    {
+        i = SLATER_MAX;
+    }
+    if (j > SLATER_MAX)
+    {
+        j = SLATER_MAX;
+    }
+    if ((i > 0) && (j > 0))
+    {
+        S = DSlater_SS[i-1][j-1](r, xi, xj);
+    }
+    else if (j > 0)
+    {
+        if (r == 0)
+        {
+            S = 0;
+        }
+        else
+        {
+            S = DSlater_NS[j-1](r, xj);
+        }
+    }
+    else if (i > 0)
+    {
+        if (r == 0)
+        {
+            S = 0;
+        }
+        else
+        {
+            S = DSlater_NS[i-1](r, xi);
+        }
+    }
+    else
+    {
+        if (r == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return -1/(r*r);
+        }
+    }
+    return S;
+}
+
+double DNuclear_SS(double r, int i, double xi)
+{
+    double S = 0;
+    if (i > SLATER_MAX)
+    {
+        cout << "Slater-Slater integral" << i << "not supported. Thus, they will reduce to the SLATER_MAX" << SLATER_MAX << endl;
+        i = SLATER_MAX;
+    }    
+    if (r == 0)
+    {
+        return 0;
+    }
+    else
+    {
+        if ((xi == 0) || (i <= 0))
+        {
+            return -1/(r*r);
+        }
+        else
+        {
+            S  = DSlater_NS[i-1](r, xi);
+            return S;
+        }
+    }
+}
+
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ set (cpptests
      cistrans graphsym gzip
      implicitH lssr isomorphism multicml regressions rotor shuffle smiles spectrophore
      squareplanar stereo stereoperception tautomer tetrahedral
-     tetranonplanar tetraplanar uniqueid
+     tetranonplanar tetraplanar uniqueid coulomb
     )
 set (automorphism_parts 1 2 3 4 5 6 7 8 9 10)
 set (builder_parts 1 2 3 4 5)
@@ -48,6 +48,7 @@ set (tetrahedral_parts 1 2 3 4 5)
 set (tetranonplanar_parts 1)
 set (tetraplanar_parts 1)
 set (uniqueid_parts 1 2)
+set (coulomb_parts 1 2 3 4 5 6 7 8 9 10 11)
 
 if (EIGEN2_FOUND OR EIGEN3_FOUND)
   set(cpptests

--- a/test/coulombtest.cpp
+++ b/test/coulombtest.cpp
@@ -1,0 +1,141 @@
+/**********************************************************************************
+coulombtest.cpp - Test the Slater and Gaussian integrals
+
+Copyright (C) 2018 by Mohammad M Ghahremanpour <mohammad.ghahremanpour@icm.uu.se>
+                      David van der Spoel Group
+                      Uppsala University
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************************/
+
+#include "obtest.h"
+
+#include <openbabel/obutil.h>
+#include <openbabel/babelconfig.h>
+#include <openbabel/slater_integrals.h>
+#include <openbabel/gaussian_integrals.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+using namespace OpenBabel;
+
+enum CoulombTestType{
+    eEnergy,
+    eForce 
+};
+
+int test_Slater(double r, int  i, int  j, 
+                double  xi, double  xj, 
+                double ref_value, int test_number, 
+                CoulombTestType ctt)
+{
+    double test_value = 0;
+    if (ctt == eEnergy)
+        test_value = Coulomb_SS(r, i, j, xi, xj);   
+    else
+        test_value = -DCoulomb_SS(r, i, j, xi, xj);
+        
+    if (IsNear(test_value, ref_value, 1e-10))
+    {
+        cout << "ok Slater test " << test_number << endl;
+        return 0;
+    }
+    else
+    {
+        cout << "not ok Slater test " << test_number  << endl;
+        cout << "Test value: " << test_value << "Ref Value: " << ref_value << endl;
+        return -1;
+    }
+}
+
+
+int test_Gaussian(double r, double  xi, double  xj, 
+                  double ref_value, int test_number, 
+                  CoulombTestType ctt)
+{
+    double test_value = 0;
+    if (ctt == eEnergy)
+        test_value = Coulomb_GG(r, xi, xj);   
+    else
+        test_value = -DCoulomb_GG(r, xi, xj);
+           
+    if (IsNear(test_value, ref_value, 1e-10))
+    {
+        cout << "ok Slater test " << test_number << endl;
+        return 0;
+    }
+    else
+    {
+      cout << "not ok Slater test " << test_number  << endl;
+      cout << "Test value: " << test_value << "Ref Value: " << ref_value << endl;
+      return -1;
+    }
+}
+
+int coulombtest(int argc, char* argv[])
+{
+  int defaultchoice = 1;  
+  int choice = defaultchoice;
+
+  if (argc > 1) {
+    if(sscanf(argv[1], "%d", &choice) != 1) {
+      printf("Couldn't parse that input as a number\n");
+      return -1;
+    }
+  }
+
+  switch(choice) {
+  case 1:
+      return test_Slater(0.1, 1, 2, 12.0, 16.0, 5.7637290944563961, choice, eEnergy);
+      break;
+  case 2:
+      return test_Slater(0.1, 1, 3, 12.0, 17.0, 4.86819764284163, choice, eEnergy);
+      break;    
+  case 3:
+      return test_Slater(0.1, 1, 3, 12.0, 17.0, -5.7309185468702326, choice, eForce);
+      break;
+  case 4:
+      return test_Slater(0, 3, 3, 11.0, 8.0, 2.3476310210961322, choice, eEnergy); // Slater 3s-3s energy at r = 0
+      break;    
+  case 5:
+      return test_Slater(0, 3, 3, 11.0, 8.0, -0, choice, eForce); //Slater 3s-3s force at r = 0
+      break;
+  case 6:
+      return test_Slater(2, 3, 3, 11.0, 8.0, 0.49999998663716444, choice, eEnergy);
+      break;    
+  case 7:
+      return test_Slater(2, 3, 3, 11.0, 8.0, -0.24999982269334378, choice, eForce);
+      break;
+  case 8:
+      return test_Gaussian(0.1, 7.0, 7.0, 5.1607269555385402, choice, eEnergy);
+      break;
+  case 9:
+      return test_Gaussian(0.1, 7.0, 7.0, -7.8917188840388235, choice, eForce);
+      break;
+  case 10:
+      return test_Gaussian(0, 5.0, 8.0, 4.7843180998583428, choice, eEnergy); //Gaussian energy at r = 0
+      break;
+  case 11:
+      return test_Gaussian(0, 5.0, 8.0, -0, choice, eForce); //Gaussian force at r = 0
+      break;
+  default:
+      cout << "Test number " << choice << " does not exist!\n";
+      return -1;
+  }
+  return 0;
+}
+


### PR DESCRIPTION
This patch includes analytical solutions for Coulomb overlap integrals for Gaussian and Slater (1s, 2s, and 3s) orbitals.