### PR TITLE
scripts: Fix Python bindings after move to subdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,9 @@ if(NOT MSVC)
     }
    " SCANDIR_NEEDS_CONST)
 
-  set(OB_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/${OB_PLUGIN_INSTALL_DIR}")
+  set(OB_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/${OB_PLUGIN_INSTALL_DIR}"
+      CACHE PATH "Set to system install for bindings only build")
+  add_definitions(-DOB_MODULE_PATH=${OB_MODULE_PATH})
 
   # Add some visibility support when using GCC
   # note: Altough MinGW g++ 4.4 passes this test, visibility can't be used

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ if(NOT MSVC)
 
   set(OB_MODULE_PATH "${CMAKE_INSTALL_PREFIX}/${OB_PLUGIN_INSTALL_DIR}"
       CACHE PATH "Set to system install for bindings only build")
-  add_definitions(-DOB_MODULE_PATH=${OB_MODULE_PATH})
+  add_definitions(-DOB_MODULE_PATH="${OB_MODULE_PATH}")
 
   # Add some visibility support when using GCC
   # note: Altough MinGW g++ 4.4 passes this test, visibility can't be used

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -37,7 +37,7 @@ endif()
 ###################
 
 if (PYTHON_BINDINGS)
-  if (EXISTS ${openbabel_SOURCE_DIR}/scripts/python/openbabel-python.cpp OR RUN_SWIG)
+  if (EXISTS ${openbabel_SOURCE_DIR}/scripts/python/openbabel/openbabel-python.cpp OR RUN_SWIG)
     find_package(PythonInterp)
     if (NOT PYTHONINTERP_FOUND)
       message(STATUS "Python interpreter NOT found")
@@ -57,10 +57,10 @@ if (PYTHON_BINDINGS)
       message(STATUS "Python bindings will be compiled")
     endif(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 
-  else (EXISTS ${openbabel_SOURCE_DIR}/scripts/python/openbabel-python.cpp OR RUN_SWIG)
+  else (EXISTS ${openbabel_SOURCE_DIR}/scripts/python/openbabel/openbabel-python.cpp OR RUN_SWIG)
     message(STATUS "Warning: Python bindings NOT found. Generate using -DRUN_SWIG=ON.")
 
-  endif (EXISTS ${openbabel_SOURCE_DIR}/scripts/python/openbabel-python.cpp OR RUN_SWIG)
+  endif (EXISTS ${openbabel_SOURCE_DIR}/scripts/python/openbabel/openbabel-python.cpp OR RUN_SWIG)
 endif (PYTHON_BINDINGS)
 
 if (DO_PYTHON_BINDINGS)

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -179,7 +179,9 @@
  #define SCANDIR_CONST
 #endif
 
-#define OB_MODULE_PATH "@OB_MODULE_PATH@"
+#ifndef OB_MODULE_PATH
+ #define OB_MODULE_PATH "@OB_MODULE_PATH@"
+#endif
 
 #ifndef TIME_WITH_SYS_TIME
   #ifdef HAVE_SYS_TIME


### PR DESCRIPTION
There were missed path changes in some places.

Fix tests for BINDINGS_ONLY build (OB_MODULE_PATH override is necessary to point to system installation of OB).