### PR TITLE
Fix reading of uninitialized data.

### DIFF
--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -24,6 +24,7 @@ GNU General Public License for more details.
 #include <openbabel/obiter.h>
 #include <openbabel/kekulize.h>
 #include <cstdlib>
+#include <cstring>
 
 namespace OpenBabel
 {
@@ -201,6 +202,7 @@ namespace OpenBabel
 
     // Create lookup of degrees
     unsigned int *degrees = (unsigned int*)malloc(sizeof(unsigned int)*atomArraySize);
+    memset(degrees, 0, sizeof(unsigned int)*atomArraySize);
     std::vector<OBAtom*> degreeOneAtoms;
     FOR_ATOMS_OF_MOL(atom, m_mol) {
       unsigned int atom_idx = atom->GetIdx();


### PR DESCRIPTION
Valgrind was reporting Conditional jump or move depends on uninitialised value(s)
I am pretty sure that initializing to zeroes is the right thing to do,
but don't really grok the kekulize code so perhaps this is a symptom of
a larger problem.  It's certainly an improvement over reading
uninitialized values.