### PR TITLE
Update coordinates in the fast option of obabel

### DIFF
--- a/src/ops/gen3d.cpp
+++ b/src/ops/gen3d.cpp
@@ -149,8 +149,10 @@ bool OpGen3D::Do(OBBase* pOb, const char* OptionText, OpMap* pOptions, OBConvers
   // Initial cleanup for every level
   pFF->ConjugateGradients(iterations, 1.0e-4);
 
-  if (speed == 4)
+  if (speed == 4) {
+    pFF->UpdateCoordinates(*pmol);
     return true; // no conformer searching
+  }
 
   switch(speed) {
   case 1:


### PR DESCRIPTION
When 3D coordinates were generated with obabel, `fast` and `fastest` options yielded the same structure. This is because `UpdateCoordinates()` was missing after force field cleanup when ` fast` is specified. This pull request solves this issue.