### PR TITLE
Rename/add valence and degree methods

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -190,16 +190,22 @@ namespace OpenBabel
       //! \return the index into a pointer-driven array as used by
       //!   GetCoordPtr() or SetCoordPtr()
       unsigned int GetCoordinateIdx() const { return((int)_cidx); }
-      //! \return The current number of explicit connections
-      unsigned int GetValence() const { return (unsigned int)_vbond.size(); }
+      //! \return The number of explicit bonds to this atom
+      unsigned int GetExplicitDegree() const { return (unsigned int)_vbond.size(); }
+      //! \return The total number of bonds to this atom including bonds to implicit hydrogens
+      unsigned int GetTotalDegree() const { return (unsigned int)(_vbond.size() + _imph); }
+      //! \return The sum of the bond orders of the explicit bonds to this atom
+      unsigned int GetExplicitValence() const;
+      //! \return The sum of the bond orders of all bonds to this atom including bonds to implicit hydrogens
+      unsigned int GetTotalValence() const;
       //! \return The hybridization of this atom: 1 for sp, 2 for sp2, 3 for sp3, 4 for sq. planar, 5 for trig. bipy, 6 for octahedral
       unsigned int GetHyb()             const;
       //! \return The number of implicit hydrogens attached to this atom
       unsigned char GetImplicitHCount() const { return _imph; };
       //! \return The number of non-hydrogens connected to this atom
-      unsigned int GetHvyValence()      const;
+      unsigned int GetHvyDegree()      const;
       //! \return The number of heteroatoms connected to an atom
-      unsigned int GetHeteroValence()   const;
+      unsigned int GetHeteroDegree()   const;
       //! \return the atomic type (e.g., for molecular mechanics)
       char        *GetType();
 
@@ -349,8 +355,6 @@ namespace OpenBabel
       double	  SmallestBondAngle();
       //! \return The average angle of bonds to this atom
       double	  AverageBondAngle();
-      //! \return The sum of the bond orders of the bonds to the atom (i.e. double bond = 2...)
-      unsigned int  BOSum()                 const;
       /** Lewis acid/base vacancies for this atom
        *  \return A pair of integers, where first is acid count and second is base count
        *  \since version 2.3

--- a/include/openbabel/stereo/cistrans.h
+++ b/include/openbabel/stereo/cistrans.h
@@ -275,7 +275,7 @@ class OBAPI OBCisTransStereo : public OBTetraPlanarStereo
      * Check if the two atoms for @p id1 & @p id2 are bonded to the same
      * atom. If the atoms for one of the atoms doesn't exist (anymore),
      * the valence of the begin and end atom is checked. If the exising
-     * atom is bonded to the begin atom and end->GetValence() == 2, the
+     * atom is bonded to the begin atom and end->GetExplicitDegree() == 2, the
      * ids are considered to be on different atoms. The reasoning behind
      * this is that hydrogens may be deleted. However, you can also use
      * OBStereo::ImplicitRef explicitly in code like:

--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -117,7 +117,7 @@ bool AliasData::FromNameLookup(OBMol& mol, const unsigned int atomindex)
   */
 
   OBAtom* XxAtom = mol.GetAtom(atomindex);
-/*  if(XxAtom->GetValence()>1)
+/*  if(XxAtom->GetExplicitDegree()>1)
   {
     obErrorLog.ThrowError(__FUNCTION__, _alias + " is multivalent, which is currently not supported.", obWarning);
     return false;

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1038,7 +1038,7 @@ namespace OpenBabel
       int S = SHELL[N];
       int V = VALENCE[N];
       int C = GetFormalCharge();
-      int B = GetImplicitHCount() + GetExplicitValence();
+      int B = GetTotalValence();
       // TODO: Do we actually want to divide by 2 here? (counting pairs instead of single)
       counts.first = (S - V - B + C) / 2;  // Acid: Number of electrons pairs desired
       counts.second = (V - B - C) / 2;     // Base: Number of electrons pairs available

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -176,14 +176,14 @@ namespace OpenBabel
 
     // not just an -OH or -NH2, etc.
     // maybe we want to add this as an option
-    //    rotatable = rotatable && ((_bgn->IsHeteroatom() || _bgn->GetHvyValence() > 1)
-    //                               && (_end->IsHeteroatom() || _end->GetHvyValence() > 1) );
-    return (_bgn->GetHvyValence() > 1 && _end->GetHvyValence() > 1);
+    //    rotatable = rotatable && ((_bgn->IsHeteroatom() || _bgn->GetHvyDegree() > 1)
+    //                               && (_end->IsHeteroatom() || _end->GetHvyDegree() > 1) );
+    return (_bgn->GetHvyDegree() > 1 && _end->GetHvyDegree() > 1);
   }
   
   static unsigned int TotalNumberOfBonds(OBAtom* atom)
   {
-    return atom->GetImplicitHCount() + atom->GetValence();
+    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
   }
 
    bool OBBond::IsAmide()
@@ -239,7 +239,7 @@ namespace OpenBabel
       if (TotalNumberOfBonds(n) != 3) return false; // must be a degree 3 nitrogen
 
       // Make sure that N is connected to one non-H
-      if (n->GetHvyValence() != 1) return(false);
+      if (n->GetHvyDegree() != 1) return(false);
 
       // Make sure C is attached to =O
       OBBond *bond;
@@ -273,7 +273,7 @@ namespace OpenBabel
       if (TotalNumberOfBonds(n) != 3) return false; // must be a degree 3 nitrogen
 
       // Make sure that N is connected to two non-H atoms
-      if (n->GetHvyValence() != 2) return(false);
+      if (n->GetHvyDegree() != 2) return(false);
 
       // Make sure C is attached to =O
       OBBond *bond;
@@ -307,7 +307,7 @@ namespace OpenBabel
       if (TotalNumberOfBonds(n) != 3) return false; // must be a degree 3 nitrogen
 
       // Make sure that N is connected to three non-H atoms
-      if (n->GetHvyValence() != 3) return(false);
+      if (n->GetHvyDegree() != 3) return(false);
 
       // Make sure C is attached to =O
       OBBond *bond;
@@ -378,7 +378,7 @@ namespace OpenBabel
     vector<OBBond*>::iterator i;
     for (bond = a1->BeginBond(i);bond;bond = a1->NextBond(i))
       if (bond->IsCarbonyl())
-        if (a2->GetHvyValence() == 2)
+        if (a2->GetHvyDegree() == 2)
           return(true);
 
     return(false);
@@ -410,7 +410,7 @@ namespace OpenBabel
     vector<OBBond*>::iterator i;
     for (bond = a1->BeginBond(i);bond;bond = a1->NextBond(i))
       if (bond->IsCarbonyl())
-        if (a2->GetHvyValence() == 3)
+        if (a2->GetHvyDegree() == 3)
           return(true);
 
     return(false);
@@ -482,8 +482,8 @@ namespace OpenBabel
     vector<OBBond*>::iterator i,j;
     // We concentrate on sp2 atoms with valence up to 3 and ignore the rest (like sp1 or S,P)
     // As this is called from PerceiveBondOrders, GetHyb() may still be undefined.
-    if (_bgn->GetHyb()==1 || _bgn->GetValence()>3||
-        _end->GetHyb()==1 || _end->GetValence()>3)
+    if (_bgn->GetHyb()==1 || _bgn->GetExplicitDegree()>3||
+        _end->GetHyb()==1 || _end->GetExplicitDegree()>3)
       return(true);
 
     for (nbrStart = static_cast<OBAtom*>(_bgn)->BeginNbrAtom(i); nbrStart;

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -181,11 +181,6 @@ namespace OpenBabel
     return (_bgn->GetHvyDegree() > 1 && _end->GetHvyDegree() > 1);
   }
   
-  static unsigned int TotalNumberOfBonds(OBAtom* atom)
-  {
-    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
-  }
-
    bool OBBond::IsAmide()
    {
       OBAtom *c,*n;
@@ -204,7 +199,7 @@ namespace OpenBabel
       }
       if (!c || !n) return(false);
       if (GetBondOrder() != 1) return(false);
-      if (TotalNumberOfBonds(n) != 3) return false; // must be a degree 3 nitrogen
+      if (n->GetTotalDegree() != 3) return false; // must be a degree 3 nitrogen
 
       // Make sure C is attached to =O
       OBBond *bond;
@@ -236,7 +231,7 @@ namespace OpenBabel
       }
       if (!c || !n) return(false);
       if (GetBondOrder() != 1) return(false);
-      if (TotalNumberOfBonds(n) != 3) return false; // must be a degree 3 nitrogen
+      if (n->GetTotalDegree() != 3) return false; // must be a degree 3 nitrogen
 
       // Make sure that N is connected to one non-H
       if (n->GetHvyDegree() != 1) return(false);
@@ -270,7 +265,7 @@ namespace OpenBabel
       }
       if (!c || !n) return(false);
       if (GetBondOrder() != 1) return(false);
-      if (TotalNumberOfBonds(n) != 3) return false; // must be a degree 3 nitrogen
+      if (n->GetTotalDegree() != 3) return false; // must be a degree 3 nitrogen
 
       // Make sure that N is connected to two non-H atoms
       if (n->GetHvyDegree() != 2) return(false);
@@ -304,7 +299,7 @@ namespace OpenBabel
       }
       if (!c || !n) return(false);
       if (GetBondOrder() != 1) return(false);
-      if (TotalNumberOfBonds(n) != 3) return false; // must be a degree 3 nitrogen
+      if (n->GetTotalDegree() != 3) return false; // must be a degree 3 nitrogen
 
       // Make sure that N is connected to three non-H atoms
       if (n->GetHvyDegree() != 3) return(false);

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -226,7 +226,7 @@ namespace OpenBabel
       //
       //  a   --->   a--*
       //
-      if (atom->GetValence() == 0) {
+      if (atom->GetExplicitDegree() == 0) {
         newbond = atom->GetVector() + VX * length;
         return newbond;
       }
@@ -254,7 +254,7 @@ namespace OpenBabel
       //    (a-1)--a   --->   (a-1)--a          angle(a-1, a, *) = 109
       //                              \                                      //
       //                               *
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         bool isCarboxylateO = atom->IsCarboxylOxygen();
 
         FOR_NBORS_OF_ATOM (nbr, atom) {
@@ -322,7 +322,7 @@ namespace OpenBabel
       //     X  --->   X--*
       //    /         /
       //
-      if (atom->GetValence() == 2) {
+      if (atom->GetExplicitDegree() == 2) {
         FOR_NBORS_OF_ATOM (nbr, atom) {
           if (bond1 == VZero)
             bond1 = atom->GetVector() - nbr->GetVector();
@@ -392,7 +392,7 @@ namespace OpenBabel
        //    /          /
        //
        */
-      if (atom->GetValence() == 3) {
+      if (atom->GetExplicitDegree() == 3) {
         if (atom->GetHyb() == 3) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
             if (bond1 == VZero)
@@ -476,7 +476,7 @@ namespace OpenBabel
         }
       }
 
-      if (atom->GetValence() == 4) {
+      if (atom->GetExplicitDegree() == 4) {
         if (atom->GetHyb() == 6) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
             if (bond1 == VZero)
@@ -526,7 +526,7 @@ namespace OpenBabel
 
       }
 
-      if (atom->GetValence() == 5) {
+      if (atom->GetExplicitDegree() == 5) {
         if (atom->GetHyb() == 6) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
             if (bond1 == VZero)
@@ -563,7 +563,7 @@ namespace OpenBabel
       //
       //  a   --->   a---*
       //
-      if (atom->GetValence() == 0) {
+      if (atom->GetExplicitDegree() == 0) {
         newbond = atom->GetVector() + VX * length;
         // Check that the vector is still finite before returning
         if (!isfinite(newbond.x()) || !isfinite(newbond.y()))
@@ -594,7 +594,7 @@ namespace OpenBabel
       //    (a-1)--a   --->   (a-1)--a          angle(a-1, a, *) = 109            //
       //                              \                                           //
       //                               *                                          //
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         OBAtom *nbr = atom->BeginNbrAtom(i);
         if (!nbr)
           return VZero;
@@ -616,14 +616,14 @@ namespace OpenBabel
         newbond *= length;
         newbond += atom->GetVector();
         return newbond;
-      } // GetValence() == 1
+      } // GetExplicitDegree() == 1
 
       //                          //
       //    \         \           //
       //     X  --->   X--*       //
       //    /         /           //
       //                          //
-      if (atom->GetValence() == 2) {
+      if (atom->GetExplicitDegree() == 2) {
         for (OBAtom *nbr = atom->BeginNbrAtom(i); nbr; nbr = atom->NextNbrAtom(i)) {
           if (bond1 == VZero)
             bond1 = atom->GetVector() - nbr->GetVector();
@@ -644,7 +644,7 @@ namespace OpenBabel
       //   --X  --->  --X--*      //
       //    /          /          //
       //                          //
-      if (atom->GetValence() == 3) {
+      if (atom->GetExplicitDegree() == 3) {
         OBStereoFacade stereoFacade((OBMol*)atom->GetParent());
         if (stereoFacade.HasTetrahedralStereo(atom->GetId())) {
           OBBond *hash = 0;
@@ -1518,7 +1518,7 @@ namespace OpenBabel
   {
     OBMol workmol = mol; // Make a copy (this invalidates Ids, but not Idxs)
     OBAtom* watom = workmol.GetAtom(mol.GetAtomById(atomId)->GetIdx());
-    if (watom->GetHvyValence() != 4) // QUESTION: Do I need to restrict it further?
+    if (watom->GetHvyDegree() != 4) // QUESTION: Do I need to restrict it further?
       return false;
 
     int atomsInSameRing = 0;

--- a/src/canon.cpp
+++ b/src/canon.cpp
@@ -162,7 +162,7 @@ namespace OpenBabel {
     if (!Fe || !C)
       return false;
 
-    if (Fe->GetValence() < 10)
+    if (Fe->GetExplicitDegree() < 10)
       return false;
 
     return C->HasDoubleBond() && C->IsInRing();

--- a/src/chains.cpp
+++ b/src/chains.cpp
@@ -1026,7 +1026,7 @@ namespace OpenBabel
     FOR_ATOMS_OF_MOL (atom, mol) {
       idx = atom->GetIdx() - 1;
 
-      if (atom->GetHvyValence() == 0) {
+      if (atom->GetHvyDegree() == 0) {
         chains[idx] = ' ';
         resnos[idx] = resno;
         resno++;
@@ -1074,7 +1074,7 @@ namespace OpenBabel
 
     // find un-connected atoms (e.g., HOH oxygen atoms)
     for (atom = mol.BeginAtom(a) ; atom ; atom = mol.NextAtom(a)) {
-      if (atom->GetAtomicNum() == OBElements::Hydrogen || atom->GetHvyValence() != 0)
+      if (atom->GetAtomicNum() == OBElements::Hydrogen || atom->GetHvyDegree() != 0)
         continue;
 
       unsigned int idx = atom->GetIdx() - 1;
@@ -1246,7 +1246,7 @@ namespace OpenBabel
         bitmasks[idx] = 0;
         for ( i = 0 ; i < tmax ; i++ )
           if ( (static_cast<unsigned int>(templ[i].elem)  == atom->GetAtomicNum()) &&
-               (static_cast<unsigned int>(templ[i].count) == atom->GetHvyValence()))
+               (static_cast<unsigned int>(templ[i].count) == atom->GetHvyDegree()))
             bitmasks[idx] |= templ[i].flag;
       }
 

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -499,7 +499,7 @@ namespace OpenBabel
     skipres = ""; // don't skip any residues right now
     for (a1 = mol.BeginAtom(i);a1;a1 = mol.NextAtom(i))
       {
-        if (a1->GetAtomicNum() == OBElements::Oxygen && !a1->GetValence())
+        if (a1->GetAtomicNum() == OBElements::Oxygen && !a1->GetExplicitDegree())
           {
             a1->SetType("O3");
             continue;
@@ -511,7 +511,7 @@ namespace OpenBabel
           }
 
         //***valence rule for O-
-        if (a1->GetAtomicNum() == OBElements::Oxygen && a1->GetValence() == 1)
+        if (a1->GetAtomicNum() == OBElements::Oxygen && a1->GetExplicitDegree() == 1)
           {
             OBBond *bond;
             bond = (OBBond*)*(a1->BeginBonds());

--- a/src/depict/depict.cpp
+++ b/src/depict/depict.cpp
@@ -250,7 +250,7 @@ namespace OpenBabel
 
     const double bias = -0.1; //towards left-alignment, which is more natural
     int alignment = 0;
-    if ((atom->GetValence() == 2) && (abs(direction.y()) > abs(direction.x()))) {
+    if ((atom->GetExplicitDegree() == 2) && (abs(direction.y()) > abs(direction.x()))) {
       if (direction.y() <= 0.0)
         alignment = Up;
       else
@@ -368,7 +368,7 @@ namespace OpenBabel
     if (spin)
       return spin == 2 ? TWO_DOT : ONE_DOT;
 
-    unsigned int actualvalence = atom->BOSum() + atom->GetImplicitHCount();
+    unsigned int actualvalence = atom->GetExplicitValence() + atom->GetImplicitHCount();
     unsigned int typicalvalence = GetTypicalValence(atom->GetAtomicNum(), actualvalence, atom->GetFormalCharge());
     int diff = typicalvalence - actualvalence;
     if (diff <= 0)
@@ -622,9 +622,9 @@ namespace OpenBabel
       if (atom->GetAtomicNum() == OBElements::Carbon) {
         if(!(d->options & drawAllC))
         {
-          if (atom->GetValence() > 1)
+          if (atom->GetExplicitDegree() > 1)
             continue;
-          if ((atom->GetValence() == 1) && !(d->options & drawTermC))//!d->drawTerminalC)
+          if ((atom->GetExplicitDegree() == 1) && !(d->options & drawTermC))//!d->drawTerminalC)
             continue;
         }
       }
@@ -806,9 +806,9 @@ namespace OpenBabel
       bool useAsymmetricDouble = options & OBDepict::asymmetricDoubleBond;
       if (HasLabel(beginAtom) && HasLabel(endAtom))
         useAsymmetricDouble = false;
-      if (HasLabel(beginAtom) && endAtom->GetValence() == 3)
+      if (HasLabel(beginAtom) && endAtom->GetExplicitDegree() == 3)
         useAsymmetricDouble = false;
-      if (HasLabel(endAtom) && beginAtom->GetValence() == 3)
+      if (HasLabel(endAtom) && beginAtom->GetExplicitDegree() == 3)
         useAsymmetricDouble = false;
       if (crossed_dbl_bond)
         useAsymmetricDouble = false; // The bond looks very strange otherwise in the case of cis
@@ -1039,7 +1039,7 @@ namespace OpenBabel
   {
     if (atom->GetAtomicNum() != OBElements::Carbon)
       return true;
-    if ((options & OBDepict::drawAllC) || ((options & OBDepict::drawTermC) && (atom->GetValence() == 1)))
+    if ((options & OBDepict::drawAllC) || ((options & OBDepict::drawTermC) && (atom->GetExplicitDegree() == 1)))
       return true;
     return false;
   }

--- a/src/depict/depict.cpp
+++ b/src/depict/depict.cpp
@@ -368,7 +368,7 @@ namespace OpenBabel
     if (spin)
       return spin == 2 ? TWO_DOT : ONE_DOT;
 
-    unsigned int actualvalence = atom->GetExplicitValence() + atom->GetImplicitHCount();
+    unsigned int actualvalence = atom->GetTotalValence();
     unsigned int typicalvalence = GetTypicalValence(atom->GetAtomicNum(), actualvalence, atom->GetFormalCharge());
     int diff = typicalvalence - actualvalence;
     if (diff <= 0)

--- a/src/descriptors/groupcontrib.cpp
+++ b/src/descriptors/groupcontrib.cpp
@@ -159,7 +159,7 @@ namespace OpenBabel
         for (j = _mlist.begin();j != _mlist.end();++j) {
           if (tmpmol.GetAtom((*j)[0])->GetAtomicNum() == OBElements::Hydrogen)
             continue;
-          int Hcount = tmpmol.GetAtom((*j)[0])->GetValence() - tmpmol.GetAtom((*j)[0])->GetHvyValence();
+          int Hcount = tmpmol.GetAtom((*j)[0])->GetExplicitDegree() - tmpmol.GetAtom((*j)[0])->GetHvyDegree();
           hydrogenValues[(*j)[0] - 1] = i->second * Hcount;
           seenHydrogen.SetBitOn((*j)[0]);
           if (_debug)
@@ -182,7 +182,7 @@ namespace OpenBabel
         debugMessage << index+1 << " = " << atomValues[index] << " ";
         if (!seenHeavy.BitIsSet(index + 1)) debugMessage << "un";
         debugMessage << "matched...";
-        int Hcount = tmpmol.GetAtom(index + 1)->GetValence() - tmpmol.GetAtom(index + 1)->GetHvyValence();
+        int Hcount = tmpmol.GetAtom(index + 1)->GetExplicitDegree() - tmpmol.GetAtom(index + 1)->GetHvyDegree();
         debugMessage << "   " << Hcount << " hydrogens = " << hydrogenValues[index] << " ";
         if (!seenHydrogen.BitIsSet(index + 1)) debugMessage << "un";
         debugMessage << "matched\n";

--- a/src/fingerprints/fingerecfp.cpp
+++ b/src/fingerprints/fingerecfp.cpp
@@ -228,8 +228,8 @@ static void ECFPFirstPass(OpenBabel::OBMol &mol,
       continue;
     OpenBabel::OBAtom* aptr = &(*atom);
     unsigned int idx = aptr->GetIdx();
-    buffer[0] = aptr->GetHvyValence(); // degree of heavy atom connections
-    buffer[1] = aptr->BOSum() - aptr->ExplicitHydrogenCount(); // valence of heavy atom connections
+    buffer[0] = aptr->GetHvyDegree(); // degree of heavy atom connections
+    buffer[1] = aptr->GetExplicitValence() - aptr->ExplicitHydrogenCount(); // valence of heavy atom connections
     buffer[2] = aptr->GetAtomicNum();
     buffer[3] = (unsigned char)aptr->GetIsotope();
     buffer[4] = (unsigned char)aptr->GetFormalCharge();

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -955,7 +955,7 @@ namespace OpenBabel
         return true;
       if (atom->GetAtomicNum() != (mol.GetAtom(atom->GetIdx()))->GetAtomicNum())
         return true;
-      if (atom->GetValence() != (mol.GetAtom(atom->GetIdx()))->GetValence())
+      if (atom->GetExplicitDegree() != (mol.GetAtom(atom->GetIdx()))->GetExplicitDegree())
         return true;
     }
     FOR_BONDS_OF_MOL (bond, _mol) {

--- a/src/forcefields/forcefieldmmff94.cpp
+++ b/src/forcefields/forcefieldmmff94.cpp
@@ -1499,7 +1499,7 @@ namespace OpenBabel
         }
         if (atom->GetAtomicNum() == OBElements::Nitrogen) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetValence() == 1)) {
+            if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetExplicitDegree() == 1)) {
               return 82; // N-oxide nitrogen in 5-ring alpha position,
               // N-oxide nitrogen in 5-ring beta position,
               // N-oxide nitrogen in other 5-ring  position,
@@ -1537,10 +1537,10 @@ namespace OpenBabel
               alphaAtoms.push_back(alphaPos[i]);
             } else if (alphaPos[i]->GetAtomicNum() == OBElements::Oxygen) {
               alphaAtoms.push_back(alphaPos[i]);
-            } else if (alphaPos[i]->GetAtomicNum() == OBElements::Nitrogen && (alphaPos[i]->GetValence() == 3)) {
+            } else if (alphaPos[i]->GetAtomicNum() == OBElements::Nitrogen && (alphaPos[i]->GetExplicitDegree() == 3)) {
               bool IsNOxide = false;
               FOR_NBORS_OF_ATOM (nbr, alphaPos[i]) {
-                if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetValence() == 1)) {
+                if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetExplicitDegree() == 1)) {
                   IsNOxide = true;
                 }
               }
@@ -1555,10 +1555,10 @@ namespace OpenBabel
               betaAtoms.push_back(betaPos[i]);
             } else if (betaPos[i]->GetAtomicNum() == OBElements::Oxygen) {
               betaAtoms.push_back(betaPos[i]);
-            } else if (betaPos[i]->GetAtomicNum() == OBElements::Nitrogen && (betaPos[i]->GetValence() == 3)) {
+            } else if (betaPos[i]->GetAtomicNum() == OBElements::Nitrogen && (betaPos[i]->GetExplicitDegree() == 3)) {
               bool IsNOxide = false;
               FOR_NBORS_OF_ATOM (nbr, betaPos[i]) {
-                if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetValence() == 1)) {
+                if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetExplicitDegree() == 1)) {
                   IsNOxide = true;
                 }
               }
@@ -1571,10 +1571,10 @@ namespace OpenBabel
           if (!betaAtoms.size()) {
             nitrogenCount = 0;
             FOR_NBORS_OF_ATOM (nbr, atom) {
-              if (nbr->GetAtomicNum() == OBElements::Nitrogen && (nbr->GetValence() == 3)) {
-                if ((nbr->BOSum() == 4) && nbr->IsAromatic()) {
+              if (nbr->GetAtomicNum() == OBElements::Nitrogen && (nbr->GetExplicitDegree() == 3)) {
+                if ((nbr->GetExplicitValence() == 4) && nbr->IsAromatic()) {
                   nitrogenCount++;
-                } else if ((nbr->BOSum() == 3) && !nbr->IsAromatic()) {
+                } else if ((nbr->GetExplicitValence() == 3) && !nbr->IsAromatic()) {
                   nitrogenCount++;
                 }
               }
@@ -1596,7 +1596,7 @@ namespace OpenBabel
               // this is the case for anions with only carbon and nitrogen in the ring
               return 78; // General carbon in 5-membered aromatic ring (C5)
             } else if (atom->GetAtomicNum() == OBElements::Nitrogen) {
-              if (atom->GetValence() == 3) {
+              if (atom->GetExplicitDegree() == 3) {
                 // this is the N: atom
                 return 39; // Aromatic 5 ring nitrogen with pi lone pair (NPYL)
               } else {
@@ -1608,7 +1608,7 @@ namespace OpenBabel
           if (alphaAtoms.size() == 2) {
             if (atom->GetAtomicNum() == OBElements::Carbon && IsInSameRing(alphaAtoms[0], alphaAtoms[1])) {
               if (alphaAtoms[0]->GetAtomicNum() == OBElements::Nitrogen && alphaAtoms[1]->GetAtomicNum() == OBElements::Nitrogen) {
-                if ((alphaAtoms[0]->GetValence() == 3) && (alphaAtoms[1]->GetValence() == 3)) {
+                if ((alphaAtoms[0]->GetExplicitDegree() == 3) && (alphaAtoms[1]->GetExplicitDegree() == 3)) {
                   return 80; // Aromatic carbon between N's in imidazolium (CIM+)
                 }
               }
@@ -1618,7 +1618,7 @@ namespace OpenBabel
             if (atom->GetAtomicNum() == OBElements::Carbon) {
               return 63; // Aromatic 5-ring C, alpha to N:, O:, or S: (C5A)
             } else if (atom->GetAtomicNum() == OBElements::Nitrogen) {
-              if (atom->GetValence() == 3) {
+              if (atom->GetExplicitDegree() == 3) {
                 return 81; // Posivite nitrogen in 5-ring alpha position (N5A+)
               } else {
                 return 65; // Aromatic 5-ring N, alpha to N:, O:, or S: (N5A)
@@ -1629,7 +1629,7 @@ namespace OpenBabel
             if (atom->GetAtomicNum() == OBElements::Carbon) {
               return 64; // Aromatic 5-ring C, beta to N:, O:, or S: (C5B)
             } else if (atom->GetAtomicNum() == OBElements::Nitrogen) {
-              if (atom->GetValence() == 3) {
+              if (atom->GetExplicitDegree() == 3) {
                 return 81; // Posivite nitrogen in 5-ring beta position (N5B+)
               } else {
                 return 66; // Aromatic 5-ring N, beta to N:, O:, or S: (N5B)
@@ -1682,12 +1682,12 @@ namespace OpenBabel
           return 37; // Aromatic carbon, e.g., in benzene (CB)
         } else if (atom->GetAtomicNum() == OBElements::Nitrogen) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetValence() == 1)) {
+            if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetExplicitDegree() == 1)) {
               return 69; // Pyridinium N-oxide nitrogen (NPOX)
             }
           }
 
-          if (atom->GetValence() == 3) {
+          if (atom->GetExplicitDegree() == 3) {
             return 58; // Aromatic nitrogen in pyridinium (NPD+)
           } else {
             return 38; // Aromatic nitrogen with sigma lone pair (NPYD)
@@ -1708,8 +1708,8 @@ namespace OpenBabel
           return 5; // Hydrogen attatched to silicon (HSI)
         }
         if (nbr->GetAtomicNum() == OBElements::Oxygen) {
-          if (nbr->BOSum() == 3) {
-            if (nbr->GetValence() == 3) {
+          if (nbr->GetExplicitValence() == 3) {
+            if (nbr->GetExplicitDegree() == 3) {
               return 50; // Hydrogen on oxonium oxygen (HO+)
             } else {
               return 52; // Hydrogen on oxenium oxygen (HO=+)
@@ -1779,15 +1779,15 @@ namespace OpenBabel
             return 23; // Generic hydrogen on sp3 nitrogen, e.g., in amines, Hydrogen on nitrogen in ammonia (HNR, H3N)
           }
 
-          if (nbr->BOSum() == 4) {
-            if (nbr->GetValence() == 2) {
+          if (nbr->GetExplicitValence() == 4) {
+            if (nbr->GetExplicitDegree() == 2) {
               return 28; // Hydrogen on N triply bonded to C (HNC%)
             } else {
               return 36; // Hydrogen on pyridinium nitrogen, Hydrogen on protonated imine nitrogen (HPD+, HNC+)
             }
           }
 
-          if (nbr->GetValence() == 2) {
+          if (nbr->GetExplicitDegree() == 2) {
             FOR_NBORS_OF_ATOM (nbrNbr, &*nbr) {
               if (nbrNbr->GetAtomicNum() == OBElements::Hydrogen)
                 continue;
@@ -1843,7 +1843,7 @@ namespace OpenBabel
                 if (nbrNbrNbr->GetIdx() == nbr->GetIdx())
                   continue;
 
-                if (nbrNbrNbr->GetAtomicNum() == OBElements::Oxygen || (nbrNbrNbr->GetValence() == 1)) {
+                if (nbrNbrNbr->GetAtomicNum() == OBElements::Oxygen || (nbrNbrNbr->GetExplicitDegree() == 1)) {
                   return 28; // Hydrogen on NSO, NSO2 or NSO3 nitrogen (HNSO)
                 }
               }
@@ -1866,7 +1866,7 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 3) {
       // 0 neighbours
-      if (atom->GetValence() == 0) {
+      if (atom->GetExplicitDegree() == 0) {
         return 92; // Lithium cation (LI+)
       }
     }
@@ -1876,7 +1876,7 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 6) {
       // 4 neighbours
-      if (atom->GetValence() == 4) {
+      if (atom->GetExplicitDegree() == 4) {
         if (atom->IsInRingSize(3)) {
           return 22; // Aliphatic carbon in 3-membered ring (CR3R)
         }
@@ -1888,7 +1888,7 @@ namespace OpenBabel
         return 1; // Alkyl carbon (CR)
       }
       // 3 neighbours
-      if (atom->GetValence() == 3) {
+      if (atom->GetExplicitDegree() == 3) {
         int N2count = 0;
         int N3count = 0;
         int N3fcharge = 0;
@@ -1900,24 +1900,24 @@ namespace OpenBabel
             doubleBondTo = nbr->GetAtomicNum();
           }
 
-          if (nbr->GetValence() == 1) {
+          if (nbr->GetExplicitDegree() == 1) {
             if (nbr->GetAtomicNum() == OBElements::Oxygen) {
               oxygenCount++;
             } else if (nbr->GetAtomicNum() == OBElements::Sulfur) {
               sulphurCount++;
             }
-          } else if (nbr->GetValence() == 3) {
+          } else if (nbr->GetExplicitDegree() == 3) {
             if (nbr->GetAtomicNum() == OBElements::Nitrogen) {
               N3fcharge += nbr->GetFormalCharge();
               N3count++;
             }
-          } else if ((nbr->GetValence() == 2) && !bond->IsAromatic() && bond->GetBondOrder() == 2) {
+          } else if ((nbr->GetExplicitDegree() == 2) && !bond->IsAromatic() && bond->GetBondOrder() == 2) {
             if (nbr->GetAtomicNum() == OBElements::Nitrogen) {
               N2count++;
             }
           }
         }
-        if ((N3count >= 2) && (doubleBondTo == 7 || (!(doubleBondTo == 6) && atom->GetValence() == 3
+        if ((N3count >= 2) && (doubleBondTo == 7 || (!(doubleBondTo == 6) && atom->GetExplicitDegree() == 3
           && N3fcharge == 1)) && !N2count && !oxygenCount && !sulphurCount) {
           // N3==C--N3
           return 57; // Guanidinium carbon, Carbon in +N=C-N: resonance structures (CGD+, CNN+)
@@ -1946,11 +1946,11 @@ namespace OpenBabel
 
       }
       // 2 neighbours
-      if (atom->GetValence() == 2) {
+      if (atom->GetExplicitDegree() == 2) {
         return 4; // Acetylenic carbon, Allenic caron (CSP, =C=)
       }
       // 1 neighbours
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         return 60; // Isonitrile carbon (C%-)
       }
     }
@@ -1960,9 +1960,9 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 7) {
       // 4 neighbours
-      if (atom->GetValence() == 4) {
+      if (atom->GetExplicitDegree() == 4) {
         FOR_NBORS_OF_ATOM (nbr, atom) {
-          if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetValence() == 1)) {
+          if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetExplicitDegree() == 1)) {
             return 68; // sp3-hybridized N-oxide nitrogen (N3OX)
           }
         }
@@ -1970,12 +1970,12 @@ namespace OpenBabel
         return 34; // Quaternary nitrogen (NR+)
       }
       // 3 neighbours
-      if (atom->GetValence() == 3) {
-        if (atom->BOSum() >= 4) { // > because we accept -N(=O)=O as a valid nitro group
+      if (atom->GetExplicitDegree() == 3) {
+        if (atom->GetExplicitValence() >= 4) { // > because we accept -N(=O)=O as a valid nitro group
           oxygenCount = nitrogenCount = doubleBondTo = 0;
 
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetValence() == 1)) {
+            if (nbr->GetAtomicNum() == OBElements::Oxygen && (nbr->GetExplicitDegree() == 1)) {
               oxygenCount++;
             }
             if (nbr->GetAtomicNum() == OBElements::Nitrogen) {
@@ -1988,7 +1988,7 @@ namespace OpenBabel
               bond = _mol.GetBond(&*nbr, atom);
               if (!bond->IsAromatic() && bond->GetBondOrder() == 2) {
                 FOR_NBORS_OF_ATOM (nbrNbr, &*nbr) {
-                  if (nbrNbr->GetAtomicNum() == OBElements::Nitrogen && (nbrNbr->GetValence() == 3)) {
+                  if (nbrNbr->GetAtomicNum() == OBElements::Nitrogen && (nbrNbr->GetExplicitDegree() == 3)) {
                     nitrogenCount++;
                   }
                 }
@@ -2018,7 +2018,7 @@ namespace OpenBabel
           }
         }
 
-        if (atom->BOSum() == 3) {
+        if (atom->GetExplicitValence() == 3) {
           bool IsAmide = false;
           bool IsSulfonAmide = false;
           bool IsNNNorNNC = false;
@@ -2030,7 +2030,7 @@ namespace OpenBabel
               oxygenCount = 0;
 
               FOR_NBORS_OF_ATOM (nbrNbr, &*nbr) {
-                if (nbrNbr->GetAtomicNum() == OBElements::Oxygen && (nbrNbr->GetValence() == 1)) {
+                if (nbrNbr->GetAtomicNum() == OBElements::Oxygen && (nbrNbr->GetExplicitDegree() == 1)) {
                   oxygenCount++;
                 }
               }
@@ -2072,7 +2072,7 @@ namespace OpenBabel
                 if (!bond->IsAromatic() && bond->GetBondOrder() == 3) {
                   tripleBondTo = nbrNbr->GetAtomicNum();
                 }
-                if (nbrNbr->GetAtomicNum() == OBElements::Nitrogen && (nbrNbr->GetValence() == 3)) {
+                if (nbrNbr->GetAtomicNum() == OBElements::Nitrogen && (nbrNbr->GetExplicitDegree() == 3)) {
                   int nbrOxygen = 0;
                   FOR_NBORS_OF_ATOM (nbrNbrNbr, &*nbrNbr) {
                     if (nbrNbrNbr->GetAtomicNum() == OBElements::Oxygen) {
@@ -2083,7 +2083,7 @@ namespace OpenBabel
                     N3count++;
                   }
                 }
-                if (nbrNbr->GetAtomicNum() == OBElements::Nitrogen && (nbrNbr->GetValence() == 2) && (bond->GetBondOrder() == 2 || bond->IsAromatic())) {
+                if (nbrNbr->GetAtomicNum() == OBElements::Nitrogen && (nbrNbr->GetExplicitDegree() == 2) && (bond->GetBondOrder() == 2 || bond->IsAromatic())) {
                   N2count++;
                 }
                 if (nbrNbr->IsAromatic()) {
@@ -2178,8 +2178,8 @@ namespace OpenBabel
         }
       }
       // 2 neighbours
-      if (atom->GetValence() == 2) {
-        if (atom->BOSum() >= 4) {
+      if (atom->GetExplicitDegree() == 2) {
+        if (atom->GetExplicitValence() >= 4) {
           bool isNbrCarbon = false;
           bool isBondTriple = false;
           FOR_NBORS_OF_ATOM (nbr, atom) {
@@ -2195,12 +2195,12 @@ namespace OpenBabel
           return 53; // Central nitrogen in C=N=N or N=N=N (=N=)
         }
 
-        if (atom->BOSum() == 3) {
+        if (atom->GetExplicitValence() == 3) {
           doubleBondTo = 0;
 
           FOR_NBORS_OF_ATOM (nbr, atom) {
             bond = _mol.GetBond(&*nbr, atom);
-            if (nbr->GetAtomicNum() == OBElements::Oxygen && !bond->IsAromatic() && bond->GetBondOrder() == 2 && (nbr->GetValence() == 1)) {
+            if (nbr->GetAtomicNum() == OBElements::Oxygen && !bond->IsAromatic() && bond->GetBondOrder() == 2 && (nbr->GetExplicitDegree() == 1)) {
               return 46; // Nitrogen in nitroso group (N=O)
             }
             if ((nbr->GetAtomicNum() == OBElements::Carbon || nbr->GetAtomicNum() == OBElements::Nitrogen) && !bond->IsAromatic() && bond->GetBondOrder() == 2) {
@@ -2212,7 +2212,7 @@ namespace OpenBabel
               oxygenCount = 0;
 
               FOR_NBORS_OF_ATOM (nbrNbr, &*nbr) {
-                if (nbrNbr->GetAtomicNum() == OBElements::Oxygen && (nbrNbr->GetValence() == 1)) {
+                if (nbrNbr->GetAtomicNum() == OBElements::Oxygen && (nbrNbr->GetExplicitDegree() == 1)) {
                   oxygenCount++;
                 }
               }
@@ -2223,13 +2223,13 @@ namespace OpenBabel
           }
         }
 
-        if (atom->BOSum() >= 2) { // Bug reported by Paolo Tosco
+        if (atom->GetExplicitValence() >= 2) { // Bug reported by Paolo Tosco
           oxygenCount = sulphurCount = 0;
 
           FOR_NBORS_OF_ATOM (nbr, atom) {
             if (nbr->GetAtomicNum() == OBElements::Sulfur) {
               FOR_NBORS_OF_ATOM (nbrNbr, &*nbr) {
-                if (nbrNbr->GetAtomicNum() == OBElements::Oxygen && (nbrNbr->GetValence() == 1)) {
+                if (nbrNbr->GetAtomicNum() == OBElements::Oxygen && (nbrNbr->GetExplicitDegree() == 1)) {
                   oxygenCount++;
                 }
               }
@@ -2243,18 +2243,18 @@ namespace OpenBabel
         }
       }
       // 1 neighbours
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
        	FOR_NBORS_OF_ATOM (nbr, atom) {
           bond = _mol.GetBond(&*nbr, atom);
           if (!bond->IsAromatic() && bond->GetBondOrder() == 3) {
             FOR_NBORS_OF_ATOM (nbrNbr, &*nbr) {
               if (atom != &*nbrNbr && !(nbr->GetAtomicNum() == OBElements::Nitrogen
-                && nbrNbr->GetAtomicNum() == OBElements::Nitrogen && nbrNbr->GetValence() == 2)) {
+                && nbrNbr->GetAtomicNum() == OBElements::Nitrogen && nbrNbr->GetExplicitDegree() == 2)) {
                 return 42; // Triply bonded nitrogen (NSP)
               }
             }
           }
-          if (nbr->GetAtomicNum() == OBElements::Nitrogen && (nbr->GetValence() == 2)) {
+          if (nbr->GetAtomicNum() == OBElements::Nitrogen && (nbr->GetExplicitDegree() == 2)) {
             return 47; // Terminal nitrogen in azido group (NAZT)
           }
         }
@@ -2267,11 +2267,11 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 8) {
       // 3 neighbours
-      if (atom->GetValence() == 3) {
+      if (atom->GetExplicitDegree() == 3) {
         return 49; // Oxonium oxygen (O+)
       }
       // 2 neighbours
-      if (atom->GetValence() == 2) {
+      if (atom->GetExplicitDegree() == 2) {
         int hydrogenCount = 0;
         FOR_NBORS_OF_ATOM (nbr, atom) {
           if (nbr->GetAtomicNum() == OBElements::Hydrogen) {
@@ -2283,7 +2283,7 @@ namespace OpenBabel
           // H--O--H
           return 70; // Oxygen in water (OH2)
         }
-        if (atom->BOSum() == 3) {
+        if (atom->GetExplicitValence() == 3) {
           return 51; // Oxenium oxygen (O=+)
         }
 
@@ -2300,7 +2300,7 @@ namespace OpenBabel
         // 59 ar
       }
       // 1 neighbour
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         oxygenCount = sulphurCount = 0;
 
         FOR_NBORS_OF_ATOM (nbr, atom) {
@@ -2308,10 +2308,10 @@ namespace OpenBabel
 
           if (nbr->GetAtomicNum() == OBElements::Carbon || nbr->GetAtomicNum() == OBElements::Nitrogen) {
             FOR_NBORS_OF_ATOM (nbrNbr, &*nbr) {
-              if (nbrNbr->GetAtomicNum() == OBElements::Oxygen && (nbrNbr->GetValence() == 1)) {
+              if (nbrNbr->GetAtomicNum() == OBElements::Oxygen && (nbrNbr->GetExplicitDegree() == 1)) {
                 oxygenCount++;
               }
-              if (nbrNbr->GetAtomicNum() == OBElements::Sulfur && (nbrNbr->GetValence() == 1)) {
+              if (nbrNbr->GetAtomicNum() == OBElements::Sulfur && (nbrNbr->GetExplicitDegree() == 1)) {
                 sulphurCount++;
               }
             }
@@ -2344,7 +2344,7 @@ namespace OpenBabel
               // Nitrate anion oxygen (O2N, O2NO, O3N)
             }
             if (!bond->IsAromatic() && bond->GetBondOrder() == 1) {
-	      if ((nbr->GetValence() == 2) || (nbr->BOSum() == 3))
+	      if ((nbr->GetExplicitDegree() == 2) || (nbr->GetExplicitValence() == 3))
 	      // O(-)--N
 	        return 35;
 	      else
@@ -2358,7 +2358,7 @@ namespace OpenBabel
                 if (bond2->GetBondOrder() == 2 || bond2->GetBondOrder() == 5)
                   ndab++;
               }
-              if (ndab + nbr->GetValence() == 5)
+              if (ndab + nbr->GetExplicitDegree() == 5)
                 // O--N
                 return 32; // Oxygen in N-oxides (ONX)
               else
@@ -2398,8 +2398,8 @@ namespace OpenBabel
                   && nbr2->GetAtomicNum() == OBElements::Carbon && oxygenBoundToSulfur == 1)
                   isSulfoxide = false; // O=S on sulfur doubly bonded to, e.g., C (O=S=)
 
-                if ((nbr2->GetAtomicNum() == OBElements::Oxygen && nbr2->GetValence() == 1)
-		  || (nbr2->GetAtomicNum() == OBElements::Nitrogen && nbr2->GetValence() == 2))
+                if ((nbr2->GetAtomicNum() == OBElements::Oxygen && nbr2->GetExplicitDegree() == 1)
+		  || (nbr2->GetAtomicNum() == OBElements::Nitrogen && nbr2->GetExplicitDegree() == 2))
                   isSulfoxide = false;
               }
 
@@ -2422,11 +2422,11 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 9) {
       // 1 neighbour
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         return 11; // Fluorine (F)
       }
       // 0 neighbours
-      if (atom->GetValence() == 0) {
+      if (atom->GetExplicitDegree() == 0) {
         return 89; // Fluoride anion (F-)
       }
     }
@@ -2456,15 +2456,15 @@ namespace OpenBabel
     // Phosphorus
     ////////////////////////////////
     if (atom->GetAtomicNum() == 15) {
-      if (atom->GetValence() == 4) {
+      if (atom->GetExplicitDegree() == 4) {
         return 25; // Phosphate group phosphorus, Phosphorus with 3 attached oxygens,
         // Phosphorus with 2 attached oxygens, Phosphine oxide phosphorus,
         // General tetracoordinate phosphorus (PO4, PO3, PO2, PO, PTET)
       }
-      if (atom->GetValence() == 3) {
+      if (atom->GetExplicitDegree() == 3) {
         return 26; // Phosphorus in phosphines (P)
       }
-      if (atom->GetValence() == 2) {
+      if (atom->GetExplicitDegree() == 2) {
         return 75; // Phosphorus doubly bonded to C (-P=C)
       }
     }
@@ -2474,13 +2474,13 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 16) {
       // 4 neighbours
-      if (atom->GetValence() == 4) {
+      if (atom->GetExplicitDegree() == 4) {
         return 18; // Sulfone sulfur, Sulfonamide sulfur, Sulfonate group sulfur,
         // Sulfate group sulfur, Sulfur in nitrogen analog of sulfone
         // (SO2, SO2N, SO3, SO4, SNO)
       }
       // 3 neighbours
-      if (atom->GetValence() == 3) {
+      if (atom->GetExplicitDegree() == 3) {
         oxygenCount = sulphurCount = doubleBondTo = 0;
 
         FOR_NBORS_OF_ATOM (nbr, atom) {
@@ -2490,7 +2490,7 @@ namespace OpenBabel
 	            doubleBondTo = 6;
           }
 
-          if (nbr->GetValence() == 1) {
+          if (nbr->GetExplicitDegree() == 1) {
             if (nbr->GetAtomicNum() == OBElements::Oxygen) {
               oxygenCount++;
             } else if (nbr->GetAtomicNum() == OBElements::Sulfur) {
@@ -2512,7 +2512,7 @@ namespace OpenBabel
         return 17; // Sulfur doubly bonded to carbon, Sulfoxide sulfur (S=C, S=O)
       }
       // 2 neighbours
-      if (atom->GetValence() == 2) {
+      if (atom->GetExplicitDegree() == 2) {
         doubleBondTo = 0;
 
         FOR_NBORS_OF_ATOM (nbr, atom) {
@@ -2530,12 +2530,12 @@ namespace OpenBabel
         return 15; // Thiol, sulfide, or disulfide sulfor (S)
       }
       // 1 neighbour
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         sulphurCount = doubleBondTo = 0;
 
         FOR_NBORS_OF_ATOM (nbr, atom) {
           FOR_NBORS_OF_ATOM (nbrNbr, &*nbr) {
-            if (nbrNbr->GetAtomicNum() == OBElements::Sulfur && (nbrNbr->GetValence() == 1)) {
+            if (nbrNbr->GetAtomicNum() == OBElements::Sulfur && (nbrNbr->GetExplicitDegree() == 1)) {
               sulphurCount++;
             }
           }
@@ -2561,7 +2561,7 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 17) {
       // 4 neighbour
-      if (atom->GetValence() == 4) {
+      if (atom->GetExplicitDegree() == 4) {
         oxygenCount = 0;
 
         FOR_NBORS_OF_ATOM (nbr, atom) {
@@ -2573,11 +2573,11 @@ namespace OpenBabel
           return 77; // Perchlorate anion chlorine (CLO4)
       }
       // 1 neighbour
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         return 12; // Chlorine (CL)
       }
       // 0 neighbours
-      if (atom->GetValence() == 0) {
+      if (atom->GetExplicitDegree() == 0) {
         return 90; // Chloride anion (CL-)
       }
     }
@@ -2594,7 +2594,7 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 20) {
       // 0 neighbours
-      if (atom->GetValence() == 0) {
+      if (atom->GetExplicitDegree() == 0) {
         return 96; // Dipositive calcium cation (CA+2)
       }
     }
@@ -2631,11 +2631,11 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 35) {
       // 1 neighbour
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         return 13; // Bromine (BR)
       }
       // 0 neighbours
-      if (atom->GetValence() == 0) {
+      if (atom->GetExplicitDegree() == 0) {
         return 91; // Bromide anion (BR-)
       }
     }
@@ -2645,7 +2645,7 @@ namespace OpenBabel
     ////////////////////////////////
     if (atom->GetAtomicNum() == 53) {
       // 1 neighbour
-      if (atom->GetValence() == 1) {
+      if (atom->GetExplicitDegree() == 1) {
         return 14; // Iodine (I)
       }
     }
@@ -3770,9 +3770,9 @@ namespace OpenBabel
 
         FOR_NBORS_OF_ATOM(nbr, &*atom) {
           FOR_NBORS_OF_ATOM(nbr2, &*nbr) {
-            if (nbr2->GetAtomicNum() == OBElements::Oxygen && (nbr2->GetValence() == 1))
+            if (nbr2->GetAtomicNum() == OBElements::Oxygen && (nbr2->GetExplicitDegree() == 1))
               o_count++;
-            if (nbr2->GetAtomicNum() == OBElements::Sulfur && (nbr2->GetValence() == 1))
+            if (nbr2->GetAtomicNum() == OBElements::Sulfur && (nbr2->GetExplicitDegree() == 1))
               s_count++;
             if (nbr2->GetAtomicNum() == OBElements::Nitrogen && !nbr2->IsAromatic())
               sulfonamide = true;
@@ -3788,8 +3788,8 @@ namespace OpenBabel
             atom->SetPartialCharge(-1.0 / o_count);  // O3N
 
           if (nbr->GetAtomicNum() == OBElements::Sulfur && !sulfonamide) {
-            if (((o_count + s_count) == 2) && (nbr->GetValence() == 3)
-                && (nbr->BOSum() >= 3) && !sulfone_s_c) {
+            if (((o_count + s_count) == 2) && (nbr->GetExplicitDegree() == 3)
+                && (nbr->GetExplicitValence() >= 3) && !sulfone_s_c) {
               atom->SetPartialCharge(-0.5); // O2S (sulfinate)
             }
             else if ((o_count + s_count) == 3) {
@@ -3830,14 +3830,14 @@ namespace OpenBabel
 
           if (nbr->GetAtomicNum() == OBElements::Phosphorus || nbr->GetAtomicNum() == OBElements::Sulfur) {
             FOR_NBORS_OF_ATOM(nbr2, &*nbr)
-              if ((nbr2->GetAtomicNum() == OBElements::Sulfur || nbr2->GetAtomicNum() == OBElements::Oxygen) && (nbr2->GetValence() == 1) && (atom->GetIdx() != nbr2->GetIdx()))
+              if ((nbr2->GetAtomicNum() == OBElements::Sulfur || nbr2->GetAtomicNum() == OBElements::Oxygen) && (nbr2->GetExplicitDegree() == 1) && (atom->GetIdx() != nbr2->GetIdx()))
                 atom->SetPartialCharge(-0.5);
           } else
             atom->SetPartialCharge(-1.0);
 
           if (nbr->GetAtomicNum() == OBElements::Carbon)
             FOR_NBORS_OF_ATOM(nbr2, &*nbr)
-              if (nbr2->GetAtomicNum() == OBElements::Sulfur && (nbr2->GetValence() == 1) && (atom->GetIdx() != nbr2->GetIdx()))
+              if (nbr2->GetAtomicNum() == OBElements::Sulfur && (nbr2->GetExplicitDegree() == 1) && (atom->GetIdx() != nbr2->GetIdx()))
                 atom->SetPartialCharge(-0.5); // SSMO
 
           if (s_count >= 2)
@@ -3873,7 +3873,7 @@ namespace OpenBabel
           if ((*ri)->IsAromatic() && (*ri)->IsMember(&*atom) && ((*ri)->Size() == 5)) {
             int n_count = 0;
             for(rj = (*ri)->_path.begin();rj != (*ri)->_path.end();++rj) // for each ring atom
-              if (_mol.GetAtom(*rj)->GetAtomicNum() == OBElements::Nitrogen && (_mol.GetAtom(*rj)->GetValence() == 3))
+              if (_mol.GetAtom(*rj)->GetAtomicNum() == OBElements::Nitrogen && (_mol.GetAtom(*rj)->GetExplicitDegree() == 3))
                 n_count++;
 
             if (n_count) // coverity defensive testing
@@ -3928,7 +3928,7 @@ namespace OpenBabel
       if (!factor)
         FOR_NBORS_OF_ATOM (nbr, &*atom)
           if (nbr->GetPartialCharge() < 0.0)
-            q0a += nbr->GetPartialCharge() / (2.0 * (double)(nbr->GetValence()));
+            q0a += nbr->GetPartialCharge() / (2.0 * (double)(nbr->GetExplicitDegree()));
 
       // needed for SEYWUO, positive charge sharing?
       if (type == 62)

--- a/src/forcefields/forcefielduff.cpp
+++ b/src/forcefields/forcefielduff.cpp
@@ -702,10 +702,10 @@ namespace OpenBabel {
       // calculate the number of lone pairs
       // e.g. for IF3 => "T-shaped"
       valenceElectrons -= b->GetFormalCharge(); // make sure to look for I+F4 -> see-saw
-      double lonePairs = (valenceElectrons - b->BOSum()) / 2.0;
+      double lonePairs = (valenceElectrons - b->GetExplicitValence()) / 2.0;
       // we actually need to round up here -- single e- take room too.
       int sites = (int)ceil(lonePairs);
-      coordination = b->GetValence() + sites;
+      coordination = b->GetExplicitDegree() + sites;
       if (coordination <= 4) { // normal valency
         coordination = ipar;
       } else if (b->GetAtomicNum() == OBElements::Sulfur && b->CountFreeOxygens() == 3) {
@@ -714,10 +714,10 @@ namespace OpenBabel {
         coordination = 2; // i.e., sp2
       }
       /* planar coordination of hexavalent molecules.*/
-      if (lonePairs == 0 && b->GetValence() == 3 && b->BOSum() == 6) {
+      if (lonePairs == 0 && b->GetExplicitDegree() == 3 && b->GetExplicitValence() == 6) {
         coordination = 2;
       }
-      if (lonePairs == 0 && b->GetValence() == 7) {
+      if (lonePairs == 0 && b->GetExplicitDegree() == 7) {
         coordination = 7;
       }
       // Check to see if coordination is really correct
@@ -726,13 +726,13 @@ namespace OpenBabel {
     } else {
       coordination = ipar; // coordination of central atom
     }
-    if (b->GetValence() > 4) {
-      coordination = b->GetValence();
+    if (b->GetExplicitDegree() > 4) {
+      coordination = b->GetExplicitDegree();
     } else {
-      int coordDifference = ipar - b->GetValence();
+      int coordDifference = ipar - b->GetExplicitDegree();
       if (abs(coordDifference) > 2)
         // low valent, but very different than expected by ipar
-        coordination = b->GetValence() - 1; // 4 coordinate == sp3
+        coordination = b->GetExplicitDegree() - 1; // 4 coordinate == sp3
     }
     return coordination;
   }
@@ -1306,7 +1306,7 @@ namespace OpenBabel {
         continue;
       }
 
-      if (b->GetValence() > 3) // no OOP for hypervalent atoms
+      if (b->GetExplicitDegree() > 3) // no OOP for hypervalent atoms
         continue;
 
       a = NULL;

--- a/src/formats/MCDLformat.cpp
+++ b/src/formats/MCDLformat.cpp
@@ -568,7 +568,7 @@ private:
     aCharge[i-1]=atom->GetFormalCharge();
     aRadical[i-1]=atom->GetSpinMultiplicity();
     aSymb[i-1]=OBElements::GetSymbol(atom->GetAtomicNum());
-    nConn[i-1]=atom->GetHvyValence();
+    nConn[i-1]=atom->GetHvyDegree();
     aNumber[i-1]=i-1;
   };
   for (i=1; i<=nbStore; i++) {

--- a/src/formats/bgfformat.cpp
+++ b/src/formats/bgfformat.cpp
@@ -265,7 +265,7 @@ namespace OpenBabel
     OBAtom *nbr;
     vector<OBBond*>::iterator j;
     for (atom = mol.BeginAtom(i);atom;atom = mol.NextAtom(i))
-      if (atom->GetValence())
+      if (atom->GetExplicitDegree())
         {
           snprintf(buffer,BUFF_SIZE,"CONECT%6d",atom->GetIdx());
           ofs << buffer;

--- a/src/formats/chem3dformat.cpp
+++ b/src/formats/chem3dformat.cpp
@@ -305,7 +305,7 @@ namespace OpenBabel
                      mol_typ,atom->GetIdx(),atom->GetType());
             obErrorLog.ThrowError(__FUNCTION__, buffer, obInfo);
             atnum = atom->GetAtomicNum();
-            type_num = atnum * 10 + atom->GetValence();
+            type_num = atnum * 10 + atom->GetExplicitDegree();
             snprintf(type_name, sizeof(type_num), "%d",type_num);
           }
         strncpy(ele_type, OBElements::GetSymbol(atom->GetAtomicNum()), sizeof(ele_type));

--- a/src/formats/cifformat.cpp
+++ b/src/formats/cifformat.cpp
@@ -1334,7 +1334,7 @@ namespace OpenBabel
     FOR_ATOMS_OF_MOL(atom, *mol) {
 
       if ((atom->GetAtomicNum() == 7 || atom->GetAtomicNum() == 15)
-          && atom->BOSum() == 4) {
+          && atom->GetExplicitValence() == 4) {
         // check if we should make a positive charge?
         // i.e., 4 non-metal neighbors
         bool nonMetalNeighbors = true;
@@ -1361,7 +1361,7 @@ namespace OpenBabel
         continue;
 
       // If we're connected to anything besides H2O, keep going
-      if (atom->GetValence() != 0) {
+      if (atom->GetExplicitDegree() != 0) {
         int nonWaterBonds = 0;
         FOR_NBORS_OF_ATOM(neighbor, &*atom) {
           if (!CIFisWaterOxygen(&*neighbor)) {

--- a/src/formats/hinformat.cpp
+++ b/src/formats/hinformat.cpp
@@ -196,7 +196,7 @@ namespace OpenBabel
                 atom->GetX(),
                 atom->GetY(),
                 atom->GetZ(),
-                atom->GetValence());
+                atom->GetExplicitDegree());
         ofs << buffer;
         for (bond = atom->BeginBond(j); bond; bond = atom->NextBond(j))
           {

--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -976,7 +976,7 @@ namespace OpenBabel
   {
     FOR_ATOMS_OF_MOL(atom, mol) {
       if ((atom->GetAtomicNum() == OBElements::Carbon || atom->GetAtomicNum() == OBElements::Nitrogen)
-          && atom->GetHvyValence() > 2
+          && atom->GetHvyDegree() > 2
           && atom->IsChiral())
         return true;
     }
@@ -1158,7 +1158,7 @@ namespace OpenBabel
           stereo = parity[atom];
 
         
-        int expval = atom->BOSum();
+        int expval = atom->GetExplicitValence();
         int impval = MDLValence(atom->GetAtomicNum(), atom->GetFormalCharge(), expval);
         int actual_impval = expval + atom->GetImplicitHCount();
         int valence;
@@ -1259,8 +1259,8 @@ namespace OpenBabel
             zchs.push_back(make_pair(origatom->GetIdx(), origatom->GetFormalCharge()));
           }
           int hcount = atom->ExplicitHydrogenCount() + atom->GetImplicitHCount();
-          int autohcount = HYDValence(origatom->GetAtomicNum(), origatom->GetFormalCharge(), origatom->BOSum())
-                             - origatom->BOSum() + atom->ExplicitHydrogenCount();
+          int autohcount = HYDValence(origatom->GetAtomicNum(), origatom->GetFormalCharge(), origatom->GetExplicitValence())
+                             - origatom->GetExplicitValence() + atom->ExplicitHydrogenCount();
           if (hcount != autohcount) {
             hyds.push_back(make_pair(origatom->GetIdx(), atom->GetImplicitHCount()));
           }

--- a/src/formats/mmodformat.cpp
+++ b/src/formats/mmodformat.cpp
@@ -252,7 +252,7 @@ namespace OpenBabel
             snprintf(buffer, BUFF_SIZE, " %5d %1d",nbr->GetIdx(),(*j)->GetBondOrder());
             ofs << buffer;
           }
-        for (k=atom->GetValence();k < 6;k++)
+        for (k=atom->GetExplicitDegree();k < 6;k++)
           {
             snprintf(buffer, BUFF_SIZE," %5d %1d",0,0);
             ofs << buffer;

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -109,10 +109,6 @@ namespace OpenBabel
     return(true);
   }
 
-  static unsigned int TotalNumberOfBonds(OBAtom* atom)
-  {
-    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
-  }
   static bool IsOxygenOrSulfur(OBAtom *atom)
   {
     switch (atom->GetAtomicNum()) {
@@ -437,7 +433,7 @@ namespace OpenBabel
 
     if (has_explicit_hydrogen) {
       FOR_ATOMS_OF_MOL(atom, mol) {
-        unsigned int total_valence = TotalNumberOfBonds(&*atom);
+        unsigned int total_valence = atom->GetTotalDegree();
         switch (atom->GetAtomicNum()) {
         case 8:
           if (total_valence != 1) continue;
@@ -464,7 +460,7 @@ namespace OpenBabel
       FOR_ATOMS_OF_MOL(atom, mol) {
         OBAtom* oxygenOrSulfur = &*atom;
         // Look first for a terminal O/S
-        if (!IsOxygenOrSulfur(oxygenOrSulfur) || TotalNumberOfBonds(oxygenOrSulfur) != 1) continue;
+        if (!IsOxygenOrSulfur(oxygenOrSulfur) || oxygenOrSulfur->GetTotalDegree() != 1) continue;
         OBAtomBondIter bitA(oxygenOrSulfur);
         OBBond *bondA = &*bitA;
         if (!bondA->IsAromatic()) continue;
@@ -477,7 +473,7 @@ namespace OpenBabel
         FOR_BONDS_OF_ATOM(bitB, carbon) {
           if (&*bitB == bondA || !bitB->IsAromatic()) continue;
           OBAtom* nbr = bitB->GetNbrAtom(carbon);
-          if (IsOxygenOrSulfur(nbr) && TotalNumberOfBonds(nbr) == 1) {
+          if (IsOxygenOrSulfur(nbr) && nbr->GetTotalDegree() == 1) {
             otherOxygenOrSulfur = nbr;
             bondB = &*bitB;
           }

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -85,7 +85,7 @@ namespace OpenBabel
   {
     if (queryatom->GetAtomicNum() != OBElements::Sulfur)
       return(false);
-    if (queryatom->GetHvyValence() != 1)
+    if (queryatom->GetHvyDegree() != 1)
       return(false);
 
     OBAtom *atom = NULL;
@@ -111,7 +111,7 @@ namespace OpenBabel
 
   static unsigned int TotalNumberOfBonds(OBAtom* atom)
   {
-    return atom->GetImplicitHCount() + atom->GetValence();
+    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
   }
   static bool IsOxygenOrSulfur(OBAtom *atom)
   {

--- a/src/formats/pcmodelformat.cpp
+++ b/src/formats/pcmodelformat.cpp
@@ -212,7 +212,7 @@ namespace OpenBabel
         ofs << "AT " << atom->GetIdx() << "," << type << ":";
         ofs << atom->GetX() << "," << atom->GetY() << "," << atom->GetZ();
 
-        if (atom->GetValence() > 0)
+        if (atom->GetExplicitDegree() > 0)
           {
             ofs << " B";
             for (nbr = atom->BeginNbrAtom(j);nbr;nbr = atom->NextNbrAtom(j))

--- a/src/formats/pdbformat.cpp
+++ b/src/formats/pdbformat.cpp
@@ -761,7 +761,7 @@ namespace OpenBabel
     for (i = 1; i <= mol.NumAtoms(); i ++)
       {
         atom = mol.GetAtom(i);
-        if (atom->GetValence() == 0)
+        if (atom->GetExplicitDegree() == 0)
           continue; // no need to write a CONECT record -- no bonds
 
         // Write out up to 4 real bonds per line PR#1711154

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -694,7 +694,7 @@ namespace OpenBabel
 
   static unsigned int TotalNumberOfBonds(OBAtom* atom)
   {
-    return atom->GetImplicitHCount() + atom->GetValence();
+    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
   }
 
   static bool IsAmidine(OBBond* querybond)
@@ -740,7 +740,7 @@ namespace OpenBabel
     if ( the_bond->GetBondOrder() != 1 || the_bond->IsAromatic() || 
          the_bond->IsAmide() || IsAmidine(the_bond) || the_bond->IsInRing() )
       return false;
-    if ( ((the_bond->GetBeginAtom())->GetValence() == 1) || ((the_bond->GetEndAtom())->GetValence() == 1) ) {return false;}
+    if ( ((the_bond->GetBeginAtom())->GetExplicitDegree() == 1) || ((the_bond->GetEndAtom())->GetExplicitDegree() == 1) ) {return false;}
     return true;
   }
 

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -692,11 +692,6 @@ namespace OpenBabel
     return(false);
   }
 
-  static unsigned int TotalNumberOfBonds(OBAtom* atom)
-  {
-    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
-  }
-
   static bool IsAmidine(OBBond* querybond)
   {
     OBAtom *c, *n;
@@ -717,7 +712,7 @@ namespace OpenBabel
     }
     if (!c || !n) return(false);
     if (querybond->GetBondOrder() != 1) return(false);
-    if (TotalNumberOfBonds(n) != 3) return false; // must be a degree 3 nitrogen
+    if (n->GetTotalDegree() != 3) return false; // must be a degree 3 nitrogen
 
     // Make sure C is attached to =N
     OBBond *bond;

--- a/src/formats/pqrformat.cpp
+++ b/src/formats/pqrformat.cpp
@@ -570,7 +570,7 @@ namespace OpenBabel
     for (i = 1; i <= mol.NumAtoms(); i ++)
       {
         atom = mol.GetAtom(i);
-        if (atom->GetValence() == 0)
+        if (atom->GetExplicitDegree() == 0)
           continue; // no need to write a CONECT record -- no bonds
 
         snprintf(buffer, BUFF_SIZE, "CONECT%5d", i);
@@ -591,7 +591,7 @@ namespace OpenBabel
           }
 
         // Add trailing spaces
-        int remainingValence = atom->GetValence() % 4;
+        int remainingValence = atom->GetExplicitDegree() % 4;
         for (int count = 0; count < (4 - remainingValence); count++) {
           snprintf(buffer, BUFF_SIZE, "     ");
           ofs << buffer;

--- a/src/formats/reportformat.cpp
+++ b/src/formats/reportformat.cpp
@@ -196,7 +196,7 @@ namespace OpenBabel
   {
     FOR_ATOMS_OF_MOL(atom, mol) {
       if ((atom->GetAtomicNum() == OBElements::Carbon || atom->GetAtomicNum() == OBElements::Nitrogen)
-        && atom->GetHvyValence() > 2
+        && atom->GetHvyDegree() > 2
         && atom->IsChiral())
         return true;
     }

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -777,8 +777,8 @@ namespace OpenBabel {
       // Note: In theory, we could relax the second requirement but we would
       //       need to change the data structure we use to store cis/trans
       //       stereo to only store 2 refs instead of 4
-      int v1 = a1->GetValence();
-      int v2 = a2->GetValence();
+      int v1 = a1->GetExplicitDegree();
+      int v2 = a2->GetExplicitDegree();
       if (v1 < 2 || v1 > 3 || v2 < 2 || v2 > 3) {
         continue;
       }
@@ -2151,7 +2151,7 @@ namespace OpenBabel {
   // to insert an atom ID into atom4refs
   int OBSmilesParser::NumConnections(OBAtom *atom, bool isImplicitRef)
   {
-    int val = atom->GetValence();
+    int val = atom->GetExplicitDegree();
     // The implicit H is not included in "val" so we need to adjust by 1
     if (isImplicitRef)
       return val+1;
@@ -2663,7 +2663,7 @@ namespace OpenBabel {
     // Don't suppress any explicit Hs attached if the atom is an H itself (e.g. [H][H]) or -xh was specified
     if (atom->GetAtomicNum() != OBElements::Hydrogen && !options.showexplicitH) {
       FOR_NBORS_OF_ATOM(nbr, atom) {
-        if (nbr->GetAtomicNum() == OBElements::Hydrogen && (!options.isomeric || nbr->GetIsotope() == 0) && nbr->GetValence() == 1 &&
+        if (nbr->GetAtomicNum() == OBElements::Hydrogen && (!options.isomeric || nbr->GetIsotope() == 0) && nbr->GetExplicitDegree() == 1 &&
           nbr->GetFormalCharge() == 0 && (!options.showatomclass || !nbr->GetData("Atom Class")))
           numExplicitHsToSuppress++;
       }
@@ -2684,7 +2684,7 @@ namespace OpenBabel {
             bracketElement = true;
         }
         else {
-          int bosum = atom->BOSum() - numExplicitHsToSuppress;
+          int bosum = atom->GetExplicitValence() - numExplicitHsToSuppress;
           unsigned int implicitValence = SmilesValence(element, bosum, false);
           unsigned int defaultNumImplicitHs = implicitValence - bosum;
           if (implicitValence == 0 // hypervalent
@@ -3286,7 +3286,7 @@ namespace OpenBabel {
   {
     if (atom->GetIsotope() != 0)          // Deuterium or Tritium
       return false;
-    if (atom->GetValence() != 1)          // not exactly one bond
+    if (atom->GetExplicitDegree() != 1)          // not exactly one bond
       return false;
 
     FOR_NBORS_OF_ATOM(nbr, atom) {
@@ -3301,7 +3301,7 @@ namespace OpenBabel {
    * FUNCTION: GetSmilesValence
    *
    * DESCRIPTION:
-   *       This is like GetHvyValence(), but it returns the "valence" of an
+   *       This is like GetHvyDegree(), but it returns the "valence" of an
    *       atom as it appears in the SMILES string.  In particular, hydrogens
    *       count if they will appear explicitly -- see IsSuppressedHydrogen()
    *       above.
@@ -3312,15 +3312,15 @@ namespace OpenBabel {
     int count = 0;
 
     if (atom->GetAtomicNum() == OBElements::Hydrogen)
-      return atom->GetValence();
+      return atom->GetExplicitDegree();
 
     if (options.showexplicitH)
-      return atom->GetValence();
+      return atom->GetExplicitDegree();
 
     FOR_NBORS_OF_ATOM(nbr, atom) {
       if (nbr->GetAtomicNum() != OBElements::Hydrogen
             || nbr->GetIsotope() != 0
-            || nbr->GetValence() != 1)
+            || nbr->GetExplicitDegree() != 1)
         count++;
     }
     return(count);
@@ -3922,13 +3922,13 @@ namespace OpenBabel {
         // For Inchified or Universal SMILES, if the start atom is an [O-] attached to atom X, choose any =O attached to X instead.
         //          Ditto for [S-] and =S.
         if ((_pconv->IsOption("I") || universal_smiles)
-             && root_atom && root_atom->GetFormalCharge()==-1  && root_atom->GetValence() == 1
+             && root_atom && root_atom->GetFormalCharge()==-1  && root_atom->GetExplicitDegree() == 1
              && root_atom->HasSingleBond() && (root_atom->GetAtomicNum() == OBElements::Oxygen || root_atom->GetAtomicNum() == OBElements::Sulfur)) {
           OBBondIterator bi = root_atom->BeginBonds();
           OBAtom* central = root_atom->BeginNbrAtom(bi);
           FOR_NBORS_OF_ATOM(nbr, central) {
             if (root_atom == &*nbr) continue;
-            if (nbr->GetAtomicNum() == root_atom->GetAtomicNum() && nbr->GetValence() == 1 && nbr->HasDoubleBond()) {
+            if (nbr->GetAtomicNum() == root_atom->GetAtomicNum() && nbr->GetExplicitDegree() == 1 && nbr->HasDoubleBond()) {
               root_atom = &*nbr;
               break;
             }

--- a/src/formats/smileyformat.cpp
+++ b/src/formats/smileyformat.cpp
@@ -469,8 +469,8 @@ namespace OpenBabel
 
       // Check that both atoms on the double bond have at least one
       // other neighbor, but not more than two other neighbors;
-      int v1 = source->GetValence();
-      int v2 = target->GetValence();
+      int v1 = source->GetExplicitDegree();
+      int v2 = target->GetExplicitDegree();
       if (v1 < 2 || v1 > 3 || v2 < 2 || v2 > 3)
         continue;
 

--- a/src/formats/tinkerformat.cpp
+++ b/src/formats/tinkerformat.cpp
@@ -271,7 +271,7 @@ namespace OpenBabel
       if (b->GetAtomicNum() == OBElements::Nitrogen) {
         if (b->IsAmideNitrogen())
           return 28;
-        if (b->GetValence() > 3)
+        if (b->GetExplicitDegree() > 3)
           return 48;// ammonium
         return 23; // default amine/imine
       }
@@ -293,7 +293,7 @@ namespace OpenBabel
       return 163; break;
 
     case 5: // B
-      if (atom->GetValence() >= 4)
+      if (atom->GetExplicitDegree() >= 4)
         return 27; // tetrahedral
       return 26; break;
 
@@ -356,7 +356,7 @@ namespace OpenBabel
         return 46;
 
       if (atom->GetHyb() == 3) {
-        if (atom->GetValence() > 3)
+        if (atom->GetExplicitDegree() > 3)
           return 39; // ammonium
         return 8;
       }
@@ -397,7 +397,7 @@ namespace OpenBabel
     case 15: // P
       if (atom->CountFreeOxygens() > 0)
         return 153; // phosphate
-      if (atom->BOSum() > 3)
+      if (atom->GetExplicitValence() > 3)
         return 60; // phosphorus V
       return 25; break;
 
@@ -417,7 +417,7 @@ namespace OpenBabel
         case 7:
           countNeighborN++; break;
         case 8:
-          if (b->GetHvyValence() == 1)
+          if (b->GetHvyDegree() == 1)
             countNeighborO++;
           break;
         case 16:

--- a/src/graphsym.cpp
+++ b/src/graphsym.cpp
@@ -79,7 +79,7 @@ namespace OpenBabel {
       std::vector<unsigned int> _canonLabels;
       OBStereoUnitSet _stereoUnits;
 
-      unsigned int GetHvyValence(OBAtom *atom);
+      unsigned int GetHvyDegree(OBAtom *atom);
       unsigned int GetHvyBondSum(OBAtom *atom);
       void FindRingAtoms(OBBitVec &ring_atoms);
       void CreateNewClassVector(std::vector<std::pair<OBAtom*,unsigned int> > &vp1,
@@ -134,10 +134,10 @@ namespace OpenBabel {
 
 
   /**
-   * Like OBAtom::GetHvyValence(): Counts the number non-hydrogen
+   * Like OBAtom::GetHvyDegree(): Counts the number non-hydrogen
    * neighbors, but doesn't count atoms not in the fragment.
    */
-  unsigned int OBGraphSymPrivate::GetHvyValence(OBAtom *atom)
+  unsigned int OBGraphSymPrivate::GetHvyDegree(OBAtom *atom)
   {
     unsigned int count = 0;
     OBBond *bond;
@@ -155,7 +155,7 @@ namespace OpenBabel {
 
   static unsigned int TotalNumberOfBonds(OBAtom* atom)
   {
-    return atom->GetImplicitHCount() + atom->GetValence();
+    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
   }
 
   /**
@@ -319,7 +319,7 @@ namespace OpenBabel {
       if (_frag_atoms.BitIsSet(atom->GetIdx())) {
         vid[i] =
           v[i]                                                    // 10 bits: graph-theoretical distance
-          | (GetHvyValence(atom)                <<10)  //  4 bits: heavy valence
+          | (GetHvyDegree(atom)                <<10)  //  4 bits: heavy valence
           | (((atom->IsAromatic()) ? 1 : 0)                <<14)  //  1 bit:  aromaticity
           | (((ring_atoms.BitIsSet(atom->GetIdx())) ? 1 : 0)<<15)  //  1 bit:  ring atom
           | (atom->GetAtomicNum()                          <<16)  //  7 bits: atomic number

--- a/src/graphsym.cpp
+++ b/src/graphsym.cpp
@@ -153,11 +153,6 @@ namespace OpenBabel {
     return(count);
   }
 
-  static unsigned int TotalNumberOfBonds(OBAtom* atom)
-  {
-    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
-  }
-
   /**
    * Sums the bond order over the bonds from this atom to other atoms
    * in the fragment.  Single = 1, double = 2, triple = 3, aromatic = 1.6,
@@ -185,7 +180,7 @@ namespace OpenBabel {
           count += (float)bond->GetBondOrder();
       }
     }
-    if (atom->GetAtomicNum() == 7 && atom->IsAromatic() && TotalNumberOfBonds(atom) == 3) {
+    if (atom->GetAtomicNum() == 7 && atom->IsAromatic() && atom->GetTotalDegree() == 3) {
       count += 1.0f;         // [nH] - add another bond
     }
     return(int(count + 0.5));     // round to nearest int

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -64,22 +64,17 @@ namespace OpenBabel
     std::vector<unsigned int> m_path;
   };
 
-  static unsigned int TotalNumberOfBonds(OBAtom* atom)
-  {
-    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
-  }
-
   static bool IsSpecialCase(OBAtom* atom)
   {
     switch(atom->GetAtomicNum()) {
     case 7:
       // Any exo-cyclic double bond from a N
       // e.g. pyridine N-oxide as the double bond form
-      if (TotalNumberOfBonds(atom) == 3 && atom->GetFormalCharge() == 0)
+      if (atom->GetTotalDegree() == 3 && atom->GetFormalCharge() == 0)
         return true;
       break;
     case 16: // e.g. Cs1(=O)ccccn1
-      if (TotalNumberOfBonds(atom) == 4 && atom->GetFormalCharge() == 0)
+      if (atom->GetTotalDegree() == 4 && atom->GetFormalCharge() == 0)
         return true;
       break;
     }
@@ -109,7 +104,7 @@ namespace OpenBabel
 
     // Is it one of the cases where we know that it only has single bonds?
     int chg = atom->GetFormalCharge();
-    int deg = TotalNumberOfBonds(atom);
+    int deg = atom->GetTotalDegree();
     switch (atom->GetAtomicNum()) {
     case 6:
       if (deg == 3 && (chg == 1 || chg == -1))

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -66,7 +66,7 @@ namespace OpenBabel
 
   static unsigned int TotalNumberOfBonds(OBAtom* atom)
   {
-    return atom->GetImplicitHCount() + atom->GetValence();
+    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
   }
 
   static bool IsSpecialCase(OBAtom* atom)

--- a/src/molchrg.cpp
+++ b/src/molchrg.cpp
@@ -151,7 +151,7 @@ namespace OpenBabel
         if (atom->IsCarboxylOxygen())
           atom->SetPartialCharge(-0.500);
         else if (atom->IsPhosphateOxygen() &&
-                 atom->GetHvyValence() == 1)
+                 atom->GetHvyDegree() == 1)
           atom->SetPartialCharge(-0.666);
         else if (atom->IsSulfateOxygen())
           atom->SetPartialCharge(-0.500);
@@ -195,7 +195,7 @@ namespace OpenBabel
       case 7: //N
         if (atom->GetHyb() == 3)
           {
-            if (atom->GetValence() == 4 || atom->GetFormalCharge())
+            if (atom->GetExplicitDegree() == 4 || atom->GetFormalCharge())
               {
                 val[0] = 0.0;
                 val[1] = 0.0;

--- a/src/obfunctions.cpp
+++ b/src/obfunctions.cpp
@@ -939,7 +939,7 @@ namespace OpenBabel
   // Set the count of implicit hydrogens according to typical valences.
   void OBAtomAssignTypicalImplicitHydrogens(OBAtom* atom)
   {
-    unsigned int bosum = atom->BOSum();
+    unsigned int bosum = atom->GetExplicitValence();
     unsigned int valence = GetTypicalValence(atom->GetAtomicNum(), bosum, atom->GetFormalCharge());
     atom->SetImplicitHCount(valence - bosum);
   }

--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -35,7 +35,7 @@ namespace OpenBabel
 {
   static unsigned int TotalNumberOfBonds(OBAtom* atom)
   {
-    return atom->GetImplicitHCount() + atom->GetValence();
+    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
   }
 
   /*! \class OBSmartsPattern parsmart.h <openbabel/parsmart.h>
@@ -2146,7 +2146,7 @@ namespace OpenBabel
         case AE_CONNECT:
           return expr->leaf.value == (int)TotalNumberOfBonds(atom);
         case AE_DEGREE:
-          return expr->leaf.value == (int)atom->GetValence();
+          return expr->leaf.value == (int)atom->GetExplicitDegree();
         case AE_IMPLICIT:
           return expr->leaf.value == (int)atom->GetImplicitHCount();
         case AE_RINGS:
@@ -2154,7 +2154,7 @@ namespace OpenBabel
         case AE_SIZE:
           return atom->IsInRingSize(expr->leaf.value);
         case AE_VALENCE:
-          return expr->leaf.value == (int)(atom->BOSum() + atom->GetImplicitHCount());
+          return expr->leaf.value == (int)(atom->GetExplicitValence() + atom->GetImplicitHCount());
         case AE_CHIRAL:
           // always return true (i.e. accept the match) and check later
           return true;

--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -33,11 +33,6 @@ using namespace std;
 
 namespace OpenBabel
 {
-  static unsigned int TotalNumberOfBonds(OBAtom* atom)
-  {
-    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
-  }
-
   /*! \class OBSmartsPattern parsmart.h <openbabel/parsmart.h>
 
     Substructure search is an incredibly useful tool in the context of a
@@ -2144,7 +2139,7 @@ namespace OpenBabel
         case AE_CHARGE:
           return expr->leaf.value == atom->GetFormalCharge();
         case AE_CONNECT:
-          return expr->leaf.value == (int)TotalNumberOfBonds(atom);
+          return expr->leaf.value == (int)atom->GetTotalDegree();
         case AE_DEGREE:
           return expr->leaf.value == (int)atom->GetExplicitDegree();
         case AE_IMPLICIT:
@@ -2154,7 +2149,7 @@ namespace OpenBabel
         case AE_SIZE:
           return atom->IsInRingSize(expr->leaf.value);
         case AE_VALENCE:
-          return expr->leaf.value == (int)(atom->GetExplicitValence() + atom->GetImplicitHCount());
+          return expr->leaf.value == (int)atom->GetTotalValence();
         case AE_CHIRAL:
           // always return true (i.e. accept the match) and check later
           return true;

--- a/src/ring.cpp
+++ b/src/ring.cpp
@@ -627,15 +627,15 @@ namespace OpenBabel
         OBAtom *atom = mol->GetAtom(*i);
         switch (atom->GetAtomicNum()) {
         case OBElements::Sulfur:
-          if (atom->GetValence() == 2)
+          if (atom->GetExplicitDegree() == 2)
             return (*i);
           break;
         case OBElements::Oxygen:
-          if (atom->GetValence() == 2)
+          if (atom->GetExplicitDegree() == 2)
             return (*i);
           break;
         case OBElements::Nitrogen:
-          if (atom->BOSum() == atom->GetValence())
+          if (atom->GetExplicitValence() == atom->GetExplicitDegree())
             return (*i);
           break;
         }

--- a/src/rotor.cpp
+++ b/src/rotor.cpp
@@ -263,7 +263,7 @@ namespace OpenBabel
         }
 
         for (unsigned int hyb=2; hyb<=3; ++hyb) { // sp2 and sp3 carbons, with explicit Hs
-          if (this_side->GetAtomicNum() == 6 && this_side->GetHyb() == hyb && this_side->GetValence() == (hyb + 1) ) {
+          if (this_side->GetAtomicNum() == 6 && this_side->GetHyb() == hyb && this_side->GetExplicitDegree() == (hyb + 1) ) {
             syms.clear();
             FOR_NBORS_OF_ATOM(nbr, this_side) {
               if ( &(*nbr) == other_side ) continue;

--- a/src/spectrophore.cpp
+++ b/src/spectrophore.cpp
@@ -1645,7 +1645,7 @@ OBSpectrophore::_calculateProperties(OpenBabel::OBMol* mol)
       switch (n)
       {
          case 1:		// H
-            if (atom->GetValence())
+            if (atom->GetExplicitDegree())
             {
                if (atom->IsNonPolarHydrogen())
                // Non-polar H

--- a/src/stereo/cistrans.cpp
+++ b/src/stereo/cistrans.cpp
@@ -245,10 +245,10 @@ namespace OpenBabel {
         // b atom not found, could be a deleted hydrogen...
         if (a->IsConnected(begin)) {
           // a is connected to begin. if this is the atom missing a hydrogen, return false
-          if (begin->GetValence() == 2)
+          if (begin->GetExplicitDegree() == 2)
             return true;
           // check if the end atom really is missing an atom
-          if (end->GetValence() != 2) {
+          if (end->GetExplicitDegree() != 2) {
             obErrorLog.ThrowError(__FUNCTION__,
                 "OBCisTransStereo::IsOnSameAtom : id2 is not valid and is not a missing hydrogen.", obError);
             return false;
@@ -258,10 +258,10 @@ namespace OpenBabel {
               "OBCisTransStereo::IsOnSameAtom : Atom with id2 doesn't exist anymore, must be a (deleted) hydrogen.", obInfo);
         } else if (a->IsConnected(end)) {
           // a is connected to end. again, if this is the atom missing a hydrogen, return false
-          if (end->GetValence() == 2)
+          if (end->GetExplicitDegree() == 2)
             return true;
           // check if the begin atom really is missing an atom
-          if (begin->GetValence() != 2) {
+          if (begin->GetExplicitDegree() != 2) {
             obErrorLog.ThrowError(__FUNCTION__,
                 "OBCisTransStereo::IsOnSameAtom : id2 is not valid and is not a missing hydrogen.", obError);
             return true;
@@ -279,10 +279,10 @@ namespace OpenBabel {
         // a atom not found, could be a deleted hydrogen...
         if (b->IsConnected(begin)) {
           // b is connected to begin. if this is the atom missing a hydrogen, return false
-          if (begin->GetValence() == 2)
+          if (begin->GetExplicitDegree() == 2)
             return true;
           // check if the end atom really is missing an atom
-          if (end->GetValence() != 2) {
+          if (end->GetExplicitDegree() != 2) {
             obErrorLog.ThrowError(__FUNCTION__,
                 "OBCisTransStereo::IsOnSameAtom : id1 is not valid and is not a missing hydrogen.", obError);
             return true;
@@ -292,10 +292,10 @@ namespace OpenBabel {
               "OBCisTransStereo::IsOnSameAtom : Atom with id1 doesn't exist, must be a (deleted) hydrogen.", obInfo);
         } else if (b->IsConnected(end)) {
           // a is connected to end. again, if this is the atom missing a hydrogen, return false
-          if (end->GetValence() == 2)
+          if (end->GetExplicitDegree() == 2)
             return true;
           // check if the begin atom really is missing an atom
-          if (begin->GetValence() != 2) {
+          if (begin->GetExplicitDegree() != 2) {
             obErrorLog.ThrowError(__FUNCTION__,
                 "OBCisTransStereo::IsOnSameAtom : id1 is not valid and is not a missing hydrogen.", obError);
             return true;
@@ -324,7 +324,7 @@ namespace OpenBabel {
           obErrorLog.ThrowError(__FUNCTION__, "OBCisTransStereo::IsOnSameAtom : invalid stereochemistry!", obError);
           return true;
         }
-        if ((begin->GetValence() != 2) || (end->GetValence() != 2)) {
+        if ((begin->GetExplicitDegree() != 2) || (end->GetExplicitDegree() != 2)) {
           obErrorLog.ThrowError(__FUNCTION__, "OBCisTransStereo::IsOnSameAtom : invalid stereochemistry!", obError);
           return true;
         }

--- a/src/stereo/perception.cpp
+++ b/src/stereo/perception.cpp
@@ -100,7 +100,7 @@ namespace OpenBabel {
   {
     std::vector<OBAtom*>::iterator ia;
     for (OBAtom *atom = mol->BeginAtom(ia); atom; atom = mol->NextAtom(ia))
-      if (atom->GetHyb() == 3 && atom->GetHvyValence() >= 3) {
+      if (atom->GetHyb() == 3 && atom->GetHvyDegree() >= 3) {
         return true;
       }
     return false;
@@ -122,7 +122,7 @@ namespace OpenBabel {
 
   static unsigned int TotalNoOfBonds(OBAtom* atom)
   {
-    return atom->GetImplicitHCount() + atom->GetValence();
+    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
   }
 
   /**
@@ -142,7 +142,7 @@ namespace OpenBabel {
   {
     // consider only potential steroecenters
     if ((atom->GetHyb() != 3 && !(atom->GetHyb() == 5 && atom->GetAtomicNum() == OBElements::Phosphorus))
-        || TotalNoOfBonds(atom) > 4 || atom->GetHvyValence() < 3 || atom->GetHvyValence() > 4)
+        || TotalNoOfBonds(atom) > 4 || atom->GetHvyDegree() < 3 || atom->GetHvyDegree() > 4)
       return false;
     // skip non-chiral N
     if (atom->GetAtomicNum() == OBElements::Nitrogen && atom->GetFormalCharge()==0) {
@@ -158,7 +158,7 @@ namespace OpenBabel {
       if (atom->GetFormalCharge())
         return false;
       FOR_NBORS_OF_ATOM (nbr, atom) {
-        if (nbr->GetAtomicNum() == 26 && nbr->GetValence() > 7)
+        if (nbr->GetAtomicNum() == 26 && nbr->GetExplicitDegree() > 7)
           return false;
       }
     }
@@ -182,9 +182,9 @@ namespace OpenBabel {
       return false;
     if (!bond->GetBeginAtom()->HasSingleBond() || !bond->GetEndAtom()->HasSingleBond())
       return false;
-    if (bond->GetBeginAtom()->GetHvyValence() == 1 || bond->GetEndAtom()->GetHvyValence() == 1)
+    if (bond->GetBeginAtom()->GetHvyDegree() == 1 || bond->GetEndAtom()->GetHvyDegree() == 1)
       return false;
-    if (bond->GetBeginAtom()->GetHvyValence() > 3 || bond->GetEndAtom()->GetHvyValence() > 3)
+    if (bond->GetBeginAtom()->GetHvyDegree() > 3 || bond->GetEndAtom()->GetHvyDegree() > 3)
       return false;
     return true;
   }
@@ -787,14 +787,14 @@ namespace OpenBabel {
         isCisTransBond = true;
         std::vector<OBBond*>::iterator j;
 
-        if (begin->GetValence() == 2) {
+        if (begin->GetExplicitDegree() == 2) {
           // Begin atom has two explicit neighbors. One is the end atom. The other should
           // be a heavy atom - this is what we test here.
           // (There is a third, implicit, neighbor which is either a hydrogen
           // or a lone pair.)
           if (begin->ExplicitHydrogenCount() == 1)
             isCisTransBond = false;
-        } else if (begin->GetValence() == 3) {
+        } else if (begin->GetExplicitDegree() == 3) {
           std::vector<unsigned int> tlist;
 
           for (OBAtom *nbr = begin->BeginNbrAtom(j); nbr; nbr = begin->NextNbrAtom(j)) {
@@ -823,11 +823,11 @@ namespace OpenBabel {
         if (!isCisTransBond)
           continue;
 
-        if (end->GetValence() == 2) {
+        if (end->GetExplicitDegree() == 2) {
           // see comment above for begin atom
           if (end->ExplicitHydrogenCount() == 1)
             isCisTransBond = false;
-        } else if (end->GetValence() == 3) {
+        } else if (end->GetExplicitDegree() == 3) {
           std::vector<unsigned int> tlist;
 
           for (OBAtom *nbr = end->BeginNbrAtom(j); nbr; nbr = end->NextNbrAtom(j)) {
@@ -2117,10 +2117,10 @@ namespace OpenBabel {
 
       // make sure we have at least 3 heavy atom neighbors
       // timvdm 28 Jun 2009: This is already checked in FindStereogenicUnits
-      if (center->GetHvyValence() < 3) {
+      if (center->GetHvyDegree() < 3) {
         std::stringstream errorMsg;
         errorMsg << "Cannot calculate a signed volume for an atom with a heavy atom valence of "
-                 << center->GetHvyValence() << std::endl;
+                 << center->GetHvyDegree() << std::endl;
         obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obInfo);
         continue;
       }
@@ -2356,10 +2356,10 @@ namespace OpenBabel {
       OBAtom *center = mol->GetAtomById(*i);
 
       // make sure we have at least 3 heavy atom neighbors
-      if (center->GetHvyValence() < 3) {
+      if (center->GetHvyDegree() < 3) {
         std::stringstream errorMsg;
         errorMsg << "Cannot calculate a signed volume for an atom with a heavy atom valence of "
-                 << center->GetHvyValence() << std::endl;
+                 << center->GetHvyDegree() << std::endl;
         obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obInfo);
         continue;
       }
@@ -2417,7 +2417,7 @@ namespace OpenBabel {
 
       // Handle the case of a tet center with four plane atoms or
       //        3 plane atoms with the fourth bond implicit
-      if (planeAtoms.size() == 4 || (planeAtoms.size() == 3 && center->GetValence()==3))
+      if (planeAtoms.size() == 4 || (planeAtoms.size() == 3 && center->GetExplicitDegree()==3))
         config.specified = false;
 
       bool success = true;
@@ -2770,7 +2770,7 @@ namespace OpenBabel {
             if (alreadyset.find(&*b) != alreadyset.end()) continue;
 
             OBAtom* nbr = b->GetNbrAtom(center);
-	    int nbr_nbonds = nbr->GetValence();
+	    int nbr_nbonds = nbr->GetExplicitDegree();
             int score = 0;
             if (!b->IsInRing()) {
 	      if (!nbr->IsInRing())

--- a/src/stereo/perception.cpp
+++ b/src/stereo/perception.cpp
@@ -120,11 +120,6 @@ namespace OpenBabel {
     return false;
   }
 
-  static unsigned int TotalNoOfBonds(OBAtom* atom)
-  {
-    return atom->GetImplicitHCount() + atom->GetExplicitDegree();
-  }
-
   /**
    * Check if the specified atom is a potential stereogenic atom.
    *
@@ -142,7 +137,7 @@ namespace OpenBabel {
   {
     // consider only potential steroecenters
     if ((atom->GetHyb() != 3 && !(atom->GetHyb() == 5 && atom->GetAtomicNum() == OBElements::Phosphorus))
-        || TotalNoOfBonds(atom) > 4 || atom->GetHvyDegree() < 3 || atom->GetHvyDegree() > 4)
+        || atom->GetTotalDegree() > 4 || atom->GetHvyDegree() < 3 || atom->GetHvyDegree() > 4)
       return false;
     // skip non-chiral N
     if (atom->GetAtomicNum() == OBElements::Nitrogen && atom->GetFormalCharge()==0) {
@@ -776,7 +771,7 @@ namespace OpenBabel {
         if (!begin || !end)
           continue;
 
-        if (TotalNoOfBonds(begin) > 3 || TotalNoOfBonds(end) > 3)
+        if (begin->GetTotalDegree() > 3 || end->GetTotalDegree() > 3)
           continue; // e.g. C=Ru where the Ru has four substituents
 
         // Needs to have at least one explicit single bond at either end

--- a/src/typer.cpp
+++ b/src/typer.cpp
@@ -207,7 +207,7 @@ namespace OpenBabel
     // check all atoms to make sure *some* hybridization is assigned
     for (atom = mol.BeginAtom(k);atom;atom = mol.NextAtom(k))
       if (atom->GetHyb() == 0) {
-        switch (atom->GetValence()) {
+        switch (atom->GetExplicitDegree()) {
           case 0:
           case 1:
           case 2:
@@ -220,7 +220,7 @@ namespace OpenBabel
             atom->SetHyb(3);
             break;
           default:
-            atom->SetHyb(atom->GetValence());
+            atom->SetHyb(atom->GetExplicitDegree());
         }
       }
   }
@@ -398,8 +398,8 @@ namespace OpenBabel
 
     unsigned int elem = atm->GetAtomicNum();
     int chg = atm->GetFormalCharge();
-    unsigned int deg = atm->GetValence() + atm->GetImplicitHCount();
-    unsigned int val = atm->BOSum() + atm->GetImplicitHCount();
+    unsigned int deg = atm->GetExplicitDegree() + atm->GetImplicitHCount();
+    unsigned int val = atm->GetExplicitValence() + atm->GetImplicitHCount();
 
     switch (elem) {
     case OBElements::Carbon:
@@ -860,7 +860,7 @@ namespace OpenBabel
 
             for (nbr = atom->BeginNbrAtom(l);nbr;nbr = atom->NextNbrAtom(l))
               {
-                // we can get this from atom->GetHvyValence()
+                // we can get this from atom->GetHvyDegree()
                 // but we need to find neighbors in rings too
                 // so let's save some time
                 if (nbr->GetAtomicNum() != OBElements::Hydrogen)

--- a/test/cistranstest.cpp
+++ b/test/cistranstest.cpp
@@ -184,10 +184,10 @@ void test_IsOnSameAtom1()
   
   OB_ASSERT( mol.GetAtomById(1) );
   OB_ASSERT( mol.GetAtomById(1)->GetAtomicNum() == OBElements::Carbon );
-  OB_ASSERT( mol.GetAtomById(1)->GetValence() == 3);
+  OB_ASSERT( mol.GetAtomById(1)->GetExplicitDegree() == 3);
   OB_ASSERT( mol.GetAtomById(3) );
   OB_ASSERT( mol.GetAtomById(3)->GetAtomicNum() == OBElements::Carbon );
-  OB_ASSERT( mol.GetAtomById(3)->GetValence() == 3);
+  OB_ASSERT( mol.GetAtomById(3)->GetExplicitDegree() == 3);
 
   OB_ASSERT( mol.GetAtomById(4) );
   OB_ASSERT( mol.GetAtomById(4)->GetAtomicNum() == 9 );

--- a/test/graphsymtest.cpp
+++ b/test/graphsymtest.cpp
@@ -77,9 +77,9 @@ void genericGraphSymTest(const std::string &smiles)
       continue;
 
     OB_ASSERT( a1->GetAtomicNum() == a2->GetAtomicNum() );
-    OB_ASSERT( a1->GetValence() == a2->GetValence() );
-    OB_ASSERT( a1->GetHvyValence() == a2->GetHvyValence() );
-    OB_ASSERT( a1->GetHeteroValence() == a2->GetHeteroValence() );
+    OB_ASSERT( a1->GetExplicitDegree() == a2->GetExplicitDegree() );
+    OB_ASSERT( a1->GetHvyDegree() == a2->GetHvyDegree() );
+    OB_ASSERT( a1->GetHeteroDegree() == a2->GetHeteroDegree() );
     OB_ASSERT( a1->GetImplicitHCount() == a2->GetImplicitHCount() );
   }
 

--- a/test/shuffletest.cpp
+++ b/test/shuffletest.cpp
@@ -58,9 +58,9 @@ void compareMolecules(OBMol *mol1, OBMol *mol2)
       continue;
 
     OB_ASSERT( a1->GetAtomicNum() == a2->GetAtomicNum() );
-    OB_ASSERT( a1->GetValence() == a2->GetValence() );
-    OB_ASSERT( a1->GetHvyValence() == a2->GetHvyValence() );
-    OB_ASSERT( a1->GetHeteroValence() == a2->GetHeteroValence() );
+    OB_ASSERT( a1->GetExplicitDegree() == a2->GetExplicitDegree() );
+    OB_ASSERT( a1->GetHvyDegree() == a2->GetHvyDegree() );
+    OB_ASSERT( a1->GetHeteroDegree() == a2->GetHeteroDegree() );
     OB_ASSERT( a1->GetImplicitHCount() == a2->GetImplicitHCount() );
   }
 


### PR DESCRIPTION
The motivation is discussed at https://github.com/openbabel/enhancement-proposals/pull/9.

The OBAtom API was changed as follows:

1. BOSum -> GetExplicitValence()
2. GetValence() -> GetExplicitDegree()
3. Added GetTotalValence() and GetTotalDegree()
4. GetHvyValence() -> GetHvyDegree()
5. GetHeteroValence() -> GetHeteroDegree()

(I thought I could get rid of 4 and 5 but they are widely used.)