### PR TITLE
Compile project in Cygwin without xtcformat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,12 @@ check_library_exists(dl dlopen "" HAVE_LIBDL)
 set(CMAKE_EXTRA_INCLUDE_FILES time.h)
 check_type_size(clock_t CLOCK_T)
 
+# Cygwin may be missing an XDR function: https://www.gnu.org/software/gnulib/manual/html_node/xdrstdio_005fcreate.html
+if(CYGWIN)
+  set(HAVE_RPC_XDR_H FALSE)
+  message(STATUS "Disabling rpc/xdr.h for Cygwin")
+endif()
+
 # Get the GCC version - from KDE4 cmake files
 if(CMAKE_COMPILER_IS_GNUCXX)
   if(NOT(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 4.0.0))


### PR DESCRIPTION
Compile project in Cygwin without xtcformat

Cygwin cannot successfully compile the development version of Open Babel due to some errors in linking xtcformat.so:

```
[ 34%] Linking CXX shared module ../../lib/xtcformat.so
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x418): undefinedreference to `xdrstdio_create'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x418): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `xdrstdio_create'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x463): undefinedreference to `xdrstdio_create'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x463): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `xdrstdio_create'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0xe18): undefinedreference to `xdr_int'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0xe18): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `xdr_int'
< [similar lines omitted] >
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x10a5): undefined reference to `xdr_opaque'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x174c): undefined reference to `xdr_int'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x1782): undefined reference to `xdr_float'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x1a50): undefined reference to `xdr_vector'
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x1a99): undefined reference to `xdr_vector'
< [etc.] >
CMakeFiles/xtcformat.dir/xtcformat.cpp.o:xtcformat.cpp:(.text+0x2f72): more undefined references to `xdr_float' follow
collect2: error: ld returned 1 exit status
make[2]: *** [src/formats/CMakeFiles/xtcformat.dir/build.make:103: lib/xtcformat.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:1675: src/formats/CMakeFiles/xtcformat.dir/all] Error 2
```

Apparently there were some upstream `gcc` changes removing Sun's RPC implementation from glibc, and some of the necessary functions (e.g. `xcrstdio_create`) aren't available in Cygwin.  I don't know much about it except what I found from these links: https://bugzilla.redhat.com/show_bug.cgi?id=1537432 and https://savannah.gnu.org/forum/forum.php?forum_id=8921

As a workaround, I marked the RPC library as unavailable for Cygwin, which disables the xtcformat but otherwise allows the project to compile successfully.