### PR TITLE
Rename MAESTRO extensions from uppercase to lowercase

### DIFF
--- a/src/formats/maeformat.cpp
+++ b/src/formats/maeformat.cpp
@@ -45,8 +45,8 @@ public:
   //Register this format type ID in the constructor
   MAEFormat()
 	{
-		OBConversion::RegisterFormat("MAE", this);
-		OBConversion::RegisterFormat("MAEGZ", this);
+		OBConversion::RegisterFormat("mae", this);
+		OBConversion::RegisterFormat("maegz", this);
 	}
 
 	virtual const char* Description() override //required


### PR DESCRIPTION
The file extensions should be lowercase for .mae and .maegz. See discussion at #1993.