### PR TITLE
Add a GitHub funding link to the open collective page.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: openbabel


### PR DESCRIPTION
This is used to enable open financial contributions
(e.g., meetings at ACS, etc.)

https://opencollective.com/openbabel