### PR TITLE
PDB and PDBQT Insertion Code Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ scripts/java/openbabel.jar
 scripts/php/openbabel.php
 scripts/php/php_openbabel.h
 external
+
+# editors
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.py[cod]
-build
 nbproject
 scripts/**/*.cpp
 scripts/python/openbabel/__init__.py
@@ -8,6 +7,10 @@ scripts/java/openbabel.jar
 scripts/php/openbabel.php
 scripts/php/php_openbabel.h
 external
+
+# build
+build
+build-static
 
 # editors
 .vscode

--- a/cmake/modules/FindRapidJSON.cmake
+++ b/cmake/modules/FindRapidJSON.cmake
@@ -40,7 +40,7 @@ else()
     set(RAPIDJSON_VERSION ${PC_RAPIDJSON_VERSION})
   elseif(EXISTS ${RAPIDJSON_INCLUDE_DIRS}/rapidjson/rapidjson.h)
     file(STRINGS ${RAPIDJSON_INCLUDE_DIRS}/rapidjson/rapidjson.h DEFINES REGEX "#define RAPIDJSON_(MAJOR|MINOR|PATCH)_VERSION ([0-9]+)")
-    string(REGEX REPLACE ".+([0-9]+).+([0-9]+).+([0-9]+)" "\\1.\\2.\\3" RAPIDJSON_VERSION ${DEFINES})
+    string(REGEX REPLACE ".+([0-9]+).+([0-9]+).+([0-9]+)" "\\1.\\2.\\3" RAPIDJSON_VERSION "${DEFINES}")
   endif()
   mark_as_advanced(RAPIDJSON_VERSION)
 

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -39,8 +39,6 @@ GNU General Public License for more details.
 
 #include <sstream>
 
-#include <iostream>
-
 using namespace std;
 namespace OpenBabel
 {

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -39,6 +39,8 @@ GNU General Public License for more details.
 
 #include <sstream>
 
+#include <iostream>
+
 using namespace std;
 namespace OpenBabel
 {
@@ -1190,15 +1192,18 @@ namespace OpenBabel
 
     /* residue sequence number */
     string resnum = sbuf.substr(16,4);
+    char icode = sbuf.substr(20,1)[0];
+    std::cout << "DEBUG ICODE: " << icode << std::endl << std::flush;
     OBResidue *res  = (mol.NumResidues() > 0) ? mol.GetResidue(mol.NumResidues()-1) : NULL;
     if (res == NULL || res->GetName() != resname
-      || res->GetNumString() != resnum)
+      || res->GetNumString() != resnum || res->GetInsertionCode() != icode)
     {
       vector<OBResidue*>::iterator ri;
       for (res = mol.BeginResidue(ri) ; res ; res = mol.NextResidue(ri))
       if (res->GetName() == resname
         && res->GetNumString() == resnum
-        && static_cast<int>(res->GetChain()) == chain)
+        && static_cast<int>(res->GetChain()) == chain
+        && res-> GetInsertionCode() == icode)
         break;
 
       if (res == NULL)
@@ -1207,6 +1212,7 @@ namespace OpenBabel
         res->SetChain(chain);
         res->SetName(resname);
         res->SetNum(resnum);
+        res->SetInsertionCode(icode);
       }
     }
 

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -1193,7 +1193,6 @@ namespace OpenBabel
     /* residue sequence number */
     string resnum = sbuf.substr(16,4);
     char icode = sbuf.substr(20,1)[0];
-    std::cout << "DEBUG ICODE: " << icode << std::endl << std::flush;
     OBResidue *res  = (mol.NumResidues() > 0) ? mol.GetResidue(mol.NumResidues()-1) : NULL;
     if (res == NULL || res->GetName() != resname
       || res->GetNumString() != resnum || res->GetInsertionCode() != icode)

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -1280,10 +1280,7 @@ namespace OpenBabel
           {
             res = NewResidue();
             src_res = src.GetResidue(k);
-            res->SetName(src_res->GetName());
-            res->SetNum(src_res->GetNumString());
-            res->SetChain(src_res->GetChain());
-            res->SetChainNum(src_res->GetChainNum());
+            *res = *src_res;
             for (src_atom=src_res->BeginAtom(ii) ; src_atom ; src_atom=src_res->NextAtom(ii))
               {
                 atom = GetAtom(src_atom->GetIdx());

--- a/src/residue.cpp
+++ b/src/residue.cpp
@@ -841,7 +841,7 @@ _insertioncode=0;
     _atomid   = src._atomid;
     _hetatm   = src._hetatm;
     _sernum   = src._sernum;
-_insertioncode=src._insertioncode;
+    _insertioncode=src._insertioncode;
 
   }
 
@@ -872,7 +872,7 @@ _insertioncode=src._insertioncode;
         _atomid   = src._atomid;
         _hetatm   = src._hetatm;
         _sernum   = src._sernum;
-   _insertioncode = src._insertioncode;
+        _insertioncode = src._insertioncode;
       }
 
     return(*this);


### PR DESCRIPTION
This PR fixes some problems associated to PDB and PDBQT insertion codes:

* When a `OBMolecule` was copied, PDB insertion codes were lost.
* When a PDBQT was parsed with `parseAtomRecord`, insertion codes were lost.

The `OBMolecule` problem was spotted by @dkoes, which suggested a fix.