### PR TITLE
For Travis builds, include output for build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_script:
 
 script:
  - make -j2
- - if [ ${RUN_CTEST} = 'true' ]; then ctest -j 2; fi
+ - if [ ${RUN_CTEST} = 'true' ]; then ctest -j 2 --output-on-failure; fi


### PR DESCRIPTION
When a test fails, it would be nice to see the test output, especially for those cases where I'm having trouble reproducing the test failure.