### PR TITLE
Remove GetGenericValueDef from OBGenericData

### DIFF
--- a/include/openbabel/generic.h
+++ b/include/openbabel/generic.h
@@ -138,13 +138,6 @@ namespace OpenBabel
       {return new OBPairTemplate<ValueT>(*this);}
     void SetValue(const ValueT t)             { _value = t;     }
     virtual const ValueT &GetGenericValue() const    { return(_value); }
-    const ValueT &GetGenericValueDef(const ValueT &def_val) const
-    { 
-      if(this == NULL)
-	return def_val;
-      else	
-        return GetGenericValue(); 
-    }
   };
 
   //! Store arbitrary key/value integer data like OBPairData


### PR DESCRIPTION
This convenience function should never have been added (https://github.com/openbabel/openbabel/pull/17) to what is a core classes of the toolkit. Fixes #1913 by removing the offending function.