### PR TITLE
Bump cmake_minimum_required to 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# Please ensure that any changes remain compliant with 2.8.10.
+# Please ensure that any changes remain compliant with 3.1.
 if(NOT EMBED_OPENBABEL)
-  cmake_minimum_required(VERSION 2.8.10)
+  cmake_minimum_required(VERSION 3.1)
 endif()
 
 project(openbabel)

--- a/INSTALL
+++ b/INSTALL
@@ -7,7 +7,7 @@ installation instructions, please see:
 
 Requirements
 ============
- -- CMake 2.8.10 or later
+ -- CMake 3.1 or later
  -- Eigen 3.0 or later (optional)
  -- libxml2 (optional)
  -- zlib (optional)


### PR DESCRIPTION
`CMAKE_CXX_STANDARD` is currently used

https://github.com/openbabel/openbabel/blob/41730e2d82d01eb52cc5a58ed60000c533ee8ce9/CMakeLists.txt#L474

But it was introduced in [CMake 3.1](https://cmake.org/cmake/help/v3.1/release/3.1.0.html#properties).