### PR TITLE
Add __init__.py to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build
 nbproject
 scripts/**/*.cpp
+scripts/python/openbabel/__init__.py
 scripts/python/openbabel/openbabel.py
 scripts/java/openbabel.jar
 scripts/php/openbabel.php


### PR DESCRIPTION
The `scripts/python/openbabel/__init__.py.in` file was added in #1946, generating file `scripts/python/openbabel/__init__.py`. The generated file should be added into gitignore.