### PR TITLE
Update GAS CONSTANT to 2018 CODATA recommended value

### DIFF
--- a/include/openbabel/forcefield.h
+++ b/include/openbabel/forcefield.h
@@ -64,7 +64,8 @@ namespace OpenBabel
 #define OBFF_NUMERICAL_GRADIENT  	(1 << 0)  //!< use numerical gradients
 #define OBFF_ANALYTICAL_GRADIENT	(1 << 1)  //!< use analytical gradients
 
-#define KCAL_TO_KJ	4.1868
+const double KCAL_TO_KJ = 4.1868;
+const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 K^-1 (2018 CODATA recommended value)
 
   // inline if statements for logging.
 #define IF_OBFF_LOGLVL_LOW    if(_loglvl >= OBFF_LOGLVL_LOW)
@@ -1383,7 +1384,7 @@ namespace OpenBabel
      *  \code
      *        3N
      *       ----
-     *  0.5  \    m_i * v_i^2 = 0.5 * Ndf * kB * T = E_kin
+     *  0.5  \    m_i * v_i^2 = 0.5 * Ndf * R * T = E_kin
      *       /
      *       ----
      *       i=1
@@ -1392,7 +1393,7 @@ namespace OpenBabel
      *  m_i : mass of atom i
      *  v_i : velocity of atom i
      *  Ndf : number of degrees of freedom (3 * number of atoms)
-     *  kB : Boltzmann's constant
+     *  R : gas constant
      *  T : temperature
      *  \endcode
      *

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -3425,8 +3425,7 @@ namespace OpenBabel
     generator.TimeSeed();
     _ncoords = _mol.NumAtoms() * 3;
     int velocityIdx;
-    double velocity, kB;
-    kB = 0.00831451 / KCAL_TO_KJ; // kcal/(mol*K)
+    double velocity;
 
     _velocityPtr = new double[_ncoords];
     memset(_velocityPtr, '\0', sizeof(double)*_ncoords);
@@ -3442,7 +3441,7 @@ namespace OpenBabel
           for (int i=0; i < 12; ++i)
             velocity += generator.NextFloat();
           velocity -= 6.0;
-          velocity *= sqrt((kB * _temp)/ (1000 * a->GetAtomicMass()));
+          velocity *= sqrt((GAS_CONSTANT * _temp)/ (1000 * a->GetAtomicMass()));
           _velocityPtr[velocityIdx] = velocity; // x10: gromacs uses nm instead of A
         }
 
@@ -3451,7 +3450,7 @@ namespace OpenBabel
           for (int i=0; i < 12; ++i)
             velocity += generator.NextFloat();
           velocity -= 6.0;
-          velocity *= sqrt((kB * _temp)/ (1000 * a->GetAtomicMass()));
+          velocity *= sqrt((GAS_CONSTANT * _temp)/ (1000 * a->GetAtomicMass()));
           _velocityPtr[velocityIdx+1] = velocity; // idem
         }
 
@@ -3460,7 +3459,7 @@ namespace OpenBabel
           for (int i=0; i < 12; ++i)
             velocity += generator.NextFloat();
           velocity -= 6.0;
-          velocity *= sqrt((kB * _temp)/ (1000 * a->GetAtomicMass()));
+          velocity *= sqrt((GAS_CONSTANT * _temp)/ (1000 * a->GetAtomicMass()));
           _velocityPtr[velocityIdx+2] = velocity; // idem
         }
       }
@@ -3473,12 +3472,11 @@ namespace OpenBabel
   {
     _ncoords = _mol.NumAtoms() * 3;
     int velocityIdx;
-    double velocity, kB, E_kin, E_kin2, factor;
-    kB = 0.00831451 / KCAL_TO_KJ; // kcal/(mol*K)
+    double velocity, E_kin, E_kin2, factor;
 
-    // E_kin = 0.5 * Ndf * kB * T
-    E_kin = _ncoords * kB * _temp;
-    //cout << "E_{kin} = Ndf * kB * T = " << E_kin << endl;
+    // E_kin = 0.5 * Ndf * R * T
+    E_kin = _ncoords * GAS_CONSTANT * _temp;
+    //cout << "E_{kin} = Ndf * R * T = " << E_kin << endl;
 
     // E_kin = 0.5 * sum( m_i * v_i^2 )
     E_kin2 = 0.0;


### PR DESCRIPTION
The variable was called as Boltzmann's constant but actually gas constant, and the value was incorrect.