### PR TITLE
WIP: Fixes OBChemTsfm regression in hydrogen count

### DIFF
--- a/test/regressionstest.cpp
+++ b/test/regressionstest.cpp
@@ -41,6 +41,16 @@ void test_OBChemTsfm()
   b.Apply(mol);
   out = conv.WriteString(&mol, true);
   OB_COMPARE(out, "ClC=CBr");
+
+  // Test for wrapping of unsigned integers
+  conv.ReadString(&mol, "ClC(=O)[O]");
+  start = "[#6]-[OD1:1]";
+  end = "[#6]-[O-1:1]";
+  OBChemTsfm c;
+  c.Init(start, end);
+  c.Apply(mol);
+  out = conv.WriteString(&mol, true);
+  OB_COMPARE(out, "ClC(=O)[OH255-]");  // we would expect "ClC(=O)[O-]"
 }
 
 // Open Babel was previously disappearing triple bonds when provided with SMILES


### PR DESCRIPTION
Some OBChemTsfm transformations, especially on radicals, can result in unexpected implicit hydrogen counts since PR#1576.  I wrote up an example failure in the first commit of this PR, where assigning a charge of -1 to an atom can give it 255 implicit hydrogens under certain conditions.

I suspect the underlying cause is unsigned integer arithmetic in phmodel.cpp:321 (possibly also 343).  Subtraction of two unsigned ints gives an unsigned int--if the difference would be negative, then the result is wrapped back to `UINT_MAX`, e.g. printing `(j->second - old_bond_order)` gives 4294967295 instead of -1.  Then there's some truncation to fit in the unsigned char.  But even if the overall expression gives the right answer most of the time, I think it would be clearer to be more explicit about the math, which would fix special cases like this bug.

How should we adjust the line(s) of code in phmodel.cpp?  We could explicitly typecast everything to a signed int then ensure that there are at least zero implicit hydrogens, but that seems verbose.  @baoilleach Please feel free to directly commit on my PR if you have any ideas.  Of course we'll need to update the test case with the correct answer as well (not H255).