### PR TITLE
Remove OBRandom from the public API

### DIFF
--- a/include/openbabel/conformersearch.h
+++ b/include/openbabel/conformersearch.h
@@ -445,7 +445,7 @@ namespace OpenBabel {
       std::vector<std::vector <int> > dynamic_niches; //!< The dynamically found niches
       std::vector<int> niche_map;                     //!< Procide the sharing niche index, given the key inddex
       
-      OBRandom unique_generator; //!< A unique random number generator for the whole algo
+      void *d; // Opaque pointer - currently for storing OBRandom* which may be removed in future
       bool use_sharing;		//!< Wether to use sharing or not.
       double alpha_share;	//!< The alpha parameter in sharing function
       double sigma_share;		//!< The sigma parameter in sharing function

--- a/include/openbabel/math/matrix3x3.h
+++ b/include/openbabel/math/matrix3x3.h
@@ -132,9 +132,6 @@ namespace OpenBabel
       //! Calculates the transpose of a matrix.
       matrix3x3 transpose(void) const;
 
-      //! Generates a matrix for a random rotation
-      void randomRotation(OBRandom &rnd);
-
       //! \return The determinant of the matrix
       double determinant() const;
 

--- a/include/openbabel/math/vector3.h
+++ b/include/openbabel/math/vector3.h
@@ -25,8 +25,6 @@ GNU General Public License for more details.
 #include <math.h>
 #include <iostream>
 
-#include <openbabel/rand.h>
-
 #ifndef RAD_TO_DEG
 #define RAD_TO_DEG (180.0/M_PI)
 #endif
@@ -39,7 +37,6 @@ namespace OpenBabel
 {
 
   class matrix3x3; // declared in math/matrix3x3.h
-  class OBRandom; // declared in rand.h
 
   // class introduction in vector3.cpp
   class OBAPI vector3
@@ -213,7 +210,7 @@ namespace OpenBabel
     vector3& operator*= ( const matrix3x3 &);
 
     //! Create a random unit vector
-    void randomUnitVector(OBRandom *oeRand= NULL);
+    void randomUnitVector();
 
     //  Member Functions
 

--- a/include/openbabel/obutil.h
+++ b/include/openbabel/obutil.h
@@ -42,9 +42,6 @@ GNU General Public License for more details.
 #define M_PI 3.14159265358979323846
 #endif
 
-// For backwards compatibility. Will be removed in the future
-#include <openbabel/rand.h>
-
 namespace OpenBabel
 {
 

--- a/scripts/openbabel-R.i
+++ b/scripts/openbabel-R.i
@@ -8,7 +8,6 @@
 
 
 #include <openbabel/obutil.h>
-#include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/math/transform3d.h>
@@ -259,7 +258,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %warnfilter(516) OpenBabel::OBElementTable; // Ignoring std::string methods in favour of char* ones
 %include <openbabel/data.h>
-%include <openbabel/rand.h>
 %include <openbabel/obutil.h>
 %warnfilter(516) OpenBabel::vector3; // Using the const x(), y() and z() in favour of the non-const
 %include <openbabel/math/vector3.h>

--- a/scripts/openbabel-csharp.i
+++ b/scripts/openbabel-csharp.i
@@ -27,7 +27,6 @@
 //renamed these because all public methods of a C# class should start with
 //a capital letter. As swig for c# matures this may become uneccesary.
 %rename(DistSq) OpenBabel::vector3::distSq(const vector3 &) const;
-%rename(RandomUnitVector) OpenBabel::vector3::randomUnitVector(OBRandom *);
 %rename(RandomUnitVector) OpenBabel::vector3::randomUnitVector();
 %rename(Normalize) OpenBabel::vector3::normalize();
 //changed this name slightly to match DistSq(vector3)
@@ -631,7 +630,6 @@ using System.Runtime.InteropServices;
 #endif
 
 #include <openbabel/obutil.h>
-#include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/math/transform3d.h>
@@ -744,7 +742,6 @@ using System.Runtime.InteropServices;
 
 %warnfilter(516) OpenBabel::OBElementTable; // Ignoring std::string methods in favour of char* ones
 %include <openbabel/data.h>
-%include <openbabel/rand.h>
 %include <openbabel/obutil.h>
 %warnfilter(516) OpenBabel::vector3; // Using the const x(), y() and z() in favour of the non-const
 %include <openbabel/math/vector3.h>

--- a/scripts/openbabel-java.i
+++ b/scripts/openbabel-java.i
@@ -8,7 +8,6 @@
 
 
 #include <openbabel/obutil.h>
-#include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/math/transform3d.h>
@@ -224,7 +223,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %warnfilter(516) OpenBabel::OBElementTable; // Ignoring std::string methods in favour of char* ones
 %include <openbabel/data.h>
-%include <openbabel/rand.h>
 %include <openbabel/obutil.h>
 %warnfilter(516) OpenBabel::vector3; // Using the const x(), y() and z() in favour of the non-const
 %include <openbabel/math/vector3.h>

--- a/scripts/openbabel-mono.i
+++ b/scripts/openbabel-mono.i
@@ -19,7 +19,6 @@
 //renamed these because all public methods of a C# class should start with
 //a capital letter. As swig for c# matures this may become uneccesary.
 %rename(DistSq) OpenBabel::vector3::distSq(const vector3 &) const;
-%rename(RandomUnitVector) OpenBabel::vector3::randomUnitVector(OBRandom *);
 %rename(RandomUnitVector) OpenBabel::vector3::randomUnitVector();
 %rename(Normalize) OpenBabel::vector3::normalize();
 //changed this name slightly to match DistSq(vector3)
@@ -151,7 +150,6 @@ WRAP_ARRAY(double,double_array)
 #endif
 
 #include <openbabel/obutil.h>
-#include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/math/transform3d.h>
@@ -247,7 +245,6 @@ SWIG_STD_VECTOR_SPECIALIZE_MINIMUM(OBBond, OpenBabel::OBBond*);
 %import <openbabel/babelconfig.h>
 
 %include <openbabel/data.h>
-%include <openbabel/rand.h>
 %include <openbabel/obutil.h>
 %include <openbabel/math/vector3.h>
 %include <openbabel/math/matrix3x3.h>

--- a/scripts/openbabel-perl.i
+++ b/scripts/openbabel-perl.i
@@ -9,7 +9,6 @@
 
 
 #include <openbabel/obutil.h>
-#include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/generic.h>
@@ -171,7 +170,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 %import <openbabel/babelconfig.h>
 
 %include <openbabel/data.h>
-%include <openbabel/rand.h>
 %include <openbabel/obutil.h>
 %include <openbabel/math/vector3.h>
 %warnfilter(503) OpenBabel::matrix3x3; // Not wrapping any of the overloaded operators

--- a/scripts/openbabel-php.i
+++ b/scripts/openbabel-php.i
@@ -8,7 +8,6 @@
 
 
 #include <openbabel/obutil.h>
-#include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/math/transform3d.h>
@@ -207,7 +206,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 %import <openbabel/babelconfig.h>
 
 %include <openbabel/data.h>
-%include <openbabel/rand.h>
 %include <openbabel/obutil.h>
 %include <openbabel/math/vector3.h>
 %warnfilter(503) OpenBabel::matrix3x3; // Not wrapping any of the overloaded operators

--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -11,7 +11,6 @@
 #endif
 
 #include <openbabel/obutil.h>
-#include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/math/transform3d.h>
@@ -246,7 +245,6 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 %import <openbabel/babelconfig.h>
 
 %include <openbabel/data.h>
-%include <openbabel/rand.h>
 %include <openbabel/obutil.h>
 %include <openbabel/math/vector3.h>
 %warnfilter(503) OpenBabel::matrix3x3; // Not wrapping any of the overloaded operators

--- a/scripts/openbabel-ruby.i
+++ b/scripts/openbabel-ruby.i
@@ -16,7 +16,6 @@
 #endif
 
 #include <openbabel/obutil.h>
-#include <openbabel/rand.h>
 #include <openbabel/math/vector3.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/math/transform3d.h>
@@ -197,7 +196,6 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 %import <openbabel/babelconfig.h>
 
 %include <openbabel/data.h>
-%include <openbabel/rand.h>
 %include <openbabel/obutil.h>
 %include <openbabel/math/vector3.h>
 %warnfilter(503) OpenBabel::matrix3x3; // Not wrapping any of the overloaded operators

--- a/src/conformersearch.cpp
+++ b/src/conformersearch.cpp
@@ -22,6 +22,7 @@ GNU General Public License for more details.
 #include <openbabel/forcefield.h>
 #include <openbabel/elements.h>
 #include <openbabel/bond.h>
+#include "rand.h"
 
 #if defined(_MSC_VER) && (_MSC_VER < 1800)
  #define OB_ISNAN _isnan
@@ -308,7 +309,11 @@ namespace OpenBabel {
     p_crossover = 0.7;
     niche_mating = 0.7;
     local_opt_rate = 3;
-    unique_generator.TimeSeed();
+    // For the moment 'd' is an opaque pointer to an instance of OBRandom*.
+    // In future, it could be a pointer to a structure storing all of the
+    // private variables.
+    d = (void*)new OBRandom();
+    ((OBRandom*)d)->TimeSeed();
     m_logstream = &cout; 	// Default logging send to standard output
     // m_logstream = NULL;
     m_printrotors = false;  // By default, do not print rotors but perform the conformer search
@@ -319,6 +324,7 @@ namespace OpenBabel {
   {
     delete m_filter;
     delete m_score;
+    delete (OBRandom*)d;
   }
 
 
@@ -783,9 +789,9 @@ namespace OpenBabel {
     for (i = 1; i <= m_rotorList.Size(); ++i, rotor = m_rotorList.NextRotor(ri))
       {
         neighbor = best;
-        new_val = unique_generator.NextInt() % rotor->GetResolution().size();
+        new_val = ((OBRandom*)d)->NextInt() % rotor->GetResolution().size();
         while (new_val == best[i])
-          new_val = unique_generator.NextInt() % rotor->GetResolution().size();
+          new_val = ((OBRandom*)d)->NextInt() % rotor->GetResolution().size();
         neighbor[i] = new_val;
         if (IsUniqueKey(backup_population, neighbor) && IsGood(neighbor))
           m_rotorKeys.push_back (neighbor);
@@ -837,30 +843,30 @@ namespace OpenBabel {
       return 0;
 
     // Make a 2-tournament selection to choose first parent
-    i = unique_generator.NextInt() % pop_size;
-    j = unique_generator.NextInt() % pop_size;
+    i = ((OBRandom*)d)->NextInt() % pop_size;
+    j = ((OBRandom*)d)->NextInt() % pop_size;
     parent1 = vshared_fitnes[i] > vshared_fitnes[j] ? i : j;
     iniche = niche_map[parent1];
     if (iniche > -1)
       nsize = dynamic_niches[iniche].size (); // Belongs to a specific niche
 
     // Do we apply crossover here?
-    flag_crossover = (unique_generator.NextFloat () <= p_crossover);
-    if (flag_crossover && (unique_generator.NextFloat () <= niche_mating)  &&  nsize > 1)
+    flag_crossover = (((OBRandom*)d)->NextFloat () <= p_crossover);
+    if (flag_crossover && (((OBRandom*)d)->NextFloat () <= niche_mating)  &&  nsize > 1)
       {
         // Apply niche mating: draw second parent in the same niche, if its has
         // at least 2 members. Make a 2-tournament selection whithin this niche
-        rnd1 =  unique_generator.NextInt() % nsize;
+        rnd1 = ((OBRandom*)d)->NextInt() % nsize;
         i =  dynamic_niches[iniche][rnd1];
-        rnd2 =  unique_generator.NextInt() % nsize;
+        rnd2 = ((OBRandom*)d)->NextInt() % nsize;
         j = dynamic_niches[iniche][rnd2];
         parent2 = vshared_fitnes[i] > vshared_fitnes[j] ? i : j;
       }
     else
       {
         // Draw second in the whole population
-        i = unique_generator.NextInt() % pop_size;
-        j = unique_generator.NextInt() % pop_size;
+        i = ((OBRandom*)d)->NextInt() % pop_size;
+        j = ((OBRandom*)d)->NextInt() % pop_size;
         parent2 = vshared_fitnes[i] > vshared_fitnes[j] ? i : j;
       }
 
@@ -869,7 +875,7 @@ namespace OpenBabel {
         // Cross the 2 vectors: toss a coin for each position (i.e. uniform crossover)
         for (i = 1; i < key1.size(); i++)
           {
-            if ( unique_generator.NextInt() % 2)
+            if (((OBRandom*)d)->NextInt() % 2)
               { // Copy parent1 to offspring 1
                 key1[i] = m_rotorKeys[parent1][i];
                 key2[i] = m_rotorKeys[parent2][i];
@@ -891,10 +897,10 @@ namespace OpenBabel {
     rotor = m_rotorList.BeginRotor(ri);
     for (i = 1; i <= m_rotorList.Size(); ++i, rotor = m_rotorList.NextRotor(ri))
       {
-        if (unique_generator.NextInt() % m_mutability == 0)
-          key1[i] = unique_generator.NextInt() % rotor->GetResolution().size();
-        if (unique_generator.NextInt() % m_mutability == 0)
-          key2[i] = unique_generator.NextInt() % rotor->GetResolution().size();
+        if (((OBRandom*)d)->NextInt() % m_mutability == 0)
+          key1[i] = ((OBRandom*)d)->NextInt() % rotor->GetResolution().size();
+        if (((OBRandom*)d)->NextInt() % m_mutability == 0)
+          key2[i] = ((OBRandom*)d)->NextInt() % rotor->GetResolution().size();
       }
     if (IsUniqueKey(m_rotorKeys, key1) && IsGood(key1))
       ret_code += 1;

--- a/src/distgeom.cpp
+++ b/src/distgeom.cpp
@@ -28,6 +28,7 @@ GNU General Public License for more details.
 #include <openbabel/builder.h>
 #include <openbabel/elements.h>
 #include <openbabel/generic.h>
+#include "rand.h"
 
 #include <openbabel/stereo/stereo.h>
 #include <openbabel/stereo/cistrans.h>

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -34,6 +34,7 @@ GNU General Public License for more details.
 #include <openbabel/grid.h>
 #include <openbabel/griddata.h>
 #include <openbabel/elements.h>
+#include "rand.h"
 
 using namespace std;
 

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -36,6 +36,8 @@ GNU General Public License for more details.
 #include <openbabel/graphsym.h>
 #include <openbabel/kekulize.h>
 #include <openbabel/canon.h>
+#include "../rand.h"
+#include "../rand.cpp"
 
 #include "smilesvalence.h"
 

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -36,8 +36,6 @@ GNU General Public License for more details.
 #include <openbabel/graphsym.h>
 #include <openbabel/kekulize.h>
 #include <openbabel/canon.h>
-#include "../rand.h"
-#include "../rand.cpp"
 
 #include "smilesvalence.h"
 
@@ -3569,21 +3567,12 @@ namespace OpenBabel {
    *    molecule, and use those to test the canonicalizer.
    ***************************************************************************/
 
-  static int timeseed = 0;
-
   void RandomLabels(OBMol *pMol, OBBitVec &frag_atoms,
       vector<unsigned int> &symmetry_classes,
       vector<unsigned int> &labels)
   {
     int natoms = pMol->NumAtoms();
     OBBitVec used(natoms);
-
-    if (!timeseed) {
-      OBRandom rand;
-      rand.TimeSeed();
-      timeseed = 1;
-    }
-
 
     FOR_ATOMS_OF_MOL(atom, *pMol) {
       if (frag_atoms.BitIsOn(atom->GetIdx())) {

--- a/src/math/matrix3x3.cpp
+++ b/src/math/matrix3x3.cpp
@@ -48,19 +48,6 @@ namespace OpenBabel
 
   */
 
-  /*! The axis of the rotation will be uniformly distributed on
-    the unit sphere and the angle will be uniformly distributed in
-    the interval 0..360 degrees. */
-  void matrix3x3::randomRotation(OBRandom &rnd)
-  {
-    double rotAngle;
-    vector3 v1;
-
-    v1.randomUnitVector(&rnd);
-    rotAngle = 360.0 * rnd.NextFloat();
-    this->RotAboutAxisByAngle(v1,rotAngle);
-  }
-
   void matrix3x3::SetupRotMat(double phi,double theta,double psi)
   {
     double p  = phi * DEG_TO_RAD;

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -24,6 +24,7 @@ GNU General Public License for more details.
 #include <float.h>
 
 #include <openbabel/math/vector3.h>
+#include "../rand.h"
 #include <openbabel/obutil.h>
 
 using namespace std;
@@ -84,22 +85,14 @@ namespace OpenBabel
 
   /*! Replaces *this with a random unit vector, which is (supposed
     to be) uniformly distributed over the unit sphere. Uses the
-    random number generator obRand, or uses the system number
-    generator with a time seed if obRand == NULL.
+    system number generator with a time seed.
 
-    @param obRandP random number generator to use, or NULL, if a singleton
-    system random number generator (with time seed) should be used
   */
-  void vector3::randomUnitVector(OBRandom *obRandP)
+  void vector3::randomUnitVector()
   {
     OBRandom *ptr;
-    if (!obRandP)
-      {
-        static OBRandom singleRand(true);
-        ptr = &singleRand;
-      }
-    else
-      ptr = obRandP;
+    static OBRandom singleRand(true);
+    ptr = &singleRand;
 
     // obtain a random vector with 0.001 <= length^2 <= 1.0, normalize
     // the vector to obtain a random vector of length 1.0.

--- a/src/rand.cpp
+++ b/src/rand.cpp
@@ -192,14 +192,14 @@ namespace OpenBabel
     return( x == 1 );
   }
 
-  void DoubleAdd( DoubleType *x, unsigned int y )
+  static void DoubleAdd( DoubleType *x, unsigned int y )
   {
     x->lo += y;
     if( x->lo < y )
       x->hi++;
   }
 
-  void DoubleMultiply( unsigned int x, unsigned int y, DoubleType *z )
+  static void DoubleMultiply( unsigned int x, unsigned int y, DoubleType *z )
   {
     unsigned int x0, x1, x2, x3;
     unsigned int hx, lx;
@@ -254,7 +254,7 @@ namespace OpenBabel
       return 32-table[x];
   }
 
-  unsigned int DoubleModulus( DoubleType *n,  unsigned int d )
+  static unsigned int DoubleModulus( DoubleType *n,  unsigned int d )
   {
     unsigned int d1, d0;
     unsigned int r1, r0;
@@ -366,7 +366,7 @@ namespace OpenBabel
     return 1;
   }
 
-  int DetermineSequence( unsigned int m, unsigned int *pm,
+  static int DetermineSequence( unsigned int m, unsigned int *pm,
                          unsigned int *pa,
                          unsigned int *pc )
   {
@@ -425,7 +425,7 @@ namespace OpenBabel
   }
 
 
-  void GenerateSequence( unsigned int p, unsigned int m,
+  static void GenerateSequence( unsigned int p, unsigned int m,
                          unsigned int a, unsigned int c )
   {
     unsigned int i;

--- a/src/rand.cpp
+++ b/src/rand.cpp
@@ -28,7 +28,7 @@ GNU General Public License for more details.
 #include <stdio.h>
 #include <math.h>
 
-#include <openbabel/rand.h>
+#include "rand.h"
 
 #if TIME_WITH_SYS_TIME
 #include <sys/time.h>

--- a/src/rand.h
+++ b/src/rand.h
@@ -38,9 +38,9 @@ namespace OpenBabel
   }
   DoubleType;
 
-  OBAPI void DoubleMultiply( unsigned int,unsigned int,DoubleType*);
-  OBAPI void DoubleAdd( DoubleType*,unsigned int);
-  OBAPI unsigned int DoubleModulus( DoubleType*,unsigned int);
+  void DoubleMultiply( unsigned int,unsigned int,DoubleType*);
+  void DoubleAdd( DoubleType*,unsigned int);
+  unsigned int DoubleModulus( DoubleType*,unsigned int);
 
   //! \class OBRandom rand.h <openbabel/rand.h>
   //! \brief Random number generator
@@ -65,7 +65,7 @@ namespace OpenBabel
      generator.Seed(10246);// Use a specific initial seed value for reproducing sequence
      \endcode
    **/
-  class OBAPI OBRandom
+  class OBRandom
   {
     DoubleType d;
     unsigned int m,a,c;

--- a/src/rand.h
+++ b/src/rand.h
@@ -38,10 +38,7 @@ namespace OpenBabel
   }
   DoubleType;
 
-  void DoubleMultiply( unsigned int,unsigned int,DoubleType*);
-  void DoubleAdd( DoubleType*,unsigned int);
-  unsigned int DoubleModulus( DoubleType*,unsigned int);
-
+  
   //! \class OBRandom rand.h <openbabel/rand.h>
   //! \brief Random number generator
   /**

--- a/test/math.cpp
+++ b/test/math.cpp
@@ -26,6 +26,8 @@ GNU General Public License for more details.
 #include <openbabel/babelconfig.h>
 #include <openbabel/math/matrix3x3.h>
 #include <openbabel/obutil.h>
+#include "../src/rand.h"
+#include "../src/rand.cpp"
 
 #include <iostream>
 #include <stdlib.h>
@@ -298,6 +300,19 @@ void testInversion()
   VERIFY( result.isUnitMatrix() );
 }
 
+
+/*! The axis of the rotation will be uniformly distributed on
+  the unit sphere and the angle will be uniformly distributed in
+  the interval 0..360 degrees. */
+void randomRotation(matrix3x3 *mat, double rotAngle)
+{
+  vector3 v1;
+
+  v1.randomUnitVector();
+
+  mat->RotAboutAxisByAngle(v1, rotAngle);
+}
+
 // Test the eigenvalue finder. Set up a diagonal matrix and conjugate
 // by a rotation. That way we obtain a symmetric matrix that can be
 // diagonalized. Check if the eigenvalue finder reveals the original
@@ -316,7 +331,7 @@ void testEigenvalues()
   VERIFY( Diagonal.isDiagonal() );
 
   matrix3x3 rndRotation;
-  rndRotation.randomRotation(randomizer);
+  randomRotation(&rndRotation, 123);
 
   // check that rndRotation is really a rotation, i.e. that randomRotation() works
   VERIFY( rndRotation.isOrthogonal() );

--- a/tools/obconformer.cpp
+++ b/tools/obconformer.cpp
@@ -41,7 +41,6 @@ using namespace std;
 using namespace OpenBabel;
 
 OBRotorList rl;
-OBRandom generator;
 
 int main(int argc,char *argv[])
 {

--- a/tools/obrotamer.cpp
+++ b/tools/obrotamer.cpp
@@ -28,6 +28,8 @@ GNU General Public License for more details.
 #include <openbabel/rotamer.h>
 #include <openbabel/rotor.h>
 #include <openbabel/obutil.h>
+#include "../src/rand.h"
+#include "../src/rand.cpp"
 
 #include <stdio.h>
 #include <iostream>


### PR DESCRIPTION
(Proposed PR as part of the API cleanup)

This removes OBRandom from the public API. It's still there, and included via # include. The changes are a bit hacky for the moment, but removing it gives us some breathing space to fix problems and bring it back (if that's what makes sense). 

So OBRandom will probably come back at some point, but it won't be the same. This code of Roger's is not a general pseudorandom number generator, but an iterator over a fixed (and small) set of intergers in pseudorandom order. The details are actually in a talk that's online from when Roger was in Metaphorics (insert reference in here from future).

This is part of the problem. The other part is that random numbers are being used with a time seed throughout the codebase in a way that hampers reproducibility. When I make a 3D structure a second time, I want to see the same coordinates. We can provide the ability to change the seed, but this should be the default. 

Fixing these problems is a bigger job than there is time for right now. Hiding OBRandom will allow us to make any API changes we need without breaking things.