### PR TITLE
Fix clang warning about in-class init of a non-static data member

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -277,7 +277,7 @@ namespace OpenBabel {
     char _updown;
     int _order;
     int _prev;
-    int _rxnrole = 1;
+    int _rxnrole;
     const char *_ptr;
     bool _preserve_aromaticity;
     vector<int>             _vprev;
@@ -306,7 +306,7 @@ namespace OpenBabel {
 
   public:
 
-    OBSmilesParser(bool preserve_aromaticity=false): _preserve_aromaticity(preserve_aromaticity) { }
+    OBSmilesParser(bool preserve_aromaticity=false): _preserve_aromaticity(preserve_aromaticity), _rxnrole(1) { }
     ~OBSmilesParser() { }
 
     bool SmiToMol(OBMol&,const string&);


### PR DESCRIPTION
Minor fix. Clang rightly warns about my setting ```int _rxnrole = 1;``` in the variable declaration of SmilesParser:
```
      in-class initialization of non-static data member is a C++11 extension
      [-Wc++11-extensions]
```