### PR TITLE
change forcefield.cpp so that steepest descent and conjugate gradient…

### DIFF
--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -2798,7 +2798,7 @@ namespace OpenBabel
           }
 
           // check to see how large the gradients are
-          if (dir.length_2() > maxgrad)
+          if (dir.length_2() < maxgrad)
             maxgrad = dir.length_2();
 
           if (!_constraints.IsXFixed(idx))
@@ -3004,7 +3004,7 @@ namespace OpenBabel
           }
 
           // check to see how large the gradients are
-          if (grad2.length_2() > maxgrad)
+          if (grad2.length_2() < maxgrad)
             maxgrad = grad2.length_2();
 
           if (!_constraints.IsXFixed(idx))


### PR DESCRIPTION
…s update maxgrad; proposed fix for github issue 1366

I think this fixes issue #1366 
The problem was that the maxgrad variable was never being updated (and thus was never found to be lower than its initial value of 1.0e20). Therefore, the energetic criteria for convergence could be satisfied, but not the gradient condition. This change affects the steepest descent and conjugate gradients (N steps) methods.