### PR TITLE
Remove low-hanging deprecated methods

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -190,8 +190,6 @@ namespace OpenBabel
       //! \return the index into a pointer-driven array as used by
       //!   GetCoordPtr() or SetCoordPtr()
       unsigned int GetCoordinateIdx() const { return((int)_cidx); }
-      //! \deprecated Use GetCoordinateIdx() instead
-      unsigned int GetCIdx()          const { return((int)_cidx); }
       //! \return The current number of explicit connections
       unsigned int GetValence() const { return (unsigned int)_vbond.size(); }
       //! \return The hybridization of this atom: 1 for sp, 2 for sp2, 3 for sp3, 4 for sq. planar, 5 for trig. bipy, 6 for octahedral

--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -251,11 +251,6 @@ namespace OpenBabel
       //! \return the OBBond object between this atom and that supplied,
       //! or NULL if the two atoms are not bonded
       OBBond    *GetBond(OBAtom *);
-      //! \return a pointer to the "next" atom (by atom index) in the
-      //!    parent OBMol, or NULL if no such atom exists.
-      //! \deprecated Use any of the other iterator methods. This
-      //!    method will be removed in the future.
-      OBAtom    *GetNextAtom();
       //@}
 
       //! \name Iterator methods

--- a/include/openbabel/bitvec.h
+++ b/include/openbabel/bitvec.h
@@ -118,8 +118,6 @@ namespace OpenBabel
       /// Return the number of bits which are set to 1 in the vector
       unsigned CountBits() const;
 
-      /// \deprecated Use IsEmpty() instead.
-      bool Empty() const   { return(IsEmpty()); }
 	  /// Are there no bits set to 1 in this vector?
       bool IsEmpty() const;
       /// Reserve space for \p size_in_bits bits
@@ -160,10 +158,6 @@ namespace OpenBabel
 			}
           return rtn;
         }
-      /// \deprecated Use BitIsSet(unsigned bit_offset) instead.
-      bool BitIsOn(int bit_offset) const
-        { return BitIsSet((unsigned)bit_offset); }
-
       /// Sets the bits listed as bit offsets
 	  void FromVecInt(const std::vector<int> & bit_offsets);
       /// Sets the bits listed as a string of integers

--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -151,15 +151,6 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
       }
     }
 
-    //! Create a new OBAtom pointer. Does no bookkeeping
-    //! \deprecated Use NewAtom instead, which ensures internal connections
-    virtual OBAtom *CreateAtom(void);
-    //! Create a new OBBond pointer. Does no bookkeeping
-    //! \deprecated Use NewBond instead, which ensures internal connections
-    virtual OBBond *CreateBond(void);
-    //! Create a new OBResidue pointer. Does no bookkeeping
-    //! \deprecated Use NewResidue instead, which ensures internal connections
-    virtual OBResidue *CreateResidue(void);
     //! Free an OBAtom pointer if defined. Does no bookkeeping
     //! \see DeleteAtom which ensures internal connections
     virtual void DestroyAtom(OBAtom*);

--- a/include/openbabel/ring.h
+++ b/include/openbabel/ring.h
@@ -88,7 +88,7 @@ namespace OpenBabel
     //! \return Whether @p i as an atom index is in this ring
     bool   IsInRing(int i)
     {
-      return(_pathset.BitIsOn(i));
+      return(_pathset.BitIsSet(i));
     }
 
     //! Set the parent of this ring to @p m

--- a/include/openbabel/rotor.h
+++ b/include/openbabel/rotor.h
@@ -500,7 +500,7 @@ namespace OpenBabel
      */
     bool HasFixedBonds()
     {
-      return !_fixedbonds.Empty();
+      return !_fixedbonds.IsEmpty();
     }
     //! Rotates each bond to zero and 180 degrees and tests
     //! if the 2 conformers are duplicates.  if so - the symmetric torsion
@@ -629,7 +629,7 @@ namespace OpenBabel
      */
     bool HasFixedAtoms()
     {
-      return(!_fixedatoms.Empty());
+      return(!_fixedatoms.IsEmpty());
     }
     //! Has no effect
     //! \deprecated Currently has no effect

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -442,12 +442,6 @@ namespace OpenBabel
     _isotope = iso;
   }
 
-  OBAtom *OBAtom::GetNextAtom()
-  {
-    OBMol *mol = (OBMol*)GetParent();
-    return(((unsigned)GetIdx() == mol->NumAtoms())? NULL : mol->GetAtom(GetIdx()+1));
-  }
-
   OBResidue *OBAtom::GetResidue()
   {
     OBMol *mol = this->GetParent();

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -185,7 +185,7 @@ namespace OpenBabel
       // Fix the binding pocket atoms
       OBFFConstraints constraints;
       FOR_ATOMS_OF_MOL (a, mol) {
-      if (pocket.BitIsOn(a->GetIdx())
+      if (pocket.BitIsSet(a->GetIdx())
       constraints.AddAtomConstraint(a->GetIdx());
       }
 
@@ -2184,21 +2184,21 @@ namespace OpenBabel
       if (HasGroups()) {
         bool isIncludedPair = false;
         for (size_t i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) &&
-              _interGroup[i].BitIsOn(b->GetIdx())) {
+          if (_interGroup[i].BitIsSet(a->GetIdx()) &&
+              _interGroup[i].BitIsSet(b->GetIdx())) {
             isIncludedPair = true;
             break;
           }
         }
         if (!isIncludedPair) {
           for (size_t i=0; i < _interGroups.size(); ++i) {
-            if (_interGroups[i].first.BitIsOn(a->GetIdx()) &&
-                _interGroups[i].second.BitIsOn(b->GetIdx())) {
+            if (_interGroups[i].first.BitIsSet(a->GetIdx()) &&
+                _interGroups[i].second.BitIsSet(b->GetIdx())) {
               isIncludedPair = true;
               break;
             }
-            if (_interGroups[i].first.BitIsOn(b->GetIdx()) &&
-                _interGroups[i].second.BitIsOn(a->GetIdx())) {
+            if (_interGroups[i].first.BitIsSet(b->GetIdx()) &&
+                _interGroups[i].second.BitIsSet(a->GetIdx())) {
               isIncludedPair = true;
               break;
             }

--- a/src/forcefields/forcefieldgaff.cpp
+++ b/src/forcefields/forcefieldgaff.cpp
@@ -549,7 +549,7 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validBond = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()))
             validBond = true;
         }
         if (!validBond)
@@ -610,8 +610,8 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validAngle = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx()))
             validAngle = true;
         }
         if (!validAngle)
@@ -678,8 +678,8 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validTorsion = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx()) && _intraGroup[i].BitIsOn(d->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx()) && _intraGroup[i].BitIsSet(d->GetIdx()))
             validTorsion = true;
         }
         if (!validTorsion)
@@ -763,8 +763,8 @@ namespace OpenBabel
       if (HasGroups()) {
 	bool validOOP = false;
 	for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-	  if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-	      _intraGroup[i].BitIsOn(c->GetIdx()) && _intraGroup[i].BitIsOn(d->GetIdx()))
+	  if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+	      _intraGroup[i].BitIsSet(c->GetIdx()) && _intraGroup[i].BitIsSet(d->GetIdx()))
 	    validOOP = true;
 	}
 	if (!validOOP)
@@ -924,13 +924,13 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validVDW = false;
         for (unsigned int i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) && _interGroup[i].BitIsOn(b->GetIdx()))
+          if (_interGroup[i].BitIsSet(a->GetIdx()) && _interGroup[i].BitIsSet(b->GetIdx()))
             validVDW = true;
         }
         for (unsigned int i=0; i < _interGroups.size(); ++i) {
-          if (_interGroups[i].first.BitIsOn(a->GetIdx()) && _interGroups[i].second.BitIsOn(b->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(a->GetIdx()) && _interGroups[i].second.BitIsSet(b->GetIdx()))
             validVDW = true;
-          if (_interGroups[i].first.BitIsOn(b->GetIdx()) && _interGroups[i].second.BitIsOn(a->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(b->GetIdx()) && _interGroups[i].second.BitIsSet(a->GetIdx()))
             validVDW = true;
         }
 
@@ -1026,13 +1026,13 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validEle = false;
         for (unsigned int i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) && _interGroup[i].BitIsOn(b->GetIdx()))
+          if (_interGroup[i].BitIsSet(a->GetIdx()) && _interGroup[i].BitIsSet(b->GetIdx()))
             validEle = true;
         }
         for (unsigned int i=0; i < _interGroups.size(); ++i) {
-          if (_interGroups[i].first.BitIsOn(a->GetIdx()) && _interGroups[i].second.BitIsOn(b->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(a->GetIdx()) && _interGroups[i].second.BitIsSet(b->GetIdx()))
             validEle = true;
-          if (_interGroups[i].first.BitIsOn(b->GetIdx()) && _interGroups[i].second.BitIsOn(a->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(b->GetIdx()) && _interGroups[i].second.BitIsSet(a->GetIdx()))
             validEle = true;
         }
 

--- a/src/forcefields/forcefieldghemical.cpp
+++ b/src/forcefields/forcefieldghemical.cpp
@@ -449,7 +449,7 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validBond = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()))
             validBond = true;
         }
         if (!validBond)
@@ -515,8 +515,8 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validAngle = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx()))
             validAngle = true;
         }
         if (!validAngle)
@@ -585,8 +585,8 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validTorsion = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx()) && _intraGroup[i].BitIsOn(d->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx()) && _intraGroup[i].BitIsSet(d->GetIdx()))
             validTorsion = true;
         }
         if (!validTorsion)
@@ -698,13 +698,13 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validVDW = false;
         for (unsigned int i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) && _interGroup[i].BitIsOn(b->GetIdx()))
+          if (_interGroup[i].BitIsSet(a->GetIdx()) && _interGroup[i].BitIsSet(b->GetIdx()))
             validVDW = true;
         }
         for (unsigned int i=0; i < _interGroups.size(); ++i) {
-          if (_interGroups[i].first.BitIsOn(a->GetIdx()) && _interGroups[i].second.BitIsOn(b->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(a->GetIdx()) && _interGroups[i].second.BitIsSet(b->GetIdx()))
             validVDW = true;
-          if (_interGroups[i].first.BitIsOn(b->GetIdx()) && _interGroups[i].second.BitIsOn(a->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(b->GetIdx()) && _interGroups[i].second.BitIsSet(a->GetIdx()))
             validVDW = true;
         }
 
@@ -801,13 +801,13 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validEle = false;
         for (unsigned int i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) && _interGroup[i].BitIsOn(b->GetIdx()))
+          if (_interGroup[i].BitIsSet(a->GetIdx()) && _interGroup[i].BitIsSet(b->GetIdx()))
             validEle = true;
         }
         for (unsigned int i=0; i < _interGroups.size(); ++i) {
-          if (_interGroups[i].first.BitIsOn(a->GetIdx()) && _interGroups[i].second.BitIsOn(b->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(a->GetIdx()) && _interGroups[i].second.BitIsSet(b->GetIdx()))
             validEle = true;
-          if (_interGroups[i].first.BitIsOn(b->GetIdx()) && _interGroups[i].second.BitIsOn(a->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(b->GetIdx()) && _interGroups[i].second.BitIsSet(a->GetIdx()))
             validEle = true;
         }
 

--- a/src/forcefields/forcefieldmmff94.cpp
+++ b/src/forcefields/forcefieldmmff94.cpp
@@ -2721,7 +2721,7 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validBond = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx())) {
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx())) {
             validBond = true;
             break;
           }
@@ -2817,8 +2817,8 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validAngle = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx())) {
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx())) {
             validAngle = true;
             break;
           }
@@ -3115,8 +3115,8 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validTorsion = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx()) && _intraGroup[i].BitIsOn(d->GetIdx())) {
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx()) && _intraGroup[i].BitIsSet(d->GetIdx())) {
             validTorsion = true;
             break;
           }
@@ -3398,8 +3398,8 @@ namespace OpenBabel
           if (HasGroups()) {
             bool validOOP = false;
             for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-              if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-                  _intraGroup[i].BitIsOn(c->GetIdx()) && _intraGroup[i].BitIsOn(d->GetIdx())) {
+              if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+                  _intraGroup[i].BitIsSet(c->GetIdx()) && _intraGroup[i].BitIsSet(d->GetIdx())) {
                 validOOP = true;
                 break;
               }
@@ -3501,18 +3501,18 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validVDW = false;
         for (unsigned int i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) && _interGroup[i].BitIsOn(b->GetIdx())) {
+          if (_interGroup[i].BitIsSet(a->GetIdx()) && _interGroup[i].BitIsSet(b->GetIdx())) {
             validVDW = true;
             break;
           }
         }
         if (!validVDW) {
           for (unsigned int i=0; i < _interGroups.size(); ++i) {
-            if (_interGroups[i].first.BitIsOn(a->GetIdx()) && _interGroups[i].second.BitIsOn(b->GetIdx())) {
+            if (_interGroups[i].first.BitIsSet(a->GetIdx()) && _interGroups[i].second.BitIsSet(b->GetIdx())) {
               validVDW = true;
               break;
             }
-            if (_interGroups[i].first.BitIsOn(b->GetIdx()) && _interGroups[i].second.BitIsOn(a->GetIdx())) {
+            if (_interGroups[i].first.BitIsSet(b->GetIdx()) && _interGroups[i].second.BitIsSet(a->GetIdx())) {
               validVDW = true;
               break;
             }
@@ -3634,18 +3634,18 @@ namespace OpenBabel
       if (HasGroups()) {
         bool validEle = false;
         for (unsigned int i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) && _interGroup[i].BitIsOn(b->GetIdx())) {
+          if (_interGroup[i].BitIsSet(a->GetIdx()) && _interGroup[i].BitIsSet(b->GetIdx())) {
             validEle = true;
             break;
           }
         }
         if (!validEle) {
           for (unsigned int i=0; i < _interGroups.size(); ++i) {
-            if (_interGroups[i].first.BitIsOn(a->GetIdx()) && _interGroups[i].second.BitIsOn(b->GetIdx())) {
+            if (_interGroups[i].first.BitIsSet(a->GetIdx()) && _interGroups[i].second.BitIsSet(b->GetIdx())) {
               validEle = true;
               break;
             }
-            if (_interGroups[i].first.BitIsOn(b->GetIdx()) && _interGroups[i].second.BitIsOn(a->GetIdx())) {
+            if (_interGroups[i].first.BitIsSet(b->GetIdx()) && _interGroups[i].second.BitIsSet(a->GetIdx())) {
               validEle = true;
               break;
             }

--- a/src/forcefields/forcefielduff.cpp
+++ b/src/forcefields/forcefielduff.cpp
@@ -872,7 +872,7 @@ namespace OpenBabel {
       if (HasGroups()) {
         bool validBond = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()))
             validBond = true;
         }
         if (!validBond)
@@ -943,8 +943,8 @@ namespace OpenBabel {
       if (HasGroups()) {
         bool validAngle = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx()))
             validAngle = true;
         }
         if (!validAngle)
@@ -1160,8 +1160,8 @@ namespace OpenBabel {
       if (HasGroups()) {
         bool validTorsion = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) && _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx()) && _intraGroup[i].BitIsOn(d->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) && _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx()) && _intraGroup[i].BitIsSet(d->GetIdx()))
             validTorsion = true;
         }
         if (!validTorsion)
@@ -1369,10 +1369,10 @@ namespace OpenBabel {
       if (HasGroups()) {
         bool validOOP = false;
         for (unsigned int i=0; i < _intraGroup.size(); ++i) {
-          if (_intraGroup[i].BitIsOn(a->GetIdx()) &&
-              _intraGroup[i].BitIsOn(b->GetIdx()) &&
-              _intraGroup[i].BitIsOn(c->GetIdx()) &&
-              _intraGroup[i].BitIsOn(d->GetIdx()))
+          if (_intraGroup[i].BitIsSet(a->GetIdx()) &&
+              _intraGroup[i].BitIsSet(b->GetIdx()) &&
+              _intraGroup[i].BitIsSet(c->GetIdx()) &&
+              _intraGroup[i].BitIsSet(d->GetIdx()))
             validOOP = true;
         }
         if (!validOOP)
@@ -1437,13 +1437,13 @@ namespace OpenBabel {
       if (HasGroups()) {
         bool validVDW = false;
         for (unsigned int i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) && _interGroup[i].BitIsOn(b->GetIdx()))
+          if (_interGroup[i].BitIsSet(a->GetIdx()) && _interGroup[i].BitIsSet(b->GetIdx()))
             validVDW = true;
         }
         for (unsigned int i=0; i < _interGroups.size(); ++i) {
-          if (_interGroups[i].first.BitIsOn(a->GetIdx()) && _interGroups[i].second.BitIsOn(b->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(a->GetIdx()) && _interGroups[i].second.BitIsSet(b->GetIdx()))
             validVDW = true;
-          if (_interGroups[i].first.BitIsOn(b->GetIdx()) && _interGroups[i].second.BitIsOn(a->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(b->GetIdx()) && _interGroups[i].second.BitIsSet(a->GetIdx()))
             validVDW = true;
         }
 
@@ -1501,13 +1501,13 @@ namespace OpenBabel {
       if (HasGroups()) {
         bool validEle = false;
         for (unsigned int i=0; i < _interGroup.size(); ++i) {
-          if (_interGroup[i].BitIsOn(a->GetIdx()) && _interGroup[i].BitIsOn(b->GetIdx()))
+          if (_interGroup[i].BitIsSet(a->GetIdx()) && _interGroup[i].BitIsSet(b->GetIdx()))
             validEle = true;
         }
         for (unsigned int i=0; i < _interGroups.size(); ++i) {
-          if (_interGroups[i].first.BitIsOn(a->GetIdx()) && _interGroups[i].second.BitIsOn(b->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(a->GetIdx()) && _interGroups[i].second.BitIsSet(b->GetIdx()))
             validEle = true;
-          if (_interGroups[i].first.BitIsOn(b->GetIdx()) && _interGroups[i].second.BitIsOn(a->GetIdx()))
+          if (_interGroups[i].first.BitIsSet(b->GetIdx()) && _interGroups[i].second.BitIsSet(a->GetIdx()))
             validEle = true;
         }
 

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -3016,7 +3016,7 @@ namespace OpenBabel {
                   used |= nbr->GetIdx();
                 }
           }
-        if (next.Empty())
+        if (next.IsEmpty())
           break;
         curr = next;
       }
@@ -3085,7 +3085,7 @@ namespace OpenBabel {
       //  _uatoms.SetBitOn(nbr->GetIdx());        // mark suppressed hydrogen, so it won't be considered
       //  continue;                               // later when looking for more fragments.
       //}
-      if (_uatoms[idx] || !frag_atoms.BitIsOn(idx))
+      if (_uatoms[idx] || !frag_atoms.BitIsSet(idx))
         continue;
 
       OBBond *nbr_bond = atom->GetBond(nbr);
@@ -3209,13 +3209,13 @@ namespace OpenBabel {
     for (bond1 = atom->BeginBond(i); bond1; bond1 = atom->NextBond(i)) {
 
       // Is this a ring-closure neighbor?
-      if (_ubonds.BitIsOn(bond1->GetIdx()))
+      if (_ubonds.BitIsSet(bond1->GetIdx()))
         continue;
       nbr1 = bond1->GetNbrAtom(atom);
       // Skip hydrogens before checking canonical_order
       // PR#1999348
       if (   (nbr1->GetAtomicNum() == OBElements::Hydrogen && IsSuppressedHydrogen(nbr1))
-             || !frag_atoms.BitIsOn(nbr1->GetIdx()))
+             || !frag_atoms.BitIsSet(nbr1->GetIdx()))
         continue;
 
       nbr1_canorder = canonical_order[nbr1->GetIdx()-1];
@@ -3549,7 +3549,7 @@ namespace OpenBabel {
                       vector<unsigned int> &labels)
   {
     FOR_ATOMS_OF_MOL(atom, *pMol) {
-      if (frag_atoms->BitIsOn(atom->GetIdx())) {
+      if (frag_atoms->BitIsSet(atom->GetIdx())) {
         labels.push_back(atom->GetIdx() - 1);
         symmetry_classes.push_back(atom->GetIdx() - 1);
       }
@@ -3577,9 +3577,9 @@ namespace OpenBabel {
     OBBitVec used(natoms);
 
     FOR_ATOMS_OF_MOL(atom, *pMol) {
-      if (frag_atoms.BitIsOn(atom->GetIdx())) {
+      if (frag_atoms.BitIsSet(atom->GetIdx())) {
         int r = rand() % natoms;
-        while (used.BitIsOn(r)) {
+        while (used.BitIsSet(r)) {
           r = (r + 1) % natoms;         // find an unused number
         }
         used.SetBitOn(r);
@@ -3902,7 +3902,7 @@ namespace OpenBabel {
       // If we specified a startatom_idx & it's in this fragment, use it to start the fragment
       if (_startatom)
         if (!_uatoms[_startatom->GetIdx()] && 
-           frag_atoms.BitIsOn(_startatom->GetIdx()) && 
+           frag_atoms.BitIsSet(_startatom->GetIdx()) && 
            (!isrxn || rxn.GetRole(_startatom)==rxnrole))
           root_atom = _startatom;
 
@@ -3911,7 +3911,7 @@ namespace OpenBabel {
           int idx = atom->GetIdx();
           if (//atom->GetAtomicNum() != OBElements::Hydrogen       // don't start with a hydrogen
               !_uatoms[idx]          // skip atoms already used (for fragments)
-              && frag_atoms.BitIsOn(idx)// skip atoms not in this fragment
+              && frag_atoms.BitIsSet(idx)// skip atoms not in this fragment
               && (!isrxn || rxn.GetRole(atom)==rxnrole) // skip atoms not in this rxn role
               //&& !atom->IsChiral()    // don't use chiral atoms as root node
               && canonical_order[idx-1] < lowest_canorder) {
@@ -4039,7 +4039,7 @@ namespace OpenBabel {
       // a chiral center, or it's something like [H][H]).
       FOR_ATOMS_OF_MOL(iatom, mol) {
         OBAtom *atom = &(*iatom);
-        if (frag_atoms.BitIsOn(atom->GetIdx()) && atom->GetAtomicNum() == OBElements::Hydrogen
+        if (frag_atoms.BitIsSet(atom->GetIdx()) && atom->GetAtomicNum() == OBElements::Hydrogen
           && (!options.isomeric || m2s.IsSuppressedHydrogen(atom))) {
           frag_atoms.SetBitOff(atom->GetIdx());
         }

--- a/src/graphsym.cpp
+++ b/src/graphsym.cpp
@@ -222,7 +222,7 @@ namespace OpenBabel {
     for (atom = _pmol->BeginAtom(ai); atom; atom = _pmol->NextAtom(ai)) {
 
       int idx = atom->GetIdx();
-      if (!_frag_atoms.BitIsOn(idx)) {     // Not in this fragment?
+      if (!_frag_atoms.BitIsSet(idx)) {     // Not in this fragment?
         gtd[idx-1] = OBGraphSym::NoSymmetryClass;
         continue;
       }
@@ -236,13 +236,13 @@ namespace OpenBabel {
         next.Clear();
         for (natom = curr.NextBit(-1);natom != curr.EndBit();natom = curr.NextBit(natom)) {
           atom1 = _pmol->GetAtom(natom);
-          if (!_frag_atoms.BitIsOn(atom1->GetIdx()))
+          if (!_frag_atoms.BitIsSet(atom1->GetIdx()))
             continue;
           for (bond = atom1->BeginBond(j);bond;bond = atom1->NextBond(j)) {
             int nbr_idx = bond->GetNbrAtomIdx(atom1);
-            if (   _frag_atoms.BitIsOn(nbr_idx)
-                && !used.BitIsOn(nbr_idx)
-                && !curr.BitIsOn(nbr_idx)
+            if (   _frag_atoms.BitIsSet(nbr_idx)
+                && !used.BitIsSet(nbr_idx)
+                && !curr.BitIsSet(nbr_idx)
                 && bond->GetNbrAtom(atom1)->GetAtomicNum() != OBElements::Hydrogen)
               next.SetBitOn(nbr_idx);
           }
@@ -316,12 +316,12 @@ namespace OpenBabel {
     for (i=0, atom = _pmol->BeginAtom(ai); atom; atom = _pmol->NextAtom(ai)) {
       //    vid[i] = 0;
       vid[i] = OBGraphSym::NoSymmetryClass;
-      if (_frag_atoms.BitIsOn(atom->GetIdx())) {
+      if (_frag_atoms.BitIsSet(atom->GetIdx())) {
         vid[i] =
           v[i]                                                    // 10 bits: graph-theoretical distance
           | (GetHvyValence(atom)                <<10)  //  4 bits: heavy valence
           | (((atom->IsAromatic()) ? 1 : 0)                <<14)  //  1 bit:  aromaticity
-          | (((ring_atoms.BitIsOn(atom->GetIdx())) ? 1 : 0)<<15)  //  1 bit:  ring atom
+          | (((ring_atoms.BitIsSet(atom->GetIdx())) ? 1 : 0)<<15)  //  1 bit:  ring atom
           | (atom->GetAtomicNum()                          <<16)  //  7 bits: atomic number
           | (GetHvyBondSum(atom)               <<23)  //  4 bits: heavy bond sum
           | ((7 + atom->GetFormalCharge())                 <<27); //  4 bits: formal charge
@@ -386,7 +386,7 @@ namespace OpenBabel {
       vector<unsigned int> vtmp;
       for (nbr = atom->BeginNbrAtom(nbr_iter); nbr; nbr = atom->NextNbrAtom(nbr_iter)) {
         int idx = nbr->GetIdx();
-        if (_frag_atoms.BitIsOn(idx))
+        if (_frag_atoms.BitIsSet(idx))
           vtmp.push_back(vp1[idx2index[idx]].second);
       }
 
@@ -564,7 +564,7 @@ namespace OpenBabel {
     std::vector<std::pair<OBAtom*, unsigned int> > symmetry_classes;
     for (atom = _pmol->BeginAtom(j); atom; atom = _pmol->NextAtom(j)) {
       int idx = atom->GetIdx();
-      if (_frag_atoms.BitIsOn(idx))
+      if (_frag_atoms.BitIsSet(idx))
         symmetry_classes.push_back(pair<OBAtom*, unsigned int> (atom, vgi[idx-1]));
       //else
       //  symmetry_classes.push_back(pair<OBAtom*, unsigned int> (atom, OBGraphSym::NoSymmetryClass));
@@ -633,7 +633,7 @@ namespace OpenBabel {
     std::vector<std::pair<OBAtom*, unsigned int> > symmetry_classes;
     for (OBAtom *atom = _pmol->BeginAtom(j); atom; atom = _pmol->NextAtom(j)) {
       int idx = atom->GetIdx();
-      if (_frag_atoms.BitIsOn(idx))
+      if (_frag_atoms.BitIsSet(idx))
         symmetry_classes.push_back(pair<OBAtom*, unsigned int> (atom, symClasses[idx-1]));
     }
 

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -209,7 +209,7 @@ namespace OpenBabel
     std::vector<OBAtom*> degreeOneAtoms;
     FOR_ATOMS_OF_MOL(atom, m_mol) {
       unsigned int atom_idx = atom->GetIdx();
-      if (!needs_dbl_bond->BitIsOn(atom_idx)) {
+      if (!needs_dbl_bond->BitIsSet(atom_idx)) {
         degrees[atom_idx] = 0;
         continue;
       }
@@ -217,7 +217,7 @@ namespace OpenBabel
       FOR_BONDS_OF_ATOM(bond, &*atom) {
         if (!bond->IsAromatic()) continue;
         OBAtom *nbr = bond->GetNbrAtom(&*atom);
-        if (needs_dbl_bond->BitIsOn(nbr->GetIdx()))
+        if (needs_dbl_bond->BitIsSet(nbr->GetIdx()))
           mdeg++;
       }
       degrees[atom_idx] = mdeg;
@@ -236,11 +236,11 @@ namespace OpenBabel
         OBAtom* atom = degreeOneAtoms.back();
         degreeOneAtoms.pop_back();
         // some nodes may already have been handled
-        if (!needs_dbl_bond->BitIsOn(atom->GetIdx())) continue;
+        if (!needs_dbl_bond->BitIsSet(atom->GetIdx())) continue;
         FOR_BONDS_OF_ATOM(bond, atom) {
           if (!bond->IsAromatic()) continue;
           OBAtom *nbr = bond->GetNbrAtom(&*atom);
-          if (!needs_dbl_bond->BitIsOn(nbr->GetIdx())) continue;
+          if (!needs_dbl_bond->BitIsSet(nbr->GetIdx())) continue;
           // create a double bond from atom -> nbr
           doubleBonds->SetBitOn(bond->GetIdx());
           needs_dbl_bond->SetBitOff(atom->GetIdx());
@@ -250,7 +250,7 @@ namespace OpenBabel
             if (&(*nbrbond) == &(*bond) || !nbrbond->IsAromatic()) continue;
             OBAtom* nbrnbr = nbrbond->GetNbrAtom(nbr);
             unsigned int nbrnbrIdx = nbrnbr->GetIdx();
-            if (!needs_dbl_bond->BitIsOn(nbrnbrIdx)) continue;
+            if (!needs_dbl_bond->BitIsSet(nbrnbrIdx)) continue;
             degrees[nbrnbrIdx]--;
             if (degrees[nbrnbrIdx] == 1)
               degreeOneAtoms.push_back(nbrnbr);
@@ -272,14 +272,14 @@ namespace OpenBabel
       NodeIterator iterator(degrees, atomArraySize);
       bool change = false;
       while (unsigned int atomIdx = iterator.next()) {
-        if (!needs_dbl_bond->BitIsOn(atomIdx)) continue;
+        if (!needs_dbl_bond->BitIsSet(atomIdx)) continue;
         // The following is almost identical to the code above for deg 1 atoms
         // except for handling the variable 'change'
         OBAtom *atom = m_mol->GetAtom(atomIdx);
         FOR_BONDS_OF_ATOM(bond, atom) {
           if (!bond->IsAromatic()) continue;
           OBAtom *nbr = bond->GetNbrAtom(&*atom);
-          if (!needs_dbl_bond->BitIsOn(nbr->GetIdx())) continue;
+          if (!needs_dbl_bond->BitIsSet(nbr->GetIdx())) continue;
           // create a double bond from atom -> nbr
           doubleBonds->SetBitOn(bond->GetIdx());
           needs_dbl_bond->SetBitOff(atomIdx);
@@ -291,7 +291,7 @@ namespace OpenBabel
               if (&(*nbrbond) == &(*bond) || !nbrbond->IsAromatic()) continue;
               OBAtom* nbrnbr = nbrbond->GetNbrAtom(ref);
               unsigned int nbrnbrIdx = nbrnbr->GetIdx();
-              if (!needs_dbl_bond->BitIsOn(nbrnbrIdx)) continue;
+              if (!needs_dbl_bond->BitIsSet(nbrnbrIdx)) continue;
               degrees[nbrnbrIdx]--;
               if (degrees[nbrnbrIdx] == 1) {
                 degreeOneAtoms.push_back(nbrnbr);
@@ -321,16 +321,16 @@ namespace OpenBabel
   // an alternating path
   bool Kekulizer::FindPath(unsigned int atomidx, bool isDoubleBond, OBBitVec &visited)
   {
-    if (needs_dbl_bond->BitIsOn(atomidx))
+    if (needs_dbl_bond->BitIsSet(atomidx))
       return true;
     visited.SetBitOn(atomidx);
     OBAtom* atom = m_mol->GetAtom(atomidx);
     FOR_BONDS_OF_ATOM(bond, atom) {
       if (!bond->IsAromatic()) continue;
       OBAtom *nbr = bond->GetNbrAtom(atom);
-      if (!kekule_system->BitIsOn(nbr->GetIdx())) continue;
-      if (doubleBonds->BitIsOn(bond->GetIdx()) == isDoubleBond) {
-        if (visited.BitIsOn(nbr->GetIdx())) continue;
+      if (!kekule_system->BitIsSet(nbr->GetIdx())) continue;
+      if (doubleBonds->BitIsSet(bond->GetIdx()) == isDoubleBond) {
+        if (visited.BitIsSet(nbr->GetIdx())) continue;
         bool found_path = FindPath(nbr->GetIdx(), !isDoubleBond, visited);
         if (found_path) {
           m_path.push_back(nbr->GetIdx());
@@ -377,7 +377,7 @@ namespace OpenBabel
           doubleBonds->SetBitOff(bond->GetIdx());
       }
     }
-    return needs_dbl_bond->Empty();
+    return needs_dbl_bond->IsEmpty();
   }
 
 // I'd like to thank John Mayfield for many helpful discussions on the topic of

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -228,10 +228,10 @@ namespace OpenBabel
     obErrorLog.ThrowError(__FUNCTION__,
                           "Ran OpenBabel::SetTorsion", obAuditMsg);
 
-    tor.push_back(a->GetCIdx());
-    tor.push_back(b->GetCIdx());
-    tor.push_back(c->GetCIdx());
-    tor.push_back(d->GetCIdx());
+    tor.push_back(a->GetCoordinateIdx());
+    tor.push_back(b->GetCoordinateIdx());
+    tor.push_back(c->GetCoordinateIdx());
+    tor.push_back(d->GetCoordinateIdx());
 
     FindChildren(atoms, b->GetIdx(), c->GetIdx());
     int j;
@@ -2028,7 +2028,7 @@ namespace OpenBabel
     int idx;
     if (atomidx != NumAtoms())
       {
-        idx = atom->GetCIdx();
+        idx = atom->GetCoordinateIdx();
         int size = NumAtoms()-atom->GetIdx();
         vector<double*>::iterator k;
         for (k = _vconf.begin();k != _vconf.end();++k)
@@ -2893,7 +2893,7 @@ namespace OpenBabel
       {
         c = GetConformer(j);
         for (k=0,i = va.begin();i != va.end(); ++i,++k)
-          memcpy((char*)&ctmp[k*3],(char*)&c[((OBAtom*)*i)->GetCIdx()],sizeof(double)*3);
+          memcpy((char*)&ctmp[k*3],(char*)&c[((OBAtom*)*i)->GetCoordinateIdx()],sizeof(double)*3);
         memcpy((char*)c,(char*)ctmp,sizeof(double)*3*NumAtoms());
       }
 

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -334,7 +334,7 @@ namespace OpenBabel
         curr.Clear();
         frag.Clear();
         for (atom = BeginAtom(i);atom;atom = NextAtom(i))
-          if (!used.BitIsOn(atom->GetIdx()))
+          if (!used.BitIsSet(atom->GetIdx()))
             {
               curr.SetBitOn(atom->GetIdx());
               break;
@@ -348,7 +348,7 @@ namespace OpenBabel
               {
                 atom = GetAtom(j);
                 for (bond = atom->BeginBond(k);bond;bond = atom->NextBond(k))
-                  if (!used.BitIsOn(bond->GetNbrAtomIdx(atom)))
+                  if (!used.BitIsSet(bond->GetNbrAtomIdx(atom)))
                     next.SetBitOn(bond->GetNbrAtomIdx(atom));
               }
 
@@ -469,7 +469,7 @@ namespace OpenBabel
         curr.Clear();
         frag.Clear();
         for (atom = BeginAtom(i);atom;atom = NextAtom(i))
-          if (!used.BitIsOn(atom->GetIdx()))
+          if (!used.BitIsSet(atom->GetIdx()))
             {
               curr.SetBitOn(atom->GetIdx());
               break;
@@ -483,7 +483,7 @@ namespace OpenBabel
               {
                 atom = GetAtom(j);
                 for (bond = atom->BeginBond(k);bond;bond = atom->NextBond(k))
-                  if (!used.BitIsOn(bond->GetNbrAtomIdx(atom)))
+                  if (!used.BitIsSet(bond->GetNbrAtomIdx(atom)))
                     next.SetBitOn(bond->GetNbrAtomIdx(atom));
               }
 
@@ -493,7 +493,7 @@ namespace OpenBabel
             curr = next;
           }
 
-        if (lf.Empty() || lf.CountBits() < frag.CountBits())
+        if (lf.IsEmpty() || lf.CountBits() < frag.CountBits())
           lf = frag;
       }
   }
@@ -528,7 +528,7 @@ namespace OpenBabel
                   used |= nbr->GetIdx();
                 }
           }
-        if (next.Empty())
+        if (next.IsEmpty())
           break;
         curr = next;
       }
@@ -554,7 +554,7 @@ namespace OpenBabel
           {
             atom = GetAtom(i);
             FOR_BONDS_OF_ATOM (bond, atom)
-              if (!used.BitIsOn(bond->GetNbrAtomIdx(atom)))
+              if (!used.BitIsSet(bond->GetNbrAtomIdx(atom)))
                 next.SetBitOn(bond->GetNbrAtomIdx(atom));
           }
 
@@ -612,7 +612,7 @@ namespace OpenBabel
               {
                 atom1 = GetAtom(natom);
                 for (bond = atom1->BeginBond(j);bond;bond = atom1->NextBond(j))
-                  if (!used.BitIsOn(bond->GetNbrAtomIdx(atom1)) && !curr.BitIsOn(bond->GetNbrAtomIdx(atom1)))
+                  if (!used.BitIsSet(bond->GetNbrAtomIdx(atom1)) && !curr.BitIsSet(bond->GetNbrAtomIdx(atom1)))
                     if (bond->GetNbrAtom(atom1)->GetAtomicNum() != OBElements::Hydrogen)
                       next.SetBitOn(bond->GetNbrAtomIdx(atom1));
               }
@@ -1540,21 +1540,6 @@ namespace OpenBabel
     DeleteData(OBGenericDataType::TorsionData);
   }
 
-  OBAtom *OBMol::CreateAtom(void)
-  {
-    return new OBAtom;
-  }
-
-  OBBond *OBMol::CreateBond(void)
-  {
-    return new OBBond;
-  }
-
-  OBResidue *OBMol::CreateResidue(void)
-  {
-    return new OBResidue;
-  }
-
   void OBMol::DestroyAtom(OBAtom *atom)
   {
     if (atom)
@@ -1606,7 +1591,7 @@ namespace OpenBabel
     if (_atomIds.at(id))
       return (OBAtom*)NULL;
 
-    OBAtom *obatom = CreateAtom();
+    OBAtom *obatom = new OBAtom;
     obatom->SetIdx(_natoms+1);
     obatom->SetParent(this);
 
@@ -1659,7 +1644,7 @@ namespace OpenBabel
 
   OBResidue *OBMol::NewResidue()
   {
-    OBResidue *obresidue = CreateResidue();
+    OBResidue *obresidue = new OBResidue;
     obresidue->SetIdx(_residue.size());
     _residue.push_back(obresidue);
     return(obresidue);
@@ -1687,7 +1672,7 @@ namespace OpenBabel
     if (_bondIds.at(id))
       return (OBBond*)NULL;
 
-    OBBond *pBond = CreateBond();
+    OBBond *pBond = new OBBond;
     pBond->SetParent(this);
     pBond->SetIdx(_nbonds);
 
@@ -1727,7 +1712,7 @@ namespace OpenBabel
         id = _atomIds.size();
     }
 
-    OBAtom *obatom = CreateAtom();
+    OBAtom *obatom = new OBAtom;
     *obatom = atom;
     obatom->SetIdx(_natoms+1);
     obatom->SetParent(this);
@@ -1799,7 +1784,7 @@ namespace OpenBabel
   {
     BeginModify();
 
-    OBResidue *obresidue = CreateResidue();
+    OBResidue *obresidue = new OBResidue;
     *obresidue = residue;
 
     obresidue->SetIdx(_residue.size());
@@ -2518,7 +2503,7 @@ namespace OpenBabel
     if ((unsigned)first <= NumAtoms() && (unsigned)second <= NumAtoms())
       //atoms exist and bond doesn't
       {
-        OBBond *bond = CreateBond();
+        OBBond *bond = new OBBond;
         if (!bond)
           {
             //EndModify();
@@ -4118,7 +4103,7 @@ namespace OpenBabel
         bool skip_cfg = false;
         if (bonds_specified) {
           FOR_BONDS_OF_ATOM(bond, begin) {
-            if (excludebonds->BitIsOn(bond->GetIdx())) {
+            if (excludebonds->BitIsSet(bond->GetIdx())) {
               skip_cfg = true;
               break;
             }
@@ -4126,7 +4111,7 @@ namespace OpenBabel
           if (skip_cfg)
             continue;
           FOR_BONDS_OF_ATOM(bond, end) {
-            if (excludebonds->BitIsOn(bond->GetIdx())) {
+            if (excludebonds->BitIsSet(bond->GetIdx())) {
               skip_cfg = true;
               break;
             }
@@ -4172,7 +4157,7 @@ namespace OpenBabel
         bool skip_cfg = false;
         if (bonds_specified) {
           FOR_BONDS_OF_ATOM(bond, center) {
-            if (excludebonds->BitIsOn(bond->GetIdx())) {
+            if (excludebonds->BitIsSet(bond->GetIdx())) {
               skip_cfg = true;
               break;
             }
@@ -4211,7 +4196,7 @@ namespace OpenBabel
     // 2. As 1. but implicit Hs are added to replace them
     // 3. As 1. but asterisks are added to replace them
     FOR_BONDS_OF_MOL(bond, this) {
-      bool skipping_bond = bonds_specified && excludebonds->BitIsOn(bond->GetIdx());
+      bool skipping_bond = bonds_specified && excludebonds->BitIsSet(bond->GetIdx());
       map<OBAtom*, OBAtom*>::iterator posB = AtomMap.find(bond->GetBeginAtom());
       map<OBAtom*, OBAtom*>::iterator posE = AtomMap.find(bond->GetEndAtom());
       if (posB == AtomMap.end() && posE == AtomMap.end())

--- a/src/residue.cpp
+++ b/src/residue.cpp
@@ -1013,7 +1013,7 @@ _insertioncode=src._insertioncode;
         vector<OBBond*>::iterator b;
         for (bond = atom->BeginBond(b) ; bond ; bond = atom->NextBond(b))
           {
-            if (!idxs.BitIsOn(bond->GetIdx()))
+            if (!idxs.BitIsSet(bond->GetIdx()))
               {
                 if (!exterior)
                   {

--- a/src/ring.cpp
+++ b/src/ring.cpp
@@ -646,12 +646,12 @@ namespace OpenBabel
 
   bool OBRing::IsMember(OBAtom *a)
   {
-    return(_pathset.BitIsOn(a->GetIdx()));
+    return(_pathset.BitIsSet(a->GetIdx()));
   }
 
   bool OBRing::IsMember(OBBond *b)
   {
-    return((_pathset.BitIsOn(b->GetBeginAtomIdx()))&&(_pathset.BitIsOn(b->GetEndAtomIdx())));
+    return((_pathset.BitIsSet(b->GetBeginAtomIdx()))&&(_pathset.BitIsSet(b->GetEndAtomIdx())));
   }
 
   OBRing::OBRing(vector<int> &path,int size) : _path(path)
@@ -726,7 +726,7 @@ namespace OpenBabel
                 }
           }
 
-        if (next.Empty())
+        if (next.IsEmpty())
           break;
         curr = next;
         level++;

--- a/src/rotamer.cpp
+++ b/src/rotamer.cpp
@@ -341,13 +341,13 @@ namespace OpenBabel
     vector<pair<OBAtom**,vector<int> > >::iterator i;
     for (size=1,i = _vrotor.begin();i != _vrotor.end();++i,++size)
       {
-        idx = (i->first[0])->GetCIdx();
+        idx = (i->first[0])->GetCoordinateIdx();
         v1.Set(c[idx],c[idx+1],c[idx+2]);
-        idx = (i->first[1])->GetCIdx();
+        idx = (i->first[1])->GetCoordinateIdx();
         v2.Set(c[idx],c[idx+1],c[idx+2]);
-        idx = (i->first[2])->GetCIdx();
+        idx = (i->first[2])->GetCoordinateIdx();
         v3.Set(c[idx],c[idx+1],c[idx+2]);
-        idx = (i->first[3])->GetCIdx();
+        idx = (i->first[3])->GetCoordinateIdx();
         v4.Set(c[idx],c[idx+1],c[idx+2]);
 
         angle = CalcTorsionAngle(v1,v2,v3,v4);
@@ -617,10 +617,10 @@ namespace OpenBabel
     double x,y,z,mag,rotang,sn,cs,t,tx,ty,tz;
 
     int tor[4];
-    tor[0] = ref[0]->GetCIdx();
-    tor[1] = ref[1]->GetCIdx();
-    tor[2] = ref[2]->GetCIdx();
-    tor[3] = ref[3]->GetCIdx();
+    tor[0] = ref[0]->GetCoordinateIdx();
+    tor[1] = ref[1]->GetCoordinateIdx();
+    tor[2] = ref[2]->GetCoordinateIdx();
+    tor[3] = ref[3]->GetCoordinateIdx();
 
     //
     //calculate the torsion angle

--- a/src/rotor.cpp
+++ b/src/rotor.cpp
@@ -144,15 +144,15 @@ namespace OpenBabel
 
   bool OBRotorList::IsFixedBond(OBBond *bond)
   {
-    if (_fixedatoms.Empty() && _fixedbonds.Empty())
+    if (_fixedatoms.IsEmpty() && _fixedbonds.IsEmpty())
       return false;
 
     // new fixed bonds
-    if (!_fixedbonds.Empty()) {
+    if (!_fixedbonds.IsEmpty()) {
       return _fixedbonds.BitIsSet(bond->GetIdx());
     }
 
-    if (_fixedatoms.Empty())
+    if (_fixedatoms.IsEmpty())
       return false;
 
     // deprecated fixed atoms
@@ -214,15 +214,15 @@ namespace OpenBabel
         used.SetBitOn(atom->GetIdx());
         curr.SetBitOn(atom->GetIdx());
 
-        while (!curr.IsEmpty() && (bv&curr).Empty())
+        while (!curr.IsEmpty() && (bv&curr).IsEmpty())
           {
             next.Clear();
             for (natom = curr.NextBit(-1);natom != curr.EndBit();natom = curr.NextBit(natom))
               {
                 atom1 = mol.GetAtom(natom);
                 for (bond = atom1->BeginBond(j);bond;bond = atom1->NextBond(j))
-                  if (!used.BitIsOn(bond->GetNbrAtomIdx(atom1)) &&
-                      !curr.BitIsOn(bond->GetNbrAtomIdx(atom1)))
+                  if (!used.BitIsSet(bond->GetNbrAtomIdx(atom1)) &&
+                      !curr.BitIsSet(bond->GetNbrAtomIdx(atom1)))
                       if (bond->GetNbrAtom(atom1)->GetAtomicNum() != OBElements::Hydrogen)
                       next.SetBitOn(bond->GetNbrAtomIdx(atom1));
               }
@@ -307,7 +307,7 @@ namespace OpenBabel
         eval |= curr;
 
         //follow all non-rotor bonds and add atoms to eval list
-        for (;!curr.Empty();)
+        for (;!curr.IsEmpty();)
           {
             next.Clear();
             for (j = curr.NextBit(0);j != curr.EndBit();j = curr.NextBit(j))

--- a/src/stereo/perception.cpp
+++ b/src/stereo/perception.cpp
@@ -207,13 +207,13 @@ namespace OpenBabel {
   bool isUnitInFragment(OBMol *mol, const OBStereoUnit &unit, const OBBitVec &fragment)
   {
     if (unit.type == OBStereo::Tetrahedral) {
-      if (fragment.BitIsOn(unit.id))
+      if (fragment.BitIsSet(unit.id))
         return true;
     } else if(unit.type == OBStereo::CisTrans) {
       OBBond *bond = mol->GetBondById(unit.id);
       OBAtom *begin = bond->GetBeginAtom();
       OBAtom *end = bond->GetEndAtom();
-      if (fragment.BitIsOn(begin->GetId()) || fragment.BitIsOn(end->GetId()))
+      if (fragment.BitIsSet(begin->GetId()) || fragment.BitIsSet(end->GetId()))
         return true;
     }
     return false;
@@ -1091,13 +1091,13 @@ namespace OpenBabel {
             OBBitVec ligand = getFragment(ligandAtom, begin);
             for (OBStereoUnitSet::iterator u2 = units.begin(); u2 != units.end(); ++u2) {
               if ((*u2).type == OBStereo::Tetrahedral) {
-                if (ligand.BitIsOn((*u2).id))
+                if (ligand.BitIsSet((*u2).id))
                   beginValid = true;
               } else if((*u2).type == OBStereo::CisTrans) {
                 OBBond *bond = mol->GetBondById((*u2).id);
                 OBAtom *begin = bond->GetBeginAtom();
                 OBAtom *end = bond->GetEndAtom();
-                if (ligand.BitIsOn(begin->GetId()) || ligand.BitIsOn(end->GetId()))
+                if (ligand.BitIsSet(begin->GetId()) || ligand.BitIsSet(end->GetId()))
                   beginValid = true;
               }
             }
@@ -1128,13 +1128,13 @@ namespace OpenBabel {
             OBBitVec ligand = getFragment(ligandAtom, end);
             for (OBStereoUnitSet::iterator u2 = units.begin(); u2 != units.end(); ++u2) {
               if ((*u2).type == OBStereo::Tetrahedral) {
-                if (ligand.BitIsOn((*u2).id))
+                if (ligand.BitIsSet((*u2).id))
                   endValid = true;
               } else if((*u2).type == OBStereo::CisTrans) {
                 OBBond *bond = mol->GetBondById((*u2).id);
                 OBAtom *begin = bond->GetBeginAtom();
                 OBAtom *end = bond->GetEndAtom();
-                if (ligand.BitIsOn(begin->GetId()) || ligand.BitIsOn(end->GetId()))
+                if (ligand.BitIsSet(begin->GetId()) || ligand.BitIsSet(end->GetId()))
                   endValid = true;
               }
             }
@@ -1566,11 +1566,11 @@ namespace OpenBabel {
     std::vector<unsigned int> ringIndices;
     for (OBStereoUnitSet::const_iterator u2 = units.begin(); u2 != units.end(); ++u2) {
       if ((*u2).type == OBStereo::Tetrahedral) {
-        if (ligand.BitIsOn((*u2).id)) {
+        if (ligand.BitIsSet((*u2).id)) {
           if ((*u2).para) {
             OBAtom *paraAtom = mol->GetAtomById((*u2).id);
             for (std::size_t ringIdx = 0; ringIdx < mergedRings.size(); ++ringIdx) {
-              if (mergedRings.at(ringIdx).BitIsOn(paraAtom->GetIdx()))
+              if (mergedRings.at(ringIdx).BitIsSet(paraAtom->GetIdx()))
                 if (std::find(ringIndices.begin(), ringIndices.end(), ringIdx) == ringIndices.end())
                   ringIndices.push_back(ringIdx);
             }
@@ -1581,10 +1581,10 @@ namespace OpenBabel {
         OBBond *bond = mol->GetBondById((*u2).id);
         OBAtom *begin = bond->GetBeginAtom();
         OBAtom *end = bond->GetEndAtom();
-        if (ligand.BitIsOn(begin->GetId()) || ligand.BitIsOn(end->GetId())) {
+        if (ligand.BitIsSet(begin->GetId()) || ligand.BitIsSet(end->GetId())) {
           if ((*u2).para) {
             for (std::size_t ringIdx = 0; ringIdx < mergedRings.size(); ++ringIdx) {
-              if (mergedRings.at(ringIdx).BitIsOn(begin->GetIdx()) || mergedRings.at(ringIdx).BitIsOn(end->GetIdx())) {
+              if (mergedRings.at(ringIdx).BitIsSet(begin->GetIdx()) || mergedRings.at(ringIdx).BitIsSet(end->GetIdx())) {
                 if (std::find(ringIndices.begin(), ringIndices.end(), ringIdx) == ringIndices.end()) {
                   ringIndices.push_back(ringIdx);
                 }


### PR DESCRIPTION
I've removed some deprecated methods (found by grepping *.h for "deprecated"). Some of these are renamed methods, where the old name was deprecated but never removed. Others are not recommended for use e.g. NewAtom.

There are a whole bunch of deprecated methods in forcefield.h, grid.h and rotor.h. I don't think I'm going to dig into these right now, as I don't know the background, but @ghutchis you might want to.