### PR TITLE
Substitute deprecated std::bind1st with std::bind`

### DIFF
--- a/src/stereo/perception.cpp
+++ b/src/stereo/perception.cpp
@@ -2877,7 +2877,7 @@ namespace OpenBabel {
 
   void StereoRefToImplicit(OBMol& mol, OBStereo::Ref atomId) {
     // The following is for use in replace_if(...) below
-    const std::binder1st<std::equal_to<OBStereo::Ref> > equal_to_atomId = std::bind1st (equal_to<OBStereo::Ref>(), atomId);
+    const auto equal_to_atomId = std::bind(equal_to<OBStereo::Ref>(), atomId, std::placeholders::_1);
 
     std::vector<OBGenericData*> vdata = mol.GetAllData(OBGenericDataType::StereoData);
     for (std::vector<OBGenericData*>::iterator data = vdata.begin(); data != vdata.end(); ++data) {
@@ -2909,7 +2909,7 @@ namespace OpenBabel {
 
   void ImplicitRefToStereo(OBMol& mol, OBStereo::Ref centerId, OBStereo::Ref newId) {
     // The following is for use in replace_if(...) below
-    const std::binder1st<std::equal_to<OBStereo::Ref> > equal_to_implicitRef = std::bind1st (equal_to<OBStereo::Ref>(), (OBStereo::Ref) OBStereo::ImplicitRef);
+    const auto equal_to_implicitRef = std::bind(equal_to<OBStereo::Ref>(), (OBStereo::Ref) OBStereo::ImplicitRef, std::placeholders::_1);
 
     std::vector<OBGenericData*> vdata = mol.GetAllData(OBGenericDataType::StereoData);
     for (std::vector<OBGenericData*>::iterator data = vdata.begin(); data != vdata.end(); ++data) {


### PR DESCRIPTION
This PR gets rid of the deprecation warnings concerning `std::bind1st` and `std::binder1st`. They are removed in favour of `std::bind` and `std::placeholders`.