### PR TITLE
Add a warning message when both -p and -h options are set

### DIFF
--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -85,9 +85,18 @@ namespace OpenBabel
 
     itr = pOptions->find("p");
     if(itr!=pOptions->end()) {
-      double pH = strtod(itr->second.c_str(), 0);
-      if(!AddHydrogens(false, true, pH))
-        ret=false;
+      if(pOptions->find("h")!=pOptions->end()){
+        stringstream errorMsg;
+        errorMsg << "Both -p and -h options are set. "
+                 << "All implicit hydrogens (-h) will be added without considering pH."
+                 << endl;
+        obErrorLog.ThrowError(__FUNCTION__, errorMsg.str(), obWarning);
+      }
+      else {
+        double pH = strtod(itr->second.c_str(), 0);
+        if(!AddHydrogens(false, true, pH))
+          ret=false;
+      }
     }
 
     if(pOptions->find("c")!=pOptions->end())


### PR DESCRIPTION
When both of `-p` and `-h` options are set, the `obabel` will behave as adding all implicit atoms without considering the pH environment, just like using `-h` only.
This PR adds a warning message to warn users when both of these options are set.