### PR TITLE
Remove OBBond::GetBO() and SetBO()

### DIFF
--- a/include/openbabel/bond.h
+++ b/include/openbabel/bond.h
@@ -114,9 +114,6 @@ namespace OpenBabel
       void SetIdx(int idx)        {          _idx = idx;        }
       void SetId(unsigned long id) { _id = id; }
       //! Set the bond order to @p order (i.e., 1 = single, 2 = double, 5 = aromatic)
-      /** \deprecated Use SetBondOrder() instead. **/
-      void SetBO(int order);
-      //! Set the bond order to @p order (i.e., 1 = single, 2 = double, 5 = aromatic)
       void SetBondOrder(int order);
       //! Set the beginning atom of this bond to @p begin. Does not update @p begin.
       void SetBegin(OBAtom *begin){          _bgn = begin;      }
@@ -176,9 +173,6 @@ namespace OpenBabel
       //! \return The unique bond index in a molecule.
       unsigned int     GetIdx()           const { return(_idx);  }
       unsigned long GetId()           const { return _id; }
-      //! \return The bond order for the bond
-      /** \deprecated Use GetBondOrder() as this method may be removed. **/
-      unsigned int     GetBO()            const { return(_order); }
       //! \return The bond order for the bond
       unsigned int     GetBondOrder()     const { return(_order); }
       //! \return The set of property flags defined for this bond.

--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -181,7 +181,7 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     //! Add a new bond to the molecule with the specified parameters
     //! \param beginIdx  the atom index of the "start" atom
     //! \param endIdx    the atom index of the "end" atom
-    //! \param order     the bond order (see OBBond::GetBO())
+    //! \param order     the bond order (see OBBond::GetBondOrder())
     //! \param flags     any bond flags such as stereochemistry (default = none)
     //! \param insertpos the position index to insert the bond (default = none)
     //! \return Whether the new bond creation was successful

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -278,7 +278,7 @@ namespace OpenBabel
     for (a1 = BeginNbrAtom(i);a1;a1 = NextNbrAtom(i))
       if (includePandS || (a1->GetAtomicNum() != OBElements::Phosphorus && a1->GetAtomicNum() != OBElements::Sulfur))
         for (a2 = a1->BeginNbrAtom(j);a2;a2 = a1->NextNbrAtom(j))
-          if (a2 != this && ((*j)->GetBO() == 2 || (*j)->GetBO() == 3 || (*j)->GetBO() == 5))
+          if (a2 != this && ((*j)->GetBondOrder() == 2 || (*j)->GetBondOrder() == 3 || (*j)->GetBondOrder() == 5))
             return(true);
 
     return(false);
@@ -289,7 +289,7 @@ namespace OpenBabel
     OBBond *bond;
     OBBondIterator i;
     for (bond = BeginBond(i);bond;bond = NextBond(i))
-      if (bond->GetBO() == order)
+      if (bond->GetBondOrder() == order)
         return(true);
 
     return(false);
@@ -301,7 +301,7 @@ namespace OpenBabel
     OBBond *bond;
     OBBondIterator i;
     for (bond = BeginBond(i);bond;bond = NextBond(i))
-      if (bond->GetBO() == order)
+      if (bond->GetBondOrder() == order)
         count++;
 
     return(count);
@@ -313,8 +313,8 @@ namespace OpenBabel
     OBBond *bond;
     OBBondIterator i;
     for(bond = BeginBond(i); bond; bond = NextBond(i))
-      if(bond->GetBO() > highest)
-        highest = bond->GetBO();
+      if(bond->GetBondOrder() > highest)
+        highest = bond->GetBondOrder();
 
     return(highest);
   }
@@ -324,7 +324,7 @@ namespace OpenBabel
     OBBond *bond;
     OBBondIterator i;
     for (bond = BeginBond(i);bond;bond = NextBond(i))
-      if (bond->GetBO() != 1)
+      if (bond->GetBondOrder() != 1)
         return(true);
 
     return(false);
@@ -572,7 +572,7 @@ namespace OpenBabel
       {
         nbratom = bond->GetNbrAtom(atom);
         for (abbond = nbratom->BeginBond(j);abbond;abbond = nbratom->NextBond(j))
-          if (abbond->GetBO() == 2 &&
+          if (abbond->GetBondOrder() == 2 &&
               (((abbond->GetNbrAtom(nbratom))->GetAtomicNum() == 8) ||
                ((abbond->GetNbrAtom(nbratom))->GetAtomicNum() == 16)))
             return(true);
@@ -590,7 +590,7 @@ namespace OpenBabel
     OBBondIterator i;
 
     for (atom = BeginNbrAtom(i);atom;atom = NextNbrAtom(i))
-      if (atom->GetAtomicNum() == OBElements::Oxygen && !(*i)->IsInRing() && (*i)->GetBO() == 2)
+      if (atom->GetAtomicNum() == OBElements::Oxygen && !(*i)->IsInRing() && (*i)->GetBondOrder() == 2)
         return(true);
 
     return(false);
@@ -1297,9 +1297,9 @@ namespace OpenBabel
           length = br1 + br2;
           if ((*i)->IsAromatic())
             length *= 0.93;
-          else if ((*i)->GetBO() == 2)
+          else if ((*i)->GetBondOrder() == 2)
             length *= 0.91;
-          else if ((*i)->GetBO() == 3)
+          else if ((*i)->GetBondOrder() == 3)
             length *= 0.87;
           ((OBBond*) *i)->SetLength(this, length);
         }

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -91,11 +91,6 @@ namespace OpenBabel
     SetFlag(flags);
   }
 
-  void OBBond::SetBO(int order)
-  {
-    SetBondOrder(order);
-  }
-
   void OBBond::SetBondOrder(int order)
   {
     _order = (char)order;
@@ -345,7 +340,7 @@ namespace OpenBabel
 
     if (!a1 || !a2)
       return(false);
-    if (GetBO() != 1)
+    if (GetBondOrder() != 1)
       return(false);
 
     OBBond *bond;
@@ -376,7 +371,7 @@ namespace OpenBabel
 
     if (!a1 || !a2)
       return(false);
-    if (GetBO() != 1)
+    if (GetBondOrder() != 1)
       return(false);
 
     OBBond *bond;
@@ -408,7 +403,7 @@ namespace OpenBabel
 
     if (!a1 || !a2)
       return(false);
-    if (GetBO() != 1)
+    if (GetBondOrder() != 1)
       return(false);
 
     OBBond *bond;
@@ -441,7 +436,7 @@ namespace OpenBabel
 
     if (!a1 || !a2)
       return(false);
-    if (GetBO() != 1)
+    if (GetBondOrder() != 1)
       return(false);
 
     OBBond *bond;
@@ -455,7 +450,7 @@ namespace OpenBabel
 
   bool OBBond::IsCarbonyl()
   {
-    if (GetBO() != 2)
+    if (GetBondOrder() != 2)
       return(false);
 
     if ((_bgn->GetAtomicNum() == 6 && _end->GetAtomicNum() == 8) ||

--- a/src/bondtyper.cpp
+++ b/src/bondtyper.cpp
@@ -142,7 +142,7 @@ namespace OpenBabel
                     b1 = a1->GetBond(a2);
 
                     if (!b1) continue;
-                    b1->SetBO(assignments[j+2]);
+                    b1->SetBondOrder(assignments[j+2]);
                   } // bond order assignments
               } // each match
           } // current pattern matches
@@ -171,7 +171,7 @@ namespace OpenBabel
                 b1 = a1->GetBond(a2);
 
                 if (!b1 ) continue;
-                b1->SetBO(2);
+                b1->SetBondOrder(2);
               }
             }
           }
@@ -198,7 +198,7 @@ namespace OpenBabel
                 b1 = a1->GetBond(a2);
 
                 if (!b1 ) continue;
-                b1->SetBO(2);
+                b1->SetBondOrder(2);
               }
             }
           }
@@ -231,8 +231,8 @@ namespace OpenBabel
               b1 = a1->GetBond(a2);
               b2 = a2->GetBond(a3);
               if (!b1 || !b2) continue;
-              b1->SetBO(2);
-              b2->SetBO(2);
+              b1->SetBondOrder(2);
+              b2->SetBondOrder(2);
 
             }
 
@@ -260,7 +260,7 @@ namespace OpenBabel
                 b1 = a1->GetBond(a2);
 
                 if (!b1 ) continue;
-                b1->SetBO(2);
+                b1->SetBondOrder(2);
               }
             }
           }

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -1241,7 +1241,7 @@ namespace OpenBabel
 
       // get the position for the new atom, this is done with GetNewBondVector
       if (prev != NULL) {
-        int bondType = a->GetBond(prev)->GetBO();
+        int bondType = a->GetBond(prev)->GetBondOrder();
         if (a->GetBond(prev)->IsAromatic())
           bondType = -1;
 
@@ -1283,7 +1283,7 @@ namespace OpenBabel
     FOR_BONDS_OF_MOL(b, mol) {
       beginIdx = b->GetBeginAtomIdx();
       endIdx = b->GetEndAtomIdx();
-      workMol.AddBond(beginIdx, endIdx, b->GetBO(), b->GetFlags());
+      workMol.AddBond(beginIdx, endIdx, b->GetBondOrder(), b->GetFlags());
     }
 
     /*

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -515,12 +515,12 @@ namespace OpenBabel
           {
             OBBond *bond;
             bond = (OBBond*)*(a1->BeginBonds());
-            if (bond->GetBO() == 2)
+            if (bond->GetBondOrder() == 2)
               {
                 a1->SetType("O2");
                 a1->SetHyb(2);
               }
-            else if (bond->GetBO() == 1)
+            else if (bond->GetBondOrder() == 1)
               {
                 // Leave the protonation/deprotonation to phmodel.txt
                 a1->SetType("O3");

--- a/src/depict/depict.cpp
+++ b/src/depict/depict.cpp
@@ -347,7 +347,7 @@ namespace OpenBabel
       else
         painter->SetPenColor(bondColor);
 
-      DrawRingBond(begin, end, center, ringBond->GetBO());
+      DrawRingBond(begin, end, center, ringBond->GetBondOrder());
       drawnBonds.SetBitOn(ringBond->GetId());
     }
   }
@@ -524,7 +524,7 @@ namespace OpenBabel
           if (!ct->GetConfig().specified)
             crossed_dbl_bond = true;
         }
-        d->DrawSimpleBond(begin, end, bond->GetBO(), crossed_dbl_bond);
+        d->DrawSimpleBond(begin, end, bond->GetBondOrder(), crossed_dbl_bond);
       }
     }
 

--- a/src/fingerprints/finger2.cpp
+++ b/src/fingerprints/finger2.cpp
@@ -152,7 +152,7 @@ void fingerprint2::getFragments(vector<int> levels, vector<int> curfrag,
 	int bo=0;
 	if(pbond)
 	{
-		bo = pbond->IsAromatic() ? 5 : pbond->GetBO();
+		bo = pbond->IsAromatic() ? 5 : pbond->GetBondOrder();
 
 //		OBAtom* pprevat = pbond->GetNbrAtom(patom);
 //		if(patom->GetFormalCharge() && (patom->GetFormalCharge() == -pprevat->GetFormalCharge()))
@@ -178,7 +178,7 @@ void fingerprint2::getFragments(vector<int> levels, vector<int> curfrag,
 			{
 				//If complete ring (last bond is back to starting atom) add bond at front
 				//and save in ringset
-				curfrag[0] = pnewbond->IsAromatic() ? 5 : pnewbond->GetBO();
+				curfrag[0] = pnewbond->IsAromatic() ? 5 : pnewbond->GetBondOrder();
 				ringset.insert(curfrag);
  				curfrag[0] = 0;
 			}

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -958,7 +958,7 @@ namespace OpenBabel
         return true;
     }
     FOR_BONDS_OF_MOL (bond, _mol) {
-      if (bond->GetBO() != (mol.GetBond(bond->GetIdx()))->GetBO())
+      if (bond->GetBondOrder() != (mol.GetBond(bond->GetIdx()))->GetBondOrder())
         return true;
       if (bond->GetBeginAtom()->GetAtomicNum()
           != (mol.GetBond(bond->GetIdx()))->GetBeginAtom()->GetAtomicNum()

--- a/src/forcefields/forcefieldmmff94.cpp
+++ b/src/forcefields/forcefieldmmff94.cpp
@@ -1403,7 +1403,7 @@ namespace OpenBabel
             prev_rj = index;
             continue;
           }
-          if (ringbond->GetBO() == 2) {
+          if (ringbond->GetBondOrder() == 2) {
             pi_electrons += 2;
             prev_rj = index;
             n++;
@@ -1434,7 +1434,7 @@ namespace OpenBabel
           if (!ringbond) {
             continue;
           }
-          if (ringbond->GetBO() == 2)
+          if (ringbond->GetBondOrder() == 2)
             pi_electrons++;
         }
 
@@ -1450,7 +1450,7 @@ namespace OpenBabel
       // is the bond from the first to the last atom double?
       ringbond = _mol.GetBond(first_rj, index);
       if (ringbond) {
-        if (ringbond->GetBO() == 2)
+        if (ringbond->GetBondOrder() == 2)
           pi_electrons += 2;
       }
 
@@ -2355,7 +2355,7 @@ namespace OpenBabel
               // (e.g. by MOE, noticed by Paolo Tosco)
               int ndab = 0;
               FOR_BONDS_OF_ATOM(bond2, &*nbr) {
-                if (bond2->GetBO() == 2 || bond2->GetBO() == 5)
+                if (bond2->GetBondOrder() == 2 || bond2->GetBondOrder() == 5)
                   ndab++;
               }
               if (ndab + nbr->GetValence() == 5)

--- a/src/formats/alchemyformat.cpp
+++ b/src/formats/alchemyformat.cpp
@@ -206,7 +206,7 @@ namespace OpenBabel
 
     for (bond = mol.BeginBond(j);bond;bond = mol.NextBond(j))
       {
-        switch(bond->GetBO())
+        switch(bond->GetBondOrder())
           {
           case 1 :
             strcpy(bond_string,"SINGLE");

--- a/src/formats/bgfformat.cpp
+++ b/src/formats/bgfformat.cpp
@@ -280,7 +280,7 @@ namespace OpenBabel
           ofs << buffer;
           for (nbr = atom->BeginNbrAtom(j);nbr;nbr = atom->NextNbrAtom(j))
             {
-              snprintf(buffer,BUFF_SIZE,"%6d",(*j)->GetBO());
+              snprintf(buffer,BUFF_SIZE,"%6d",(*j)->GetBondOrder());
               ofs << buffer;
             }
           ofs << endl;

--- a/src/formats/cacheformat.cpp
+++ b/src/formats/cacheformat.cpp
@@ -128,7 +128,7 @@ namespace OpenBabel
     vector<OBBond*>::iterator j;
     for (bond = mol.BeginBond(j);bond;bond = mol.NextBond(j))
       {
-        switch (bond->GetBO())
+        switch (bond->GetBondOrder())
           {
           case 1:
             strcpy(bstr,"single");

--- a/src/formats/chemdrawct.cpp
+++ b/src/formats/chemdrawct.cpp
@@ -99,7 +99,7 @@ namespace OpenBabel
         snprintf(buffer, BUFF_SIZE, "%3d%3d%3d%3d",
                  bond->GetBeginAtomIdx(),
                  bond->GetEndAtomIdx(),
-                 bond->GetBO(), bond->GetBO());
+                 bond->GetBondOrder(), bond->GetBondOrder());
         ofs << buffer << endl;
       }
     return(true);

--- a/src/formats/chemtoolformat.cpp
+++ b/src/formats/chemtoolformat.cpp
@@ -110,9 +110,9 @@ namespace OpenBabel
         bondtype = 0;
         atom1 = bond->GetBeginAtom();
         atom2 = bond->GetEndAtom();
-        if (bond->GetBO() == 2)
+        if (bond->GetBondOrder() == 2)
           bondtype = 1;
-        if (bond->GetBO() == 3)
+        if (bond->GetBondOrder() == 3)
           bondtype = 3;
         // @todo: use flag-info, too
         snprintf(buffer, BUFF_SIZE, "%d\t%d\t%d\t%d\t%1d",

--- a/src/formats/cofformat.cpp
+++ b/src/formats/cofformat.cpp
@@ -421,7 +421,7 @@ namespace OpenBabel
       if (bond->IsAromatic())
         sstream <<"1.5";
       else
-        sstream << bond->GetBO() << ".0";
+        sstream << bond->GetBondOrder() << ".0";
       outlabel = sstream.str();
       ofs << outlabel << endl;
     }

--- a/src/formats/crkformat.cpp
+++ b/src/formats/crkformat.cpp
@@ -455,7 +455,7 @@ namespace OpenBabel
         OBBond *bnd=mol.GetBond(m);
 
         int from=bnd->GetBeginAtom()->GetIdx(),to=bnd->GetEndAtom()->GetIdx();
-        double order=bnd->GetBO();
+        double order=bnd->GetBondOrder();
         if (bnd->IsAromatic())
           order=1.5;
         int style=0;

--- a/src/formats/fastsearchformat.cpp
+++ b/src/formats/fastsearchformat.cpp
@@ -689,14 +689,14 @@ virtual const char* Description() //required
 
     if(idx>=patternMol.NumBonds())
       return;
-    if(patternMol.GetBond(idx)->GetBO()==4)
+    if(patternMol.GetBond(idx)->GetBondOrder()==4)
     {
-      patternMol.GetBond(idx)->SetBO(1);
+      patternMol.GetBond(idx)->SetBondOrder(1);
       patternMols.push_back(patternMol);
       AddPattern(patternMols, patternMol,idx+1);
 
       patternMols.push_back(patternMol);
-      patternMols.back().GetBond(idx)->SetBO(5);
+      patternMols.back().GetBond(idx)->SetBondOrder(5);
     }
     AddPattern(patternMols, patternMol,idx+1);
   }

--- a/src/formats/ghemicalformat.cpp
+++ b/src/formats/ghemicalformat.cpp
@@ -235,7 +235,7 @@ namespace OpenBabel
     char bond_char;
     FOR_BONDS_OF_MOL(bond, mol)
     {
-      switch(bond->GetBO())
+      switch(bond->GetBondOrder())
       {
         case 1 :
           bond_char = 'S';

--- a/src/formats/hinformat.cpp
+++ b/src/formats/hinformat.cpp
@@ -200,7 +200,7 @@ namespace OpenBabel
         ofs << buffer;
         for (bond = atom->BeginBond(j); bond; bond = atom->NextBond(j))
           {
-            switch(bond->GetBO())
+            switch(bond->GetBondOrder())
               {
               case 1 :
                 bond_char = 's';

--- a/src/formats/inchiformat.cpp
+++ b/src/formats/inchiformat.cpp
@@ -349,7 +349,7 @@ bool InChIFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
           continue;
 
         iat.neighbor[nbonds]      = pbond->GetNbrAtomIdx(patom)-1;
-        int bo = pbond->GetBO();
+        int bo = pbond->GetBondOrder();
         if(bo==5)
           bo=4;
         iat.bond_type[nbonds]     = bo;

--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -1198,7 +1198,7 @@ namespace OpenBabel
 
             ofs << setw(3) << atom->GetIdx(); // begin atom number
             ofs << setw(3) << nbr->GetIdx(); // end atom number
-            ofs << setw(3) << bond->GetBO(); // bond type
+            ofs << setw(3) << bond->GetBondOrder(); // bond type
             ofs << setw(3) << stereo; // bond stereo
             ofs << "  0  0  0" << endl;
 
@@ -1706,7 +1706,7 @@ namespace OpenBabel
                 bond = (OBBond*) *j;
                 ofs << "M  V30 "
                     << index++ << " "
-                    << bond->GetBO() << " "
+                    << bond->GetBondOrder() << " "
                     << bond->GetBeginAtomIdx() << " "
                     << bond->GetEndAtomIdx();
                 //@todo do the following stereo chemistry properly

--- a/src/formats/mmodformat.cpp
+++ b/src/formats/mmodformat.cpp
@@ -185,8 +185,8 @@ namespace OpenBabel
     OBBond *bond;
     vector<OBBond*>::iterator bi;
     for (bond = mol.BeginBond(bi);bond;bond = mol.NextBond(bi))
-      if (bond->GetBO() == 5 && !bond->IsInRing())
-        bond->SetBO(1);
+      if (bond->GetBondOrder() == 5 && !bond->IsInRing())
+        bond->SetBondOrder(1);
 
     if ( natoms != (signed)mol.NumAtoms() )
       return(false);
@@ -249,7 +249,7 @@ namespace OpenBabel
         ofs << buffer;
         for (nbr = atom->BeginNbrAtom(j);nbr;nbr = atom->NextNbrAtom(j))
           {
-            snprintf(buffer, BUFF_SIZE, " %5d %1d",nbr->GetIdx(),(*j)->GetBO());
+            snprintf(buffer, BUFF_SIZE, " %5d %1d",nbr->GetIdx(),(*j)->GetBondOrder());
             ofs << buffer;
           }
         for (k=atom->GetValence();k < 6;k++)

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -700,7 +700,7 @@ namespace OpenBabel
         else if (bond->IsAmide())
           strcpy(label,"am");
         else
-          snprintf(label,BUFF_SIZE,"%d",bond->GetBO());
+          snprintf(label,BUFF_SIZE,"%d",bond->GetBondOrder());
 
         snprintf(buffer, BUFF_SIZE,"%6d %5d %5d   %2s",
                  bond->GetIdx()+1,bond->GetBeginAtomIdx(),bond->GetEndAtomIdx(),

--- a/src/formats/molreport.cpp
+++ b/src/formats/molreport.cpp
@@ -139,7 +139,7 @@ namespace OpenBabel
                  bond->GetIdx(),
                  bond->GetBeginAtomIdx(),
                  bond->GetEndAtomIdx(),
-                 bond->GetBO());
+                 bond->GetBondOrder());
         ofs << buffer << "\n";
       }
 

--- a/src/formats/pcmodelformat.cpp
+++ b/src/formats/pcmodelformat.cpp
@@ -219,7 +219,7 @@ namespace OpenBabel
               {
                 nbrIdx = nbr->GetIdx();
                 ofs << " " << nbrIdx << ","
-                    << (mol.GetBond(nbrIdx, atomIdx))->GetBO();
+                    << (mol.GetBond(nbrIdx, atomIdx))->GetBondOrder();
               }
           }
 

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -680,7 +680,7 @@ namespace OpenBabel
 
   static bool IsImide(OBBond* querybond)
   {
-    if (querybond->GetBO() != 2)
+    if (querybond->GetBondOrder() != 2)
       return(false);
 
     OBAtom* bgn = querybond->GetBeginAtom();

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2746,13 +2746,13 @@ namespace OpenBabel {
                      (bond->GetEndAtom())->HasDoubleBond() )
                   buffer += '/';
               }
-              if (bond->GetBO() == 2 && !bond->IsAromatic()) // TODO: need to check for kekulesmi
+              if (bond->GetBondOrder() == 2 && !bond->IsAromatic()) // TODO: need to check for kekulesmi
                 buffer += '=';
-              if (bond->GetBO() == 2 && bond->IsAromatic())
+              if (bond->GetBondOrder() == 2 && bond->IsAromatic())
                 buffer += ':';
-              if (bond->GetBO() == 3)
+              if (bond->GetBondOrder() == 3)
                 buffer += '#';
-              if (bond->GetBO() == 4)
+              if (bond->GetBondOrder() == 4)
                 buffer += '$';
               char tmp[10];
               snprintf(tmp, 10, "%d", externalBond->first);
@@ -3239,7 +3239,7 @@ namespace OpenBabel {
       bond1 = *bi;
       _ubonds.SetBitOn(bond1->GetIdx());
       int digit = GetUnusedIndex();
-      int bo = (bond1->IsAromatic())? 1 : bond1->GetBO();  // CJ: why was this line added?  bo is never used?
+      int bo = (bond1->IsAromatic())? 1 : bond1->GetBondOrder();  // CJ: why was this line added?  bo is never used?
       _vopen.push_back(OBBondClosureInfo(bond1->GetNbrAtom(atom), atom, bond1, digit, true));
       vp_closures.push_back(OBBondClosureInfo(bond1->GetNbrAtom(atom), atom, bond1, digit, true));
     }
@@ -3453,7 +3453,7 @@ namespace OpenBabel {
             buffer += bs;	// append "/" or "\"
           else
           {
-            switch (bci->bond->GetBO())
+            switch (bci->bond->GetBondOrder())
             {
             case 1:
               if (!bci->bond->IsAromatic() && bci->bond->IsInRing() && bci->bond->GetBeginAtom()->IsAromatic() && bci->bond->GetEndAtom()->IsAromatic())
@@ -3503,7 +3503,7 @@ namespace OpenBabel {
       if (i+1 < node->Size() || node->GetAtom() == _endatom)
         buffer += '(';
 
-      switch (bond->GetBO()) {
+      switch (bond->GetBondOrder()) {
       case 1:
         char cc[2];
         cc[0] = GetCisTransBondSymbol(bond, node);

--- a/src/formats/xml/cdxmlformat.cpp
+++ b/src/formats/xml/cdxmlformat.cpp
@@ -448,7 +448,7 @@ bool ChemDrawXMLFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
     xmlTextWriterWriteFormatAttribute(writer(), C_BEGIN , "%d", patom->GetIdx() + _offset);
 	patom = pbond->GetEndAtom();
     xmlTextWriterWriteFormatAttribute(writer(), C_END , "%d", patom->GetIdx() + _offset);
-	n = pbond->GetBO();
+	n = pbond->GetBondOrder();
     if (n != 1)
     {
       xmlTextWriterWriteFormatAttribute(writer(), C_ORDER , "%d", n);

--- a/src/formats/xml/cmlformat.cpp
+++ b/src/formats/xml/cmlformat.cpp
@@ -1815,7 +1815,7 @@ namespace OpenBabel
         vector<OBBond*>::iterator ib;
         for (pbond = mol.BeginBond(ib);pbond;pbond = mol.NextBond(ib))
           {
-            int bo = pbond->GetBO();
+            int bo = pbond->GetBondOrder();
 
             if(!arrayform)
               {
@@ -1936,7 +1936,7 @@ namespace OpenBabel
           {
             for (pbond = mol.BeginBond(ib);pbond;pbond = mol.NextBond(ib))
               {
-                if(pbond->GetBO()==2 || pbond->IsWedge() || pbond->IsHash())
+                if(pbond->GetBondOrder()==2 || pbond->IsWedge() || pbond->IsHash())
                   WriteBondStereo(pbond, atomIds);
               }
           }

--- a/src/formats/yasaraformat.cpp
+++ b/src/formats/yasaraformat.cpp
@@ -549,7 +549,7 @@ bool YOBFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
     //printf("Babel atom %d with %d links:\n",i,links);
     for (linkedatom=srcatom->BeginNbrAtom(iter);linkedatom;linkedatom=srcatom->NextNbrAtom(iter))
     { storeint32le(buffer,linkedatom->GetIdx()-1);
-      bondorder=(*iter)->GetBO();
+      bondorder=(*iter)->GetBondOrder();
       //printf("  Order %d\n",bondorder);
       if (bondorder==4) bondorder=MOB_LINKQUADRUPLE;
       else if (bondorder==5) bondorder=MOB_LINKRESONANCE50;

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -1374,7 +1374,7 @@ namespace OpenBabel
       bond->SetId(NoId);//Need to remove ID which relates to source mol rather than this mol
       AddBond(bond->GetBeginAtomIdx() + prevatms,
               bond->GetEndAtomIdx() + prevatms,
-              bond->GetBO(), bond->GetFlags());
+              bond->GetBondOrder(), bond->GetFlags());
     }
 
     // Now update all copied residues too
@@ -2593,7 +2593,7 @@ namespace OpenBabel
   {
     if(!AddBond(bond.GetBeginAtomIdx(),
                    bond.GetEndAtomIdx(),
-                   bond.GetBO(),
+                   bond.GetBondOrder(),
                    bond.GetFlags()))
       return false;
     //copy the bond's generic data
@@ -3448,7 +3448,7 @@ namespace OpenBabel
                   }
               }
             if (c)
-              (atom->GetBond(c))->SetBO(3);
+              (atom->GetBond(c))->SetBondOrder(3);
           }
         // Possible sp2-hybrid atoms
         else if ( (atom->GetHyb() == 2 || atom->GetValence() == 1)
@@ -3514,7 +3514,7 @@ namespace OpenBabel
                   }
               } // loop through neighbors
             if (c)
-              (atom->GetBond(c))->SetBO(2);
+              (atom->GetBond(c))->SetBondOrder(2);
           }
       } // pass 6
 
@@ -3750,7 +3750,7 @@ namespace OpenBabel
                 else
                   ++chg2;
                 pNbratom->SetFormalCharge(chg2);
-                pbond->SetBO(pbond->GetBO()+1);
+                pbond->SetBondOrder(pbond->GetBondOrder()+1);
               }
           }
       }
@@ -3789,7 +3789,7 @@ namespace OpenBabel
         OBBondIterator bi;
         for (bestbond = bond = patom->BeginBond(bi); bond; bond = patom->NextBond(bi))
         {
-          unsigned int bo = bond->GetBO();
+          unsigned int bo = bond->GetBondOrder();
           if(bo>=2 && bo<=4)
           {
             bool het = IsNotCorH(bond->GetNbrAtom(patom));

--- a/src/obiter.cpp
+++ b/src/obiter.cpp
@@ -635,7 +635,7 @@ namespace OpenBabel
          // The variable b behaves like OBBond* when used with -> and * but
          // but needs to be explicitly converted when appearing as a parameter
          // in a function call - use &*b
-         bondOrderSum +=  b->GetBO();
+         bondOrderSum +=  b->GetBondOrder();
       }
       \endcode
   **/
@@ -783,7 +783,7 @@ namespace OpenBabel
          // The variable b behaves like OBBond* when used with -> and * but
          // but needs to be explicitly converted when appearing as a parameter
          // in a function call - use &*b
-         if (b->GetBO() == 3)
+         if (b->GetBondOrder() == 3)
             tripleBondCount++;
       }
       \endcode

--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -2230,15 +2230,15 @@ namespace OpenBabel
         case BE_ANY:
           return true;
         case BE_DEFAULT:
-          return bond->GetBO()==1 || bond->IsAromatic();
+          return bond->GetBondOrder()==1 || bond->IsAromatic();
         case BE_SINGLE:
-          return bond->GetBO()==1 && !bond->IsAromatic();
+          return bond->GetBondOrder()==1 && !bond->IsAromatic();
         case BE_DOUBLE:
-          return bond->GetBO()==2 && !bond->IsAromatic();
+          return bond->GetBondOrder()==2 && !bond->IsAromatic();
         case BE_TRIPLE:
-          return bond->GetBO() == 3;
+          return bond->GetBondOrder() == 3;
         case BE_QUAD:
-          return bond->GetBO() == 4;
+          return bond->GetBondOrder() == 4;
         case BE_AROM:
           return bond->IsAromatic();
         case BE_RING:

--- a/src/stereo/perception.cpp
+++ b/src/stereo/perception.cpp
@@ -114,7 +114,7 @@ namespace OpenBabel {
   {
     std::vector<OBBond*>::iterator ib;
     for (OBBond *bond = mol->BeginBond(ib); bond; bond = mol->NextBond(ib))
-      if (bond->GetBO() == 2) {
+      if (bond->GetBondOrder() == 2) {
         return true;
       }
     return false;
@@ -770,7 +770,7 @@ namespace OpenBabel {
       if (bond->IsInRing() && bond->IsAromatic())
         continue; // Exclude C=C in phenyl rings for example
 
-      if (bond->GetBO() == 2) {
+      if (bond->GetBondOrder() == 2) {
         OBAtom *begin = bond->GetBeginAtom();
         OBAtom *end = bond->GetEndAtom();
         if (!begin || !end)

--- a/test/testcdjsonformat.py
+++ b/test/testcdjsonformat.py
@@ -66,7 +66,7 @@ class TestCdJsonFormat(PybelWrapper):
         """Test reading bonds."""
         mols = list(pybel.readfile("cdjson", os.path.join(filedir, 'butane.json')))
         self.assertEqual(mols[0].OBMol.NumBonds(), 3)
-        self.assertEqual([mols[0].OBMol.GetBond(i).GetBO() for i in range(0, 3)], [1, 1, 1])
+        self.assertEqual([mols[0].OBMol.GetBond(i).GetBondOrder() for i in range(0, 3)], [1, 1, 1])
 
     def test_write_atoms(self):
         """Test writing atoms."""

--- a/test/testpcjsonformat.py
+++ b/test/testpcjsonformat.py
@@ -76,7 +76,7 @@ class TestPcJsonFormat(PybelWrapper):
         mols = list(pybel.readfile("pcjson", os.path.join(filedir, 'CID_6857552_2D.json')))
         self.assertEqual(len(mols), 1)
         self.assertEqual(mols[0].OBMol.NumBonds(), 13)
-        self.assertEqual([mols[0].OBMol.GetBond(i).GetBO() for i in range(0, 13)], [1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+        self.assertEqual([mols[0].OBMol.GetBond(i).GetBondOrder() for i in range(0, 13)], [1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1])
 
     def test_write_cid(self):
         """Test writing a PubChem compound CID."""


### PR DESCRIPTION
These functions have been deprecated since forever and replaced by SetBondOrder(), GetBondOrder().