### PR TITLE
Do not stoke around the text

### DIFF
--- a/src/depict/svgpainter.cpp
+++ b/src/depict/svgpainter.cpp
@@ -151,7 +151,7 @@ namespace OpenBabel
   void SVGPainter::DrawText(double x, double y, const std::string &text)
   {
     m_ofs << "<text x=\"" << x << "\" y=\"" << y << "\""
-      << " fill=" << MakeRGB(m_Pencolor) << " stroke=" << MakeRGB(m_Pencolor) << "stroke-width=\"1\" "
+      << " fill=" << MakeRGB(m_Pencolor) << "stroke-width=\"0\" "
       << "font-size=\"" << m_fontPointSize << "\" >"
       << text << "</text>\n";
   }


### PR DESCRIPTION
The current version of OpenBabel adds a stroke around the text, creating an awkward "rounded bold" effect that looks worse than both regular text and bold text. This commit removes such strokes.