### PR TITLE
Fix randomly failing Python gradient test

### DIFF
--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -243,6 +243,8 @@ H          0.74700        0.50628       -0.64089
         ff = pybel._forcefields["mmff94"]
 
         self.assertTrue(ff.Setup(mol.OBMol))
+        energy = ff.Energy() # note: calling GetGradient w/o calling Energy()
+                             #       just returns random numbers
         for atom in mol.atoms:
             # this should throw an AttributeError if not available
             grad = ff.GetGradient(atom.OBAtom)


### PR DESCRIPTION
The gradient test was failing randomly as calling GetGradient() appears to just return random numbers (different values each time). This fixes it by ensuring that Energy() is called first. This may be a problem in the underlying C++, but for now, this sorts it out.