### PR TITLE
Tidy setting/unsetting of molecule perception flags

### DIFF
--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -101,6 +101,11 @@ namespace OpenBabel
   //! Treat as reaction
 #define OB_REACTION_MOL          (1<<22)
   // flags 22-32 unspecified
+
+#define SET_OR_UNSET_FLAG(X) \
+  if (value) SetFlag(X); \
+  else     UnsetFlag(X);
+
 #define OB_CURRENT_CONFORMER	 -1
 
 enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
@@ -128,9 +133,6 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     std::vector<OBResidue*>       _residue;     //!< Residue information (if applicable)
     std::vector<OBInternalCoord*> _internals;   //!< Internal Coordinates (if applicable)
     unsigned short int            _mod;	        //!< Number of nested calls to BeginModify()
-
-    bool  HasFlag(int flag)    { return((_flags & flag) ? true : false); }
-    void  SetFlag(int flag)    { _flags |= flag; }
 
   public:
 
@@ -368,50 +370,38 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     { _autoPartialCharge=val; }
 
     //! Mark that aromaticity has been perceived for this molecule (see OBAromaticTyper)
-    void   SetAromaticPerceived()    { SetFlag(OB_AROMATIC_MOL);    }
+    void   SetAromaticPerceived(bool value = true)    { SET_OR_UNSET_FLAG(OB_AROMATIC_MOL);    }
     //! Mark that Smallest Set of Smallest Rings has been run (see OBRing class)
-    void   SetSSSRPerceived()        { SetFlag(OB_SSSR_MOL);        }
+    void   SetSSSRPerceived(bool value = true)        { SET_OR_UNSET_FLAG(OB_SSSR_MOL);        }
     //! Mark that Largest Set of Smallest Rings has been run (see OBRing class)
-    void   SetLSSRPerceived()        { SetFlag(OB_LSSR_MOL);        }
+    void   SetLSSRPerceived(bool value = true)        { SET_OR_UNSET_FLAG(OB_LSSR_MOL);        }
     //! Mark that rings have been perceived (see OBRing class for details)
-    void   SetRingAtomsAndBondsPerceived(){SetFlag(OB_RINGFLAGS_MOL);}
+    void   SetRingAtomsAndBondsPerceived(bool value = true) { SET_OR_UNSET_FLAG(OB_RINGFLAGS_MOL); }
     //! Mark that atom types have been perceived (see OBAtomTyper for details)
-    void   SetAtomTypesPerceived()   { SetFlag(OB_ATOMTYPES_MOL);   }
+    void   SetAtomTypesPerceived(bool value = true)   { SET_OR_UNSET_FLAG(OB_ATOMTYPES_MOL);   }
     //! Mark that ring types have been perceived (see OBRingTyper for details)
-    void   SetRingTypesPerceived()   { SetFlag(OB_RINGTYPES_MOL);   }
+    void   SetRingTypesPerceived(bool value = true)   { SET_OR_UNSET_FLAG(OB_RINGTYPES_MOL);   }
     //! Mark that chains and residues have been perceived (see OBChainsParser)
-    void   SetChainsPerceived(bool is_perceived=true)
-    {
-      if (is_perceived)      SetFlag(OB_CHAINS_MOL);
-      else                 UnsetFlag(OB_CHAINS_MOL);
-    }
+    void   SetChainsPerceived(bool value = true)      { SET_OR_UNSET_FLAG(OB_CHAINS_MOL);      }
     //! Mark that chirality has been perceived
-    void   SetChiralityPerceived()   { SetFlag(OB_CHIRALITY_MOL);   }
+    void   SetChiralityPerceived(bool value = true)   { SET_OR_UNSET_FLAG(OB_CHIRALITY_MOL);   }
     //! Mark that partial charges have been assigned
-    void   SetPartialChargesPerceived(){ SetFlag(OB_PCHARGE_MOL);   }
+    void   SetPartialChargesPerceived(bool value = true) { SET_OR_UNSET_FLAG(OB_PCHARGE_MOL);  }
     //! Mark that hybridization of all atoms has been assigned
-    void   SetHybridizationPerceived() { SetFlag(OB_HYBRID_MOL);    }
+    void   SetHybridizationPerceived(bool value = true)  { SET_OR_UNSET_FLAG(OB_HYBRID_MOL);   }
     //! Mark that ring closure bonds have been assigned by graph traversal
-    void   SetClosureBondsPerceived(){ SetFlag(OB_CLOSURE_MOL);     }
+    void   SetClosureBondsPerceived(bool value = true)   { SET_OR_UNSET_FLAG(OB_CLOSURE_MOL);  }
     //! Mark that explicit hydrogen atoms have been added
-    void   SetHydrogensAdded()       { SetFlag(OB_H_ADDED_MOL);     }
-    void   SetCorrectedForPH()       { SetFlag(OB_PH_CORRECTED_MOL);}
-    void   SetSpinMultiplicityAssigned(){ SetFlag(OB_ATOMSPIN_MOL);    }
-    void   SetIsReaction(bool val=true) {
-      if (val)  SetFlag(OB_REACTION_MOL);
-      else    UnsetFlag(OB_REACTION_MOL);
-    }
-    void   SetFlags(int flags)       { _flags = flags;              }
-
-    void   UnsetAromaticPerceived()  { _flags &= (~(OB_AROMATIC_MOL));   }
-    //! Mark that chains perception will need to be run again if required
-    void   UnsetSSSRPerceived()  { _flags &= (~(OB_SSSR_MOL));   }
-    //! Mark that Largest Set of Smallest Rings will need to be run again if required (see OBRing class)
-    void   UnsetLSSRPerceived()  { _flags &= (~(OB_LSSR_MOL));   }
-    void   UnsetRingTypesPerceived()  { _flags &= (~(OB_RINGTYPES_MOL));   }
-    void   UnsetPartialChargesPerceived(){ _flags &= (~(OB_PCHARGE_MOL));}
-    void   UnsetHydrogensAdded()       { UnsetFlag(OB_H_ADDED_MOL);     }
-    void   UnsetFlag(int flag)       { _flags &= (~(flag));              }
+    void   SetHydrogensAdded(bool value = true) { SET_OR_UNSET_FLAG(OB_H_ADDED_MOL); }
+    void   SetCorrectedForPH(bool value = true) { SET_OR_UNSET_FLAG(OB_PH_CORRECTED_MOL); }
+    void   SetSpinMultiplicityAssigned(bool value = true) { SET_OR_UNSET_FLAG(OB_ATOMSPIN_MOL); }
+    //! The OBMol is a pattern, not a complete molecule. Left unchanged by Clear().
+    void   SetIsPatternStructure(bool value = true) { SET_OR_UNSET_FLAG(OB_PATTERN_STRUCTURE); }
+    void   SetIsReaction(bool value = true)               { SET_OR_UNSET_FLAG(OB_REACTION_MOL) };
+    bool   HasFlag(int flag)   { return (_flags & flag) ? true : false; }
+    void   SetFlag(int flag)   { _flags |= flag; }
+    void   UnsetFlag(int flag) { _flags &= (~(flag)); }
+    void   SetFlags(int flags) { _flags = flags; }
     //@}
 
     //! \name Molecule modification methods
@@ -514,9 +504,6 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     //! Assumes all the hydrogen is explicitly included in the molecule.
     //! \since version 2.4
     bool AssignTotalChargeToAtoms(int charge);
-
-    //! The OBMol is a pattern, not a complete molecule. Left unchanged by Clear().
-    void   SetIsPatternStructure()       { SetFlag(OB_PATTERN_STRUCTURE);}
 
     //! \return the center of the supplied conformer @p nconf
     //! \see Center() to actually center all conformers at the origin

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -828,7 +828,7 @@ namespace OpenBabel
       if (_mol.NumAtoms() && _constraints.Size())
         _constraints.Setup(_mol);
 
-      _mol.UnsetSSSRPerceived();
+      _mol.SetSSSRPerceived(false);
       _mol.DeleteData(OBGenericDataType::TorsionData); // bug #1954233
 
       if (!SetTypes()) {
@@ -885,7 +885,7 @@ namespace OpenBabel
       if (_mol.NumAtoms() && _constraints.Size())
         _constraints.Setup(_mol);
 
-      _mol.UnsetSSSRPerceived();
+      _mol.SetSSSRPerceived(false);
       _mol.DeleteData(OBGenericDataType::TorsionData); // bug #1954233
 
       if (!SetTypes()) {

--- a/src/forcefields/forcefieldgaff.cpp
+++ b/src/forcefields/forcefieldgaff.cpp
@@ -1428,7 +1428,7 @@ namespace OpenBabel
     // Trigger calculation of Gasteiger charges
     // Note that the Gastegier charge calculation checks for the values of particular atom types
     _mol.SetAutomaticPartialCharge(true);
-    _mol.UnsetPartialChargesPerceived();
+    _mol.SetPartialChargesPerceived(false);
     // Trigger partial charge calculation
     FOR_ATOMS_OF_MOL(atom, _mol) {
       atom->GetPartialCharge();

--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -607,7 +607,7 @@ namespace OpenBabel
           obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
           // return false; Should we return false for a kekulization failure?
         }
-        mol.UnsetAromaticPerceived();
+        mol.SetAromaticPerceived(false);
       }
 
       //

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -661,7 +661,7 @@ namespace OpenBabel {
     }
 
     if (!_preserve_aromaticity)
-      mol.UnsetAromaticPerceived();
+      mol.SetAromaticPerceived(false);
 
     CreateCisTrans(mol);
 

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -1906,8 +1906,8 @@ namespace OpenBabel
 
     DecrementMod();
 
-    UnsetSSSRPerceived();
-    UnsetLSSRPerceived();
+    SetSSSRPerceived(false);
+    SetLSSRPerceived(false);
     return(true);
   }
 
@@ -1949,8 +1949,8 @@ namespace OpenBabel
 
     DecrementMod();
 
-    UnsetSSSRPerceived();
-    UnsetLSSRPerceived();
+    SetSSSRPerceived(false);
+    SetLSSRPerceived(false);
     return(true);
   }
 
@@ -1967,7 +1967,7 @@ namespace OpenBabel
       if (atom->GetAtomicNum() == OBElements::Hydrogen && IsSuppressibleHydrogen(atom))
         delatoms.push_back(atom);
 
-    UnsetHydrogensAdded();
+    SetHydrogensAdded(false);
 
     if (delatoms.empty())
       return(true);
@@ -1995,8 +1995,8 @@ namespace OpenBabel
 
     DecrementMod();
 
-    UnsetSSSRPerceived();
-    UnsetLSSRPerceived();
+    SetSSSRPerceived(false);
+    SetLSSRPerceived(false);
     return(true);
   }
 
@@ -2020,9 +2020,9 @@ namespace OpenBabel
       DeleteHydrogen((OBAtom*)*i);
     DecrementMod();
 
-    UnsetHydrogensAdded();
-    UnsetSSSRPerceived();
-    UnsetLSSRPerceived();
+    SetHydrogensAdded(false);
+    SetSSSRPerceived(false);
+    SetLSSRPerceived(false);
     return(true);
   }
 
@@ -2073,12 +2073,12 @@ namespace OpenBabel
     for (idx=1,atomi = BeginAtom(i);atomi;atomi = NextAtom(i),++idx)
       atomi->SetIdx(idx);
 
-    UnsetHydrogensAdded();
+    SetHydrogensAdded(false);
 
     DestroyAtom(atom);
 
-    UnsetSSSRPerceived();
-    UnsetLSSRPerceived();
+    SetSSSRPerceived(false);
+    SetLSSRPerceived(false);
     return(true);
   }
 
@@ -2466,8 +2466,8 @@ namespace OpenBabel
     if (destroyAtom)
       DestroyAtom(atom);
 
-    UnsetSSSRPerceived();
-    UnsetLSSRPerceived();
+    SetSSSRPerceived(false);
+    SetLSSRPerceived(false);
     return(true);
   }
 
@@ -2482,8 +2482,8 @@ namespace OpenBabel
     if (destroyResidue)
       DestroyResidue(residue);
 
-    UnsetSSSRPerceived();
-    UnsetLSSRPerceived();
+    SetSSSRPerceived(false);
+    SetLSSRPerceived(false);
     return(true);
   }
 
@@ -2508,8 +2508,8 @@ namespace OpenBabel
     if (destroyBond)
       DestroyBond(bond);
 
-    UnsetSSSRPerceived();
-    UnsetLSSRPerceived();
+    SetSSSRPerceived(false);
+    SetLSSRPerceived(false);
     return(true);
   }
 
@@ -3347,7 +3347,7 @@ namespace OpenBabel
         obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
         // return false; Should we return false for a kekulization failure?
       }
-      this->UnsetAromaticPerceived();
+      this->SetAromaticPerceived(false);
     }
 
     // Quick pass.. eliminate inter-ring sulfur atom multiple bonds
@@ -3999,7 +3999,7 @@ namespace OpenBabel
   for more information).
 
   Aromaticity is preserved as present in the original OBMol. If this is not desired,
-  the user should call OBMol::UnsetAromaticPerceived() on the new OBMol.
+  the user should call OBMol::SetAromaticPerceived(false) on the new OBMol.
 
   Stereochemistry is only preserved if the corresponding elements are wholly present in
   the substructure. For example, all four atoms and bonds of a tetrahedral stereocenter

--- a/src/tautomer.cpp
+++ b/src/tautomer.cpp
@@ -620,7 +620,7 @@ namespace OpenBabel {
         FOR_BONDS_OF_MOL (bond, mol)
           if (bondTypes[bond->GetIdx()] == Unassigned)
             bond->SetBondOrder(1);
-        mol->UnsetAromaticPerceived();
+        mol->SetAromaticPerceived(false);
         
         std::vector<unsigned int> symmetryClasses;
         OBGraphSym gs(mol);

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -87,7 +87,7 @@ class TestSuite(PythonBindings):
         mol = pybel.readstring("smi", "c1ccccc1").OBMol
         mol.DeleteAtom(mol.GetFirstAtom())
         self.assertTrue(mol.GetFirstAtom().IsAromatic())
-        mol.UnsetAromaticPerceived()
+        mol.SetAromaticPerceived(False)
         self.assertFalse(mol.GetFirstAtom().IsAromatic())
 
     def testLPStereo(self):
@@ -152,7 +152,7 @@ class TestSuite(PythonBindings):
             # Aromaticity is perceived during the last step of reading SMILES
             # so let's unset it here for the first pass
             if N == 0:
-                obmol.UnsetAromaticPerceived()
+                obmol.SetAromaticPerceived(False)
             else:
                 self.assertTrue(obmol.HasAromaticPerceived())
 


### PR DESCRIPTION
(Part of the pre-3.0 API cleanup)
The current situation is that some molecular perception flags have an unset method. Others do not. Furthermore, some setters take a boolean for set/unset (full disclosure - this may have been all me).

The latter approach of a single method with a boolean seems reasonable. It reduces the number of methods, reduces the developer error (forgetting to add an unset method), and frankly is easier for users - just one method to do two things. 

This PR gets rid of the Unset methods for molecule flag perception, and ensures that all setters (for perception flags) take a boolean. I've also moved HasFlag and SetFlag from "protected" to "public". I get the idea of encapsulation, but consider the case where the user wants to set a custom flag. I can move it back if someone feels strongly.

If this goes through, I will do the same for OBAtom and OBBond, but I think the majority of perception flags are at the OBMol level.



