### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/data/gaff.dat
+++ b/data/gaff.dat
@@ -5816,7 +5816,7 @@ CH3Br and 2.25 for CH3I, in contrast, the old parameters give 1.31 and
 
 3. New van der Waals parameters have been suggested by David Mobley for
 c1, cg and ch atom types. The justification of the changes is discussed at
-http://dx.doi.org/10.1021/ct800409d
+https://doi.org/10.1021/ct800409d
 
 4. We have performed B3LYP/6-31G* optimization for 15 thousands marketed
 or experimental drugs/bio-actives. Reliable bond length and bond angle

--- a/src/chiral.cpp
+++ b/src/chiral.cpp
@@ -276,7 +276,7 @@ namespace OpenBabel
   //! <em>Logical and Combinatorial Algorithms for Drug Design</em>. \n
   //! For an example see:
   //! Walters, W. P., Yalkowsky, S. H., \em JCICS, 1996, 36(5), 1015-1017.
-  //! <a href="http://dx.doi.org/10.1021/ci950278o">DOI: 10.1021/ci950278o</a>
+  //! <a href="https://doi.org/10.1021/ci950278o">DOI: 10.1021/ci950278o</a>
   void GraphPotentials(OBMol &mol, std::vector<double> &pot)
   {
     double det;

--- a/src/distgeom.cpp
+++ b/src/distgeom.cpp
@@ -741,7 +741,7 @@ namespace OpenBabel {
   //! Implements the smoothing described by
   //! Dress, AWM, Havel TF; Discrete Applied Mathematics (1988) v. 19 pp. 129-144
   //! "Shortest Path Problems and Molecular Conformation"
-  //! http://dx.doi.org/10.1016/0166-218X(88)90009-1
+  //! https://doi.org/10.1016/0166-218X(88)90009-1
   void OBDistanceGeometry::TriangleSmooth(int iterations)
   {
     int a, b, c;

--- a/src/elementtable.h
+++ b/src/elementtable.h
@@ -19,10 +19,10 @@
 #   - elemental symbol                                                       #
 #   - Allred and Rochow electronegativity  0.0 if unknown                    #
 #   - covalent radii (in Angstrom)         1.6 if unknown                    #
-#       from http://dx.doi.org/10.1039/b801115j                              #
+#       from https://doi.org/10.1039/b801115j                              #
 #   - "bond order" radii -- ignored, but included for compatibility          #
 #   - van der Waals radii (in Angstrom)    2.0 if unknown                    #
-#       from http://dx.doi.org/10.1021/jp8111556                             #
+#       from https://doi.org/10.1021/jp8111556                             #
 #   - maximum bond valence                   6 if unknown                    #
 #   - IUPAC recommended atomic masses (in amu)                               #
 #   - Pauling electronegativity            0.0 if unknown                    #

--- a/src/formats/MCDLformat.cpp
+++ b/src/formats/MCDLformat.cpp
@@ -46,7 +46,7 @@ public:
 "            Language (MCDL): Composition, Connectivity and\n"
 "            Supplementary Modules.**\n"
 "            *J. Chem. Inf. Comput. Sci.*, **2004**, *41*, 1491-1499.\n"
-"            [`Link <http://dx.doi.org/10.1021/ci000108y>`_]\n\n"
+"            [`Link <https://doi.org/10.1021/ci000108y>`_]\n\n"
 
 "Here's an example conversion from SMILES to MCDL::\n\n"
 "  obabel -:\"CC(=O)Cl\" -omcdl\n"

--- a/src/formats/MNAformat.cpp
+++ b/src/formats/MNAformat.cpp
@@ -132,7 +132,7 @@ namespace OpenBabel
 "            Tatyana Gloriozova. **Chemical Similarity Assessment through\n"
 "            Multilevel Neighborhoods of Atoms: Definition and Comparison with\n"
 "            the Other Descriptors.** *J. Chem. Inf. Comput. Sci.* **1999**, *39*, 666-670.\n"
-"            [`Link <http://dx.doi.org/10.1021/ci980335o>`_]\n\n"
+"            [`Link <https://doi.org/10.1021/ci980335o>`_]\n\n"
 
         "Write Options e.g. -x" << levels_option << "1 \n"
 				"  " << levels_option << "#  Levels (default = " << levels << ")\n\n"

--- a/src/formats/mpdformat.cpp
+++ b/src/formats/mpdformat.cpp
@@ -60,7 +60,7 @@ namespace OpenBabel
 "             Similarity Searching Using Atom Environments, Information-Based\n"
 "             Feature Selection, and a Naive Bayesian Classifier.**\n"
 "             *J. Chem. Inf. Comput. Sci.* **2004**, *44*, 170-178.\n"
-"             [`Link <http://dx.doi.org/10.1021/ci034207y>`_]\n\n"
+"             [`Link <https://doi.org/10.1021/ci034207y>`_]\n\n"
 
            " Write Options: e.g. -xnc\n"
            "  n prefix molecule names with name of file \n"
@@ -70,7 +70,7 @@ namespace OpenBabel
 
     virtual const char* SpecificationURL()
     {
-      return "http://dx.doi.org/10.1021/ci034207y";
+      return "https://doi.org/10.1021/ci034207y";
     }; //optional
 
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links.

Cheers!