### PR TITLE
Changed indexing of fragments, should fix #1889

### DIFF
--- a/src/mcdlutil.cpp
+++ b/src/mcdlutil.cpp
@@ -5983,7 +5983,7 @@ namespace OpenBabel {
       pf->fragID1=0;
       pf->fragID2=0;
       pf->fragID3=0;
-      pf->fragFirstAtomNo=nA+1;
+      pf->fragFirstAtomNo=nA; // Was nA+1, lead to off-by-one problems with fragments
       pf->fragmentCount=1;
       pf->fragWidth=xMax-xMin;
       pf->fragHeight=yMax-yMin;

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -22,6 +22,7 @@ import os
 import re
 import sys
 import unittest
+import itertools
 
 here = sys.path[0]
 iswin = sys.platform.startswith("win")
@@ -461,6 +462,17 @@ H         -0.26065        0.64232       -2.62218
         self.assertEqual(elements, [6,6,6,6,6,6,6,8,17])
         bonds = list(ob.OBMolBondIter(mol.OBMol))
         self.assertEqual(len(bonds), 9)
+
+    def testProper2DofFragments(self):
+        """Check for proper handling of fragments in mcdl routines, see issue #1889"""
+        mol = pybel.readstring("smi", "[H+].CC[O-].CC[O-]")
+        mol.draw(show=False, update=True)
+        dists = [
+            abs(a.coords[0] - b.coords[0]) + abs(a.coords[1] - b.coords[1])
+            for a, b in itertools.combinations(mol.atoms, 2)
+        ]
+        mindist = min(dists)
+        self.assertTrue(mindist > 0.00001)
 
 class NewReactionHandling(PythonBindings):
 


### PR DESCRIPTION
This should fix #1889 
It looks like there was a problem with 0-based and 1-based indexing in mcdlutil.