### PR TITLE
Fix BUILD_SHARED=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,7 +479,7 @@ endif()
 
 
 find_package(Boost)
-if(Boost_FOUND)
+if(Boost_FOUND AND BUILD_SHARED)
     include_directories(${Boost_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
     option(WITH_MAEPARSER "Build Maestro support" ON)
 else()


### PR DESCRIPTION
maeparser doesn't appear to support static builds out of the box, so
disable it in this case