### PR TITLE
H vector fix

### DIFF
--- a/include/openbabel/builder.h
+++ b/include/openbabel/builder.h
@@ -74,7 +74,8 @@ namespace OpenBabel
       void LoadFragments();
       std::vector<vector3> GetFragmentCoord(std::string smiles);
 
-      /*! Get the position for a new neighbour on atom.
+      /*! Get the position for a new neighbour on atom.  Returns
+       * non-finite vector if there is no reasonable location.
        *  \param atom Atom for which we want a new neighbour location.
        *  \returns The position for the new atom.
        */

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -335,8 +335,9 @@ namespace OpenBabel
         v1 = bond1 + bond2;
         v1 = v1.normalize();
 
-        newbond = v1; //default
-        if (atom->GetHyb() == 3) {
+        if (atom->GetHyb() == 2)
+          newbond = v1; 
+        else if (atom->GetHyb() == 3) {
           v2 = cross(bond1, bond2); // find the perpendicular
           v2.normalize();
           newbond = bond1 - v2 * tan(DEG_TO_RAD*(180.0 - 109.471));
@@ -362,7 +363,7 @@ namespace OpenBabel
           newbond = v2;
         }
 
-        newbond = newbond.normalize();
+        newbond = newbond.normalize(); //if newbond was not set, it will become non-finite here
         newbond *= length;
         newbond += atom->GetVector();
         return newbond;

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -2200,6 +2200,7 @@ namespace OpenBabel
         double bondlen = hbrad + CorrectedBondRad(atom->GetAtomicNum(), atom->GetHyb());
         for (m = 0;m < k->second;++m)
           {
+            int badh = 0;
             for (n = 0;n < NumConformers();++n)
               {
                 SetConformer(n);
@@ -2218,40 +2219,36 @@ namespace OpenBabel
                       _c[(NumAtoms())*3+1] = 0.0;
                       _c[(NumAtoms())*3+2] = 0.0;
                       obErrorLog.ThrowError(__FUNCTION__,
-                                            "Ran OpenBabel::AddHydrogens -- non-finite hydrogens found.",
+                                            "Ran OpenBabel::AddHydrogens -- no reasonable bond geometry for desired hydrogen.",
                                             obAuditMsg);
+                      badh++;
                     }
                   }
                 else
                   memset((char*)&_c[NumAtoms()*3],'\0',sizeof(double)*3);
               }
-            h = NewAtom();
-            h->SetType("H");
-            h->SetAtomicNum(1);
-
-            // copy parent atom residue to added hydrogen     REG 6/30/02
-
-            if (atom->HasResidue())
+            if(badh == 0 || badh < NumConformers()) 
               {
+                h = NewAtom();
+                h->SetType("H");
+                h->SetAtomicNum(1);
 
-                string aname;
+                // copy parent atom residue to added hydrogen     REG 6/30/02
+                if (atom->HasResidue())
+                  {
+                    string aname = "H";
+                    // Add the new H atom to the appropriate residue list
+                    atom->GetResidue()->AddAtom(h);
+                    // Give the new atom a pointer back to the residue
+                    h->SetResidue(atom->GetResidue());
+                    atom->GetResidue()->SetAtomID(h,aname);
+                  }
 
-                aname = "H";
-
-                // Add the new H atom to the appropriate residue list
-                atom->GetResidue()->AddAtom(h);
-
-                // Give the new atom a pointer back to the residue
-                h->SetResidue(atom->GetResidue());
-
-                atom->GetResidue()->SetAtomID(h,aname);
-
+                int bondFlags = 0;
+                AddBond(atom->GetIdx(),h->GetIdx(),1, bondFlags);
+                h->SetCoordPtr(&_c);
+                OpenBabel::ImplicitRefToStereo(*this, atom->GetId(), h->GetId());
               }
-
-            int bondFlags = 0;
-            AddBond(atom->GetIdx(),h->GetIdx(),1, bondFlags);
-            h->SetCoordPtr(&_c);
-            OpenBabel::ImplicitRefToStereo(*this, atom->GetId(), h->GetId());
           }
       }
 

--- a/test/addhtest.cpp
+++ b/test/addhtest.cpp
@@ -41,7 +41,7 @@ using namespace OpenBabel;
 void addh_check(OBMol *mol)
 {
     unsigned len = mol->NumAtoms();
-    unsigned vcnts[len];
+    unsigned *vcnts = (unsigned*)alloca(len*sizeof(unsigned));
     memset(vcnts, 0, sizeof(unsigned)*len);
     //chemistry is weird, so can't rely on MaxBonds in general
     //we recod the valence count before adding hydrogens


### PR DESCRIPTION
This is an alternative fix to generating crazy hydrogens.  Instead of defaulting to a hybridization 2 kind of bond, if the builder doesn't think there is a reasonable bond vector, then the hydrogen isn't added.  I've also updated the documentation for GetNewBondVector to state that a non-finite vector can be returned if there isn't a reasonable location for another atom.

This restores the old behavior of GetNewBondVector (return non-finite bond vectors), which is good in the off chance anyone was relying on it while still fixing the problem.  In the corner case that a molecule has multiple conformers, some where the hydrogen can be added and some where it can't the hydrogen is added at (0,0,0), but I'm not sure this can actually happen.

This also comes with updated hydrogen testing code.  The goal is to eventually always perform consistent and reasonable protonation and this PR is a baby step in that direction.

Incidentally, the problem with the test molecule is that it has had the formal charge information stripped from the azide.  In my perfect world, AddHydrogens would also update formal charges if doing so resulted in a more reasonable molecule than adding a hydrogen.