### PR TITLE
Fix incorrect use of `memcpy`.

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -3688,7 +3688,7 @@ namespace OpenBabel
   void OBMol::CopyConformer(double *c,int idx)
   {
     //    obAssert(!_vconf.empty() && (unsigned)idx < _vconf.size());
-    memcpy((char*)_vconf[idx],(char*)c,sizeof(double)*3*NumAtoms());
+    memcpy((char*)c, (char*)_vconf[idx], sizeof(double)*3*NumAtoms());
   }
 
   // void OBMol::CopyConformer(double *c,int idx)


### PR DESCRIPTION
Fixes https://github.com/openbabel/openbabel/issues/1907