### PR TITLE
Fix OBChemTsfm wrapping of implicit H counts

### DIFF
--- a/src/phmodel.cpp
+++ b/src/phmodel.cpp
@@ -316,9 +316,12 @@ namespace OpenBabel
           for (j = _vchrg.begin();j != _vchrg.end();++j)
             if (j->first < (signed)i->size()) { //goof proofing
               OBAtom *atom = mol.GetAtom((*i)[j->first]);
-              unsigned int old_charge = atom->GetFormalCharge();
+              int old_charge = atom->GetFormalCharge();
               atom->SetFormalCharge(j->second);
-              atom->SetImplicitHCount(atom->GetImplicitHCount() + (j->second - old_charge));
+              int new_hcount = atom->GetImplicitHCount() + (j->second - old_charge);
+              if (new_hcount < 0)
+                new_hcount = 0;
+              atom->SetImplicitHCount(new_hcount);
             }
       }
 
@@ -340,7 +343,10 @@ namespace OpenBabel
               bond->SetBondOrder(j->second);
               for (int k = 0; k < 2; ++k) {
                 OBAtom* atom = k == 0 ? bond->GetBeginAtom() : bond->GetEndAtom();
-                atom->SetImplicitHCount(atom->GetImplicitHCount() - (j->second - old_bond_order));
+                int new_hcount = atom->GetImplicitHCount() - (j->second - old_bond_order);
+                if (new_hcount < 0)
+                  new_hcount = 0;
+                atom->SetImplicitHCount(new_hcount);
               }
             }
       }

--- a/test/regressionstest.cpp
+++ b/test/regressionstest.cpp
@@ -41,6 +41,24 @@ void test_OBChemTsfm()
   b.Apply(mol);
   out = conv.WriteString(&mol, true);
   OB_COMPARE(out, "ClC=CBr");
+
+  conv.ReadString(&mol, "ClC(=O)[O]");
+  start = "[#6]-[OD1:1]";
+  end = "[#6]-[O-1:1]";
+  OBChemTsfm c;
+  c.Init(start, end);
+  c.Apply(mol);
+  out = conv.WriteString(&mol, true);
+  OB_COMPARE(out, "ClC(=O)[O-]");
+
+  conv.ReadString(&mol, "Cl[C]CBr");
+  start = "Cl[C:1]-[C:2]";
+  end = "[C:1]=[C:2]";
+  OBChemTsfm d;
+  d.Init(start, end);
+  d.Apply(mol);
+  out = conv.WriteString(&mol, true);
+  OB_COMPARE(out, "Cl[C]=CBr");
 }
 
 // Open Babel was previously disappearing triple bonds when provided with SMILES


### PR DESCRIPTION
Fix OBChemTsfm handling where the implicit H count was going below 0 and wrapping. As reported by @bbucior. See #1895 for more info. Includes the test case reported by Ben along with another one for the same problem triggered by bond order changes.