### PR TITLE
Revert "Updates to SMILES options to specify first and last atoms when writing"

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -150,19 +150,11 @@ namespace OpenBabel {
         "  F  <atom numbers> Generate SMILES for a fragment\n"
         "     The atom numbers should be specified like \"1 2 4 7\".\n"
         "  R  Do not reuse bond closure symbols\n"
-        "  f  <atomno> Specify the first atom and adjust any implicit hydrogen count\n"
-        "     This atom will be used to begin the SMILES string. If the atom\n"
-        "     would normally have a hydrogen count specified, the number\n"
-        "     of hydrogens will be reduced by one. This makes it easy to\n"
-        "     concatenate SMILES strings to generate new molecules.\n\n"
-        "  g  <atomno> Specify the first atom\n"
+        "  f  <atomno> Specify the first atom\n"
         "     This atom will be used to begin the SMILES string.\n"
-        "  l  <atomno> Specify the last atom and adjust for concatenation\n"
+        "  l  <atomno> Specify the last atom\n"
         "     The output will be rearranged so that any additional\n"
-        "     SMILES added to the end will be attached to this atom. If the atom\n"
-        "     would normally have a hydrogen count specified, the number\n"
-        "     of hydrogens will be reduced by one. This makes it easy to\n"
-        "     concatenate SMILES strings to generate new molecules.\n\n"
+        "     SMILES added to the end will be attached to this atom.\n\n"
         "  T  <max seconds> Specify the canonicalization timeout\n"
         "     Canonicalization can take a while for symmetric molecules and a\n"
         "     timeout is used. The default is 5 seconds.\n\n"
@@ -2304,7 +2296,6 @@ namespace OpenBabel {
 
     OBAtom* _endatom;
     OBAtom* _startatom;
-    bool _startatom_adjustvalence;
 
     OutOptions &options;
 
@@ -2381,8 +2372,6 @@ namespace OpenBabel {
 
     _endatom = NULL;
     _startatom = NULL;
-    _startatom_adjustvalence = false;
-    
   }
 
 
@@ -2796,8 +2785,8 @@ namespace OpenBabel {
 
     // Add extra hydrogens.
     int hcount = numImplicitHs;
-    if (hcount > 0 && (atom == _endatom || (_startatom_adjustvalence && atom == _startatom)))
-      hcount--; // Leave a free valence for attachment
+    if (hcount > 0 && (atom == _endatom || atom == _startatom)) // Leave a free valence for attachment
+      hcount--;
     if (hcount > 0) {
       if (options.smarts && stereo == (const char*)0) {
         char tcount[10];
@@ -3361,7 +3350,7 @@ namespace OpenBabel {
     // and we cannot concatenate another SMILES string without creating a 5-valent C.
 
     bool is_chiral = AtomIsChiral(atom);
-    if (is_chiral && atom!=_endatom && (!_startatom_adjustvalence || atom!=_startatom)) {
+    if (is_chiral && atom!=_endatom && atom!=_startatom) {
 
       // If there's a parent node, it's the first atom in the ordered neighbor-vector
       // used for chirality.
@@ -3776,28 +3765,16 @@ namespace OpenBabel {
     symmetry_classes.reserve(mol.NumAtoms());
     canonical_order.reserve(mol.NumAtoms());
 
-    // Remember the desired endatom, if specified.
+    // Remember the desired endatom, if specified
     const char* pp = _pconv->IsOption("l");
     unsigned int atom_idx  = pp ? atoi(pp) : 0;
     if (atom_idx >= 1 && atom_idx <= mol.NumAtoms())
       _endatom = mol.GetAtom(atom_idx);
-
-    // Was a start atom specified? This can be done via either 'f' or 'g'
-    // - 'f' takes precedence over 'g'
+    // Was a start atom specified?
     pp = _pconv->IsOption("f");
     atom_idx  = pp ? atoi(pp) : 0;
-    if (atom_idx >= 1 && atom_idx <= mol.NumAtoms()) {
+    if (atom_idx >= 1 && atom_idx <= mol.NumAtoms())
       _startatom = mol.GetAtom(atom_idx);
-      _startatom_adjustvalence = true;
-    }
-    if (!_startatom) {
-      pp = _pconv->IsOption("g");
-      atom_idx = pp ? atoi(pp) : 0;
-      if (atom_idx >= 1 && atom_idx <= mol.NumAtoms()) {
-        _startatom = mol.GetAtom(atom_idx);
-        // By default, _startatom_adjustvalence = false;
-      }
-    }
 
     // Was an atom ordering specified?
     const char* ppo = options.ordering;

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -54,24 +54,6 @@ class PybelWrapper(PythonBindings):
 
 class TestSuite(PythonBindings):
 
-    def testSettingFirstAndLastAtom(self):
-        """Test options for specifying first/last atom in SMILES"""
-        # Some basic tests of 'f', 'g' and 'l'
-        data = [("I[14CH2]F",
-                 [({"f": 2}, "[14CH](I)F"),
-                  ({"g": 2}, "[14CH2](I)F"),
-                  ({"l": 2}, "I[14CH](F)")]),
-                ("F[C@@H](Cl)Br",
-                 [({"f": 2}, "C(F)(Cl)Br"),
-                  ({"g": 2}, "[C@H](F)(Cl)Br"),
-                  ({"l": 2}, "FC(Cl)(Br)")]),
-                 ]
-        for smi, testcases in data:
-            mol = pybel.readstring("smi", smi)
-            for options, output in testcases:
-                myoutput = mol.write("smi", opt=options).rstrip()
-                self.assertEqual(output, myoutput)
-
     def testInChIIsotopes(self):
         """Ensure that we correctly set and read isotopes in InChIs"""
         with open(os.path.join(here, "inchi", "inchi_isotopes.txt")) as inp:


### PR DESCRIPTION
Reverts openbabel/openbabel#1870 as it appears to cause a test failure with clang