### PR TITLE
Address CMake build warning about policy CMP0005 being set to OLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,9 +275,7 @@ if(NOT MSVC)
     }
    " SCANDIR_NEEDS_CONST)
 
-  set(OB_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/${OB_PLUGIN_INSTALL_DIR}"
-      CACHE PATH "Set to system install for bindings only build")
-  add_definitions(-DOB_MODULE_PATH=${OB_MODULE_PATH})
+  set(OB_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/${OB_PLUGIN_INSTALL_DIR}")
 
   # Add some visibility support when using GCC
   # note: Altough MinGW g++ 4.4 passes this test, visibility can't be used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_MODULE_PATH ${openbabel_SOURCE_DIR}/cmake/modules)
 
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
-  cmake_policy(SET CMP0005 OLD) # add_definitions need updating to set to NEW
+  cmake_policy(SET CMP0005 NEW)
   if(POLICY CMP0042)
     cmake_policy(SET CMP0042 OLD)
   endif()
@@ -277,7 +277,7 @@ if(NOT MSVC)
 
   set(OB_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/${OB_PLUGIN_INSTALL_DIR}"
       CACHE PATH "Set to system install for bindings only build")
-  add_definitions(-DOB_MODULE_PATH="\\"${OB_MODULE_PATH}\\"")
+  add_definitions(-DOB_MODULE_PATH=${OB_MODULE_PATH})
 
   # Add some visibility support when using GCC
   # note: Altough MinGW g++ 4.4 passes this test, visibility can't be used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ set(CMAKE_MODULE_PATH ${openbabel_SOURCE_DIR}/cmake/modules)
 
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
-  cmake_policy(SET CMP0005 NEW)
   if(POLICY CMP0042)
     cmake_policy(SET CMP0042 OLD)
   endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # define TESTDATADIR for tests that need input files
-add_definitions(-DTESTDATADIR="\\"${CMAKE_SOURCE_DIR}/test/files/\\"")
+add_definitions(-DTESTDATADIR="${CMAKE_SOURCE_DIR}/test/files/")
 
 # define FORMATDIR for location of format plugin binaries
 if(BINDINGS_ONLY)
@@ -7,7 +7,7 @@ if(BINDINGS_ONLY)
 else()
   set(FORMATDIR "${openbabel_BINARY_DIR}/lib${LIB_SUFFIX}/")
 endif()
-add_definitions(-DFORMATDIR="\\"${FORMATDIR}/\\"")
+add_definitions(-DFORMATDIR="${FORMATDIR}/")
 
 ###########################################################
 #  new tests using obtest.h

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -38,8 +38,12 @@ def run_exec(*args):
     else:
         raise Exception("One or two arguments expected")
 
-    broken = commandline.encode().split()
-    exe = executable(broken[0].decode())
+    if sys.platform.startswith("win"):
+        broken = commandline.split()
+        exe = executable(broken[0])
+    else:
+        broken = commandline.encode().split()
+        exe = executable(broken[0].decode())
     # Note that bufsize = -1 means default buffering
     # Without this, it's unbuffered and it takes 10x longer on MacOSX
     if text:
@@ -218,9 +222,11 @@ ENDBRANCH   1   9
 TORSDOF 5
 '''
         output, error = run_exec(pdb, "obabel -ipdb -opdbqt")
-        self.assertEqual(output, pdbqt)        
+        self.assertEqual(output.replace("\r", ""), pdbqt.replace("\r", ""))
 
     def testMissingPlugins(self):
+        if sys.platform.startswith("win32"):
+            return
         libdir = os.environ.pop("BABEL_LIBDIR", None)
         os.environ["BABEL_LIBDIR"] = ""
 


### PR DESCRIPTION
Newer CMakes warn that CMake policies CMP0005 and CMP0042 are being set to OLD. This PR addresses CMP0005 by removing the problematic definition - as far as I can tell, it's unneeded - in fact, it wasn't being handled correctly and once it was, it caused warnings due to duplicate definition in babelconfig.h.

The other policy warning is discussed a bit in https://github.com/openbabel/openbabel/pull/85.