### PR TITLE
ADF DFTB: Add new detection string for ADF 2018

### DIFF
--- a/src/formats/adfformat.cpp
+++ b/src/formats/adfformat.cpp
@@ -604,7 +604,8 @@ namespace OpenBabel {
           pmol->SetData(cell);
         }
       }
-      else if (strcmp(buffer, "Energies") == 0) {
+      else if (strcmp(buffer, "Energies") == 0 ||
+               strcmp(buffer, "Energy Decomposition") == 0) {
         // Final energy line looks like this:
         // Total Energy (eV)                   -220.34976964
         while (ifs.getline(buffer, BUFF_SIZE)) {

--- a/src/formats/outformat.cpp
+++ b/src/formats/outformat.cpp
@@ -124,6 +124,11 @@ namespace OpenBabel
           } else if (strstr(buffer, "|     D F T B     |") != NULL) {
             formatName = "adfdftb";
             break;
+          } else if (strstr(buffer, "DFTB Engine") != NULL) {
+            // "|     D F T B     |" is no longer printed in ADF 2018
+            // Hopefully, "DFTB Engine" will work fine...
+            formatName = "adfdftb";
+            break;
           }
         }
         break;


### PR DESCRIPTION
For ADF 2018 (which has not yet been released), the string
"|     D F T B     |" is no longer printed in DFTB output. This
is partially because they changed several of their executables to
run via an "ams" executable instead, including the dftb executable.

Hopefully, "DFTB Engine" will suffice instead... it seems to work thus
far.