### PR TITLE
include babelconfig in vector3.h 

### DIFF
--- a/include/openbabel/math/vector3.h
+++ b/include/openbabel/math/vector3.h
@@ -25,6 +25,8 @@ GNU General Public License for more details.
 #include <math.h>
 #include <iostream>
 
+#include <openbabel/babelconfig.h>
+
 #ifndef RAD_TO_DEG
 #define RAD_TO_DEG (180.0/M_PI)
 #endif


### PR DESCRIPTION
vector3.h includes no other openbabel headers and so OBAPI is not defined.  This is a not a problem with user code - it is reasonable to expect a library's header files to be syntactically correct regardless of what order they are included.