### PR TITLE
Add deprecated attribute

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -335,7 +335,8 @@ namespace OpenBabel
       bool HtoMethyl();
       //! Change the hybridization of this atom and modify the geometry accordingly
       //! \return success or failure
-      bool SetHybAndGeom(int);
+      //! \deprecated This will be removed in future versions of Open Babel
+      OB_DEPRECATED bool SetHybAndGeom(int);
       //@}
 
       //! \name Property information

--- a/include/openbabel/bond.h
+++ b/include/openbabel/bond.h
@@ -94,6 +94,7 @@ namespace OpenBabel
       };
       //! Whether this bond has been visited by a graph algorithm
       /** \deprecated Use OBBitVec objects instead to be fully thread-safe. **/
+      OB_DEPRECATED_MSG("Use OBBitVec objects instead to be fully thread-safe.")
       bool Visit;
 
       //! Constructor

--- a/include/openbabel/data.h
+++ b/include/openbabel/data.h
@@ -253,6 +253,7 @@ namespace OpenBabel
       bool SetResName(const std::string &);
       //! \return the bond order for the bond specified in the current residue
       //! \deprecated Easier to use the two-argument form
+      OB_DEPRECATED_MSG("Easier to use the two-argument form")
       int  LookupBO(const std::string &);
       //! \return the bond order for the bond specified between the two specified
       //! atom labels

--- a/include/openbabel/forcefield.h
+++ b/include/openbabel/forcefield.h
@@ -710,6 +710,7 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
      */
     bool GetCoordinates(OBMol &mol);
     //! \deprecated Use GetCooordinates instead.
+    OB_DEPRECATED_MSG("Use GetCooordinates instead.")
     bool UpdateCoordinates(OBMol &mol) {return GetCoordinates(mol); }
     /*! Get coordinates for all conformers and attach OBConformerData with energies, forces, ... to mol.
      *  \param mol The OBMol object to copy the coordinates to (from OBForceField::_mol).
@@ -717,6 +718,7 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
      */
     bool GetConformers(OBMol &mol);
     //! \deprecated Use GetConformers instead.
+    OB_DEPRECATED_MSG("Use GetConformers instead.")
     bool UpdateConformers(OBMol &mol) { return GetConformers(mol); }
     /*! Set coordinates for current conformer.
      *  \param mol the OBMol object to copy the coordinates from (to OBForceField::_mol).
@@ -1044,6 +1046,7 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
     //@{
     //! Generate coordinates for the molecule (distance geometry)
     //! \deprecated Use OBDistanceGeometry class instead
+    OB_DEPRECATED_MSG("Use OBDistanceGeometry class instead")
     void DistanceGeometry();
     /*! Generate conformers for the molecule (systematicaly rotating torsions).
      *
@@ -1216,6 +1219,7 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
     /*! Perform a linesearch starting at atom in direction direction.
      * \deprecated Current code should use LineSearch(double *, double*) instead.
      */
+    OB_DEPRECATED_MSG("Current code should use LineSearch(double *, double*) instead.")
     vector3 LineSearch(OBAtom *atom, vector3 &direction);
     /*! Perform a linesearch for the entire molecule in direction @p direction.
      *  This function is called when using LineSearchType::Simple.
@@ -1516,6 +1520,7 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
     static double VectorDistanceDerivative(const double* const pos_i, const double* const pos_j,
                                            double *force_i, double *force_j);
     //! \deprecated
+    OB_DEPRECATED
     static double VectorLengthDerivative(vector3 &a, vector3 &b);
 
     /*! Calculate the derivative of a angle a-b-c. The angle is given by dot(ab,cb)/rab*rcb.
@@ -1531,6 +1536,7 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
     static double VectorAngleDerivative(double *pos_a, double *pos_b, double *pos_c,
                                         double *force_a, double *force_b, double *force_c);
     //! \deprecated
+    OB_DEPRECATED
     static double VectorAngleDerivative(vector3 &a, vector3 &b, vector3 &c);
     /*! Calculate the derivative of a OOP angle a-b-c-d. b is the central atom, and a-b-c is the plane.
      * The OOP angle is given by 90° - arccos(dot(corss(ab,cb),db)/rabbc*rdb).
@@ -1547,6 +1553,7 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
     static double VectorOOPDerivative(double *pos_a, double *pos_b, double *pos_c, double *pos_d,
                                       double *force_a, double *force_b, double *force_c, double *force_d);
     //! \deprecated
+    OB_DEPRECATED
     static double VectorOOPDerivative(vector3 &a, vector3 &b, vector3 &c, vector3 &d);
     /*! Calculate the derivative of a torsion angle a-b-c-d. The torsion angle is given by arccos(dot(corss(ab,bc),cross(bc,cd))/rabbc*rbccd).
      * \param pos_a atom a (coordinates)
@@ -1562,6 +1569,7 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
     static double VectorTorsionDerivative(double *pos_a, double *pos_b, double *pos_c, double *pos_d,
                                           double *force_a, double *force_b, double *force_c, double *force_d);
     //! \deprecated
+    OB_DEPRECATED
     static double VectorTorsionDerivative(vector3 &a, vector3 &b, vector3 &c, vector3 &d);
 
     /*! inline fuction to speed up minimization speed

--- a/include/openbabel/grid.h
+++ b/include/openbabel/grid.h
@@ -102,7 +102,7 @@ namespace OpenBabel
   {
   protected:
     std::vector<double> _values;   //!< floating point values
-    int   *_ival;             //!< for integer values (deprecated)
+    OB_DEPRECATED int   *_ival;    //!< for integer values \deprecated
     double _midz,_midx,_midy; //!< center of grid in world coordinates
     int _ydim,_xdim,_zdim;    //!< grid dimensions
     double _spacing,_inv_spa; //!< spacing between grid points and its inverse
@@ -128,6 +128,7 @@ namespace OpenBabel
     //! Get the minimum point in the grid.
     //! \deprecated Will be removed.
     //! Use \sa GetMin()
+    OB_DEPRECATED_MSG("Use GetMin() instead")
     void GetMin(double *a)
     {
       a[0]=_xmin;
@@ -141,6 +142,7 @@ namespace OpenBabel
     //! Get the maximum point in the grid.
     //! \deprecated Will be removed.
     //! \sa GetMax()
+    OB_DEPRECATED_MSG("Use GetMax() instead")
     void GetMax(double *a)
     {
       a[0]=_xmax;
@@ -153,6 +155,7 @@ namespace OpenBabel
     //! Get the grid spacing.
     //! \deprecated Will be removed.
     //! \sa GetSpacing()
+    OB_DEPRECATED_MSG("Use GetSpacing() instead")
     void GetSpacing(double &s)
     {
       s=_spacing;
@@ -170,6 +173,7 @@ namespace OpenBabel
     //! Get the x, y and z dimensions (must pass an double[3] at least).
     //! \deprecated May be removed in future.
     //! \sa GetXdim() \sa GetYdim() \sa GetZdim()
+    OB_DEPRECATED_MSG("Use GetXdim(), GetYdim() or GetZdim() instead")
     void GetDim(int *a)
     {
       a[0]=_xdim;
@@ -221,6 +225,7 @@ namespace OpenBabel
                    const vector3& z);
     //! \deprecated Will be removed.
     //! \sa SetLimits(const vector3& origin, const vector3& x, const vector3& y, const vector3& z)
+    OB_DEPRECATED_MSG("Use vector version instead")
     void SetLimits(const double origin[3], const double x[3], const double y[3],
                    const double z[3]);
 
@@ -235,6 +240,7 @@ namespace OpenBabel
     //! one dimensional array.
     //! \deprecated Will be removed.
     //! \sa GetDataVector()
+    OB_DEPRECATED_MSG("Use GetDataVector instead")
     double *GetVals()    {        return(&_values[0]);    }
 
     //! \return Value at the point in the grid specified by i, j and k.
@@ -248,6 +254,7 @@ namespace OpenBabel
 
     //! \deprecated Will be removed.
     //! \sa SetVals(const std::vector<double> & vals)
+    OB_DEPRECATED_MSG("Use vector version instead")
     void SetVals(double *ptr)
     {
      for (int i = 0; i < _xdim*_ydim*_zdim; ++i)
@@ -295,7 +302,7 @@ namespace OpenBabel
   //! \class OBProxGrid grid.h <openbabel/grid.h>
   //! \brief A grid for determining the proximity of a given point to atoms in an OBMol
   //! \deprecated May be removed in the future, since docking is not a key feature
- class OBAPI OBProxGrid: public OBGrid
+ class OBAPI OB_DEPRECATED OBProxGrid: public OBGrid
   {
   protected:
     int _gridtype;
@@ -337,7 +344,7 @@ namespace OpenBabel
   //! \class OBScoreGrid grid.h <openbabel/grid.h>
   //! \brief A base class for scoring docking interactions between multiple molecules
   //! \deprecated Will disappear in future versions. Use your own code.
-  class OBAPI OBScoreGrid
+  class OBAPI OB_DEPRECATED OBScoreGrid
   {
   protected:
     score_t gridtype;

--- a/include/openbabel/griddata.h
+++ b/include/openbabel/griddata.h
@@ -85,6 +85,7 @@ namespace OpenBabel {
     /// \param o set to the origin (i.e., the minimum x, y, and z coords of the grid).
     /// \deprecated Will be removed.
     /// \sa GetOriginVector()
+    OB_DEPRECATED_MSG("Use GetOriginVector() instead")
     void GetOriginVector(double o[3]) const;
     /// \return The maximum point in the grid.
     vector3 GetMaxVector() const;
@@ -107,6 +108,7 @@ namespace OpenBabel {
                    const vector3 &z);
     /// \deprecated Will be removed.
     /// \sa SetLimits(const vector3 &origin, const vector3 &x, const vector3 &y, const vector3 &z)
+    OB_DEPRECATED_MSG("Use vector version instead")
     void SetLimits(const double origin[3], const double x[3], const double y[3],
                    const double z[3]);
     /// Set an individual value, grid must have been initialised

--- a/include/openbabel/math/matrix3x3.h
+++ b/include/openbabel/math/matrix3x3.h
@@ -168,6 +168,7 @@ namespace OpenBabel
       /*! \warning row or column are not in the range 0..2, zero is returned
        *! \deprecated use the constant operator() instead
        */
+      OB_DEPRECATED_MSG("use the constant operator() instead")
       double Get(int row,int column) const
         {
 #ifdef OB_OLD_MATH_CHECKS
@@ -184,6 +185,7 @@ namespace OpenBabel
       /*! \warning if row or column are not in the range 0..2, nothing will happen
        *! \deprecated use the non-constant operator() instead
        */
+      OB_DEPRECATED_MSG("use the non-constant operator() instead")
       void Set(int row,int column, double v)
         {
 #ifdef OB_OLD_MATH_CHECKS

--- a/include/openbabel/math/vector3.h
+++ b/include/openbabel/math/vector3.h
@@ -270,11 +270,13 @@ namespace OpenBabel
     //! \deprecated This method uses unreliable floating point == comparisons
     //!    Use vector3::IsApprox() instead.
     //! \return true if every component is equal
-    int operator== ( const vector3& ) const;
+    OB_DEPRECATED_MSG("Use vector3::IsApprox() instead.")
+    bool operator== ( const vector3& ) const;
     //! \deprecated This method uses unreliable floating point == comparisons
     //!    Use vector3::IsApprox() instead.
     //! \return true if at least one component of the two vectors is !=
-    int operator!= ( const vector3& other ) const
+    OB_DEPRECATED_MSG("Use vector3::IsApprox() instead.")
+    bool operator!= ( const vector3& other ) const
     {
       return ! ( (*this) == other );
     }

--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -276,6 +276,7 @@ enum HydrogenType { AllHydrogen, PolarHydrogen, NonPolarHydrogen };
     OBAtom      *GetAtomById(unsigned long id) const;
     //! \return the first atom in this molecule, or NULL if none exist.
     //! \deprecated Will be removed in favor of more standard iterator methods
+    OB_DEPRECATED
     OBAtom      *GetFirstAtom() const;
     //! \return the bond at index @p idx or NULL if it does not exist.
     //! \warning Bond indexing may change. Use iterator methods instead.

--- a/include/openbabel/obutil.h
+++ b/include/openbabel/obutil.h
@@ -186,6 +186,7 @@ namespace OpenBabel
    * backwards compatibility.
    * \deprecated Use IsApprox() instead
    */
+  OB_DEPRECATED_MSG("Use IsApprox() instead")
   OBAPI bool IsNear(const double &, const double &, const double epsilon=2e-6);
   /*! "Safe" comparison for floats/doubles: true if a is less than epsilon
    * This function really doesn't make any sense w.r.t. floating-point
@@ -193,6 +194,7 @@ namespace OpenBabel
    * backwards compatibility.
    * \deprecated
    */
+  OB_DEPRECATED
   OBAPI bool IsNearZero(const double &, const double epsilon=2e-6);
   OBAPI bool IsNan(const double &);
   /**

--- a/include/openbabel/parsmart.h
+++ b/include/openbabel/parsmart.h
@@ -155,7 +155,7 @@ namespace OpenBabel
   {
   protected:
     OBSmartsPrivate                *_d;        //!< Internal data storage for future expansion
-    std::vector<bool>          		  _growbond; //!< \deprecated (Not used)
+    OB_DEPRECATED std::vector<bool> _growbond; //!< \deprecated (Not used)
     std::vector<std::vector<int> >	_mlist;    //!< The list of matches
     Pattern                        *_pat;      //!< The parsed SMARTS pattern
     std::string				              _str;      //!< The string of the SMARTS expression

--- a/include/openbabel/patty.h
+++ b/include/openbabel/patty.h
@@ -34,7 +34,7 @@ namespace OpenBabel
 #define PT_METAL	   8
 
 // class introduction in patty.cpp
-class OBAPI patty
+class OBAPI OB_DEPRECATED patty
 {
     std::vector<OBSmartsPattern*> _sp;
     std::vector<std::string> smarts;

--- a/include/openbabel/ring.h
+++ b/include/openbabel/ring.h
@@ -62,6 +62,7 @@ namespace OpenBabel
     size_t    Size()     const  {    return(_path.size());  }
     //! \return the size of this ring (i.e., how many atoms in the cycle)
     //! \deprecated Use Size() instead
+    OB_DEPRECATED_MSG("Use Size() instead")
     size_t    PathSize() const  {    return(_path.size());  }
 
     //! \return whether this ring is aromatic
@@ -117,7 +118,7 @@ namespace OpenBabel
   **/
   class OBAPI OBRingSearch
   {
-    std::vector<OBBond*> _bonds; //!< the internal list of closure bonds (deprecated)
+    OB_DEPRECATED std::vector<OBBond*> _bonds; //!< the internal list of closure bonds (deprecated)
     std::vector<OBRing*> _rlist; //!< the internal list of rings
   public:
     OBRingSearch()    {}

--- a/include/openbabel/rotor.h
+++ b/include/openbabel/rotor.h
@@ -425,22 +425,31 @@ namespace OpenBabel
     ///@name Deprecated
     ///@{
     /** @deprecated Has no effect. */
+    OB_DEPRECATED_MSG("Has no effect.")
     void SetDelta(double UNUSED(d)) {}
     /** @deprecated Has no effect. */
+    OB_DEPRECATED_MSG("Has no effect.")
     double GetDelta() { return 10.0; }
     /** @deprecated */
+    OB_DEPRECATED
     OBBitVec &GetFixedAtoms() { return _fixedatoms; }
     /** @deprecated See SetFixedBonds */
+    OB_DEPRECATED_MSG("See SetFixedBonds")
     void SetFixedAtoms(OBBitVec &bv) { _fixedatoms = bv; }
     /** @deprecated */
+    OB_DEPRECATED
     OBBitVec &GetEvalAtoms() { return _evalatoms; }
     /** @deprecated */
+    OB_DEPRECATED
     void SetEvalAtoms(OBBitVec &bv) { _evalatoms = bv; }
     /** @deprecated */
+    OB_DEPRECATED
     void* GetRotAtoms() { return &_rotatoms; }
     /** @deprecated Bad name, see GetTorsionValues() */
+    OB_DEPRECATED_MSG("See GetTorsionValues()")
     std::vector<double> &GetResolution() { return _torsionAngles; }
     /** @deprecated */
+    OB_DEPRECATED
     void SetNumCoords(int UNUSED(nc)) {}
     ///@}
 
@@ -615,11 +624,13 @@ namespace OpenBabel
     ///@{
     // Not declared
     //! \deprecated Not declared. Use Setup() for top-level functionality
+    OB_DEPRECATED_MSG("Not declared. Use Setup() for top-level functionality")
     bool   IdentifyEvalAtoms(OBMol &mol) { return SetEvalAtoms(mol); }
     /**
      * Set the list of fixed (invariant) atoms to the supplied OBBitVec
      * @deprecated See SetFixedBonds()
      */
+    OB_DEPRECATED_MSG("See SetFixedBonds()")
     void SetFixAtoms(OBBitVec &fix)
     {
       _fixedatoms = fix;
@@ -629,12 +640,14 @@ namespace OpenBabel
      * @return whether this rotor list has any fixed (invariant) atoms
      * @deprecated See HasFixedBonds()
      */
+    OB_DEPRECATED_MSG("See HasFixedBonds()")
     bool HasFixedAtoms()
     {
       return(!_fixedatoms.IsEmpty());
     }
     //! Has no effect
     //! \deprecated Currently has no effect
+    OB_DEPRECATED_MSG("Currently has no effect")
     void IgnoreSymmetryRemoval()    { _removesym = false;}
     //! \brief Set the atoms to rotate from the dihedral atoms for each rotor
     //! Insures the fixed atoms are respected, but otherwise functions like

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -1246,7 +1246,7 @@ namespace OpenBabel
   }
 
   //! \deprecated This will be removed in future versions of Open Babel
-  bool OBAtom::SetHybAndGeom(int hyb)
+  OB_DEPRECATED bool OBAtom::SetHybAndGeom(int hyb)
   {
     obErrorLog.ThrowError(__FUNCTION__,
                           "Ran OpenBabel::SetHybridizationAndGeometry",

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -31,6 +31,20 @@
  #define OB_HIDDEN
 #endif
 
+// deprecated attribute (C++14)
+#if defined(__has_cpp_attribute) && !defined(SWIG)
+  #if __has_cpp_attribute(deprecated)
+    #define OB_DEPRECATED [[deprecated]]
+    #define OB_DEPRECATED_MSG(msg) [[deprecated(msg)]]
+  #else
+    #define OB_DEPRECATED
+    #define OB_DEPRECATED_MSG(msg)
+  #endif
+#else
+  #define OB_DEPRECATED
+  #define OB_DEPRECATED_MSG(msg)
+#endif
+
 /* Used to export symbols for DLL / shared library builds */
 #if defined(MAKE_OBDLL) // e.g. in src/main.cpp
  #ifndef OB_EXTERN

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -326,6 +326,7 @@ namespace OpenBabel
   //!  string and null-terminating as needed
   //! \deprecated Because there is no guarantee on the length of an atom type
   //!  you should consider using std::string instead
+  OB_DEPRECATED_MSG("you should consider using std::string instead")
   bool OBTypeTable::Translate(char *to, const char *from)
   {
     if (!_init)

--- a/src/math/matrix3x3.cpp
+++ b/src/math/matrix3x3.cpp
@@ -93,6 +93,7 @@ namespace OpenBabel
 
     @param norm specifies the normal to the plane
   */
+  OB_DEPRECATED
   void matrix3x3::PlaneReflection(const vector3 &norm)
   {
     //@@@ add a safety net
@@ -125,6 +126,7 @@ namespace OpenBabel
     @param v specifies the axis of the rotation
     @param angle angle in degrees (0..360)
   */
+  OB_DEPRECATED
   void matrix3x3::RotAboutAxisByAngle(const vector3 &v,const double angle)
   {
     double theta = angle*DEG_TO_RAD;

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -112,7 +112,7 @@ namespace OpenBabel
     return co ;
   }
 
-  OBAPI int vector3::operator== ( const vector3& other ) const
+  OBAPI bool vector3::operator== ( const vector3& other ) const
   {
     return ( ( x() == other.x() ) &&
              ( y() == other.y() ) &&

--- a/src/obutil.cpp
+++ b/src/obutil.cpp
@@ -52,6 +52,7 @@ namespace OpenBabel
 
   //! Deprecated: use the OBMessageHandler class instead
   //! \deprecated Throw an error through the OpenBabel::OBMessageHandler class
+  OB_DEPRECATED_MSG("use the OBMessageHandler class instead")
   void ThrowError(char *str)
   {
     obErrorLog.ThrowError("", str, obInfo);
@@ -59,6 +60,7 @@ namespace OpenBabel
 
   //! Deprecated: use the OBMessageHandler class instead
   //! \deprecated Throw an error through the OpenBabel::OBMessageHandler class
+  OB_DEPRECATED_MSG("use the OBMessageHandler class instead")
   void ThrowError(std::string &str)
   {
     obErrorLog.ThrowError("", str, obInfo);


### PR DESCRIPTION
Define `OB_DEPRECATED` and `OB_DEPRECATED_MSG` to declare classes, functions, and variables are deprecated.

Unless `[[deprecated]]` attribute is effective (C++14 feature) or `SWIG` is defined, these macros are ignored