### PR TITLE
Add SMILES support for elements specified by 3-digit number, e.g. [#101]

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -1677,21 +1677,18 @@ namespace OpenBabel {
         break;
 
       case '#':
-        if (_ptr[1]>='0' && _ptr[1]<='9') {
-          element = _ptr[1]-'0';
-          if (_ptr[2]>='0' && _ptr[2]<='9') {
-            element = 10*element + (_ptr[2]-'0');
-            if (_ptr[3]>='0' && _ptr[3]<='9') {
-              element = 10*element + (_ptr[3]-'0');
-              if (element > 255) {
-                std::string err = "Element number must be <= 255)";
-                obErrorLog.ThrowError(__FUNCTION__,
-                  err, obError);
-                return false;
-              }
-              _ptr += 3;
-            } else _ptr += 2;
-          } else _ptr++;
+        // Only support three digits for this extension
+        if ((_ptr[1] == '1' || _ptr[1] == '2') &&
+            (_ptr[2] >= '0' && _ptr[2] <= '9') &&
+            (_ptr[3] >= '0' && _ptr[3] <= '9')) {
+          element = (_ptr[1]-'0')*100 + (_ptr[2]-'0')*10 + (_ptr[3]-'0');
+          if (element > 255) {
+            std::string err = "Element number must be <= 255)";
+            obErrorLog.ThrowError(__FUNCTION__,
+              err, obError);
+            return false;
+          }
+          _ptr += 3;
           break;
         }
         /* fall through to default */

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -3,6 +3,7 @@ Copyright (C) 2005-2007 by Craig A. James, eMolecules Inc.
 Some portions Copyright (C) 1998-2001 by OpenEye Scientific Software, Inc.
 Some portions Copyright (C) 2001-2008 by Geoffrey R. Hutchison
 Some portions Copyright (C) 2004 by Chris Morley
+Some portions Copyright (C) 2019 by NextMove Software.
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -1674,6 +1675,20 @@ namespace OpenBabel {
         else
           return false;
         break;
+
+      case '#':
+        if (_ptr[1]>='1' && _ptr[1]<='9') {
+          element = _ptr[1]-'0';
+          if (_ptr[2]>='0' && _ptr[2]<='9') {
+            element = 10*element + (_ptr[2]-'0');
+            if (_ptr[3]>='0' && _ptr[3]<='9') {
+              element = 10*element + (_ptr[3]-'0');
+              _ptr += 3;
+            } else _ptr += 2;
+          } else _ptr++;
+          break;
+        }
+        /* fall through to default */
 
       default:
         {

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -1677,12 +1677,18 @@ namespace OpenBabel {
         break;
 
       case '#':
-        if (_ptr[1]>='1' && _ptr[1]<='9') {
+        if (_ptr[1]>='0' && _ptr[1]<='9') {
           element = _ptr[1]-'0';
           if (_ptr[2]>='0' && _ptr[2]<='9') {
             element = 10*element + (_ptr[2]-'0');
             if (_ptr[3]>='0' && _ptr[3]<='9') {
               element = 10*element + (_ptr[3]-'0');
+              if (element > 255) {
+                std::string err = "Element number must be <= 255)";
+                obErrorLog.ThrowError(__FUNCTION__,
+                  err, obError);
+                return false;
+              }
               _ptr += 3;
             } else _ptr += 2;
           } else _ptr++;

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2803,8 +2803,13 @@ namespace OpenBabel {
       if (atom->GetAtomicNum() == OBElements::Hydrogen && options.smarts)
         buffer += "#1";
       else {
-        const char* symbol = OBElements::GetSymbol(atom->GetAtomicNum());
-        if (!options.kekulesmi && atom->IsAromatic()) { // aromatic atom
+        unsigned int elem = atom->GetAtomicNum();
+        const char* symbol = OBElements::GetSymbol(elem);
+        if (*symbol == '\0') {
+          char atomnum[8];  // '#' plus 3 digits plus null
+          snprintf(atomnum, 8, "#%u", elem);
+          buffer += atomnum;
+        } else if (!options.kekulesmi && atom->IsAromatic()) { // aromatic atom
           buffer += symbol[0] + ('a' - 'A');
           if (symbol[1])
             buffer += symbol[1];

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2792,8 +2792,8 @@ namespace OpenBabel {
       if (iso >= 10000) // max 4 characters
         obErrorLog.ThrowError(__FUNCTION__, "Isotope value larger than 9999. Ignoring value.", obWarning);
       else {
-        char iso[5]; // 4 characters plus null
-        sprintf(iso, "%d", atom->GetIsotope());
+        char iso[8]; // 7 characters plus null
+        snprintf(iso, 8, "%u", atom->GetIsotope());
         buffer += iso;
       }
     }

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -464,6 +464,24 @@ H         -0.26065        0.64232       -2.62218
 
         self.assertTrue(N > 100)
 
+    def testElementsSpecifiedByAtomicNumberInSmiles(self):
+        smis = [
+                ("[#6H4]", "C"),
+                ("[#255]", None),
+                ("[254#255]", None),
+                ("[#256]", -1),
+                ("[#0]", "*")
+               ]
+
+        for smi, rt in smis:
+            if rt==-1:
+                self.assertRaises(IOError, pybel.readstring, "smi", smi)
+                continue
+            if rt is None:
+                rt = smi
+            nsmi = pybel.readstring("smi", smi).write("smi").rstrip()
+            self.assertEqual(rt, nsmi)
+
     def testIterators(self):
         """Basic check that at least two iterators are working"""
         mol = pybel.readstring("smi", "c1ccccc1C(=O)Cl")

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -466,11 +466,12 @@ H         -0.26065        0.64232       -2.62218
 
     def testElementsSpecifiedByAtomicNumberInSmiles(self):
         smis = [
-                ("[#6H4]", "C"),
+                ("[#100]", "[Fm]"),
                 ("[#255]", None),
                 ("[254#255]", None),
+                ("[#6]", -1),
                 ("[#256]", -1),
-                ("[#0]", "*")
+                ("[#10a]", -1)
                ]
 
         for smi, rt in smis:


### PR DESCRIPTION
The original patch is from @rogersayle, which I've restricted a bit. This is is a SMILES extension that is already present in OEChem and RDKit, both undocumented and due to Roger. For at least OEChem, support is present for 1- and 2-digit numbers too.

The primary use case is to support new elements where we don't yet have the symbol, but also to read SMILES written by OEChem/RDKit where *they* don't yet have the symbol.

My own take is that this seems relatively safe, at least if restricted to 3-digits. As an implementation detail, if an atomic number >255 is specified, the SMILES is rejected with a warning (we use a char for the atomic number).
