### PR TITLE
Do not hard-code Open Babel major version for include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ else() # Windows - bin dir = lib dir to load libraries
   endif()
 endif()
 if(NOT DEFINED OB_INCLUDE_DIRS)
-  set(OB_INCLUDE_DIRS "include/openbabel3")
+  set(OB_INCLUDE_DIRS "include/openbabel${BABEL_MAJ_VER}")
 endif()
 set(OB_EXPORTS_FILE "${openbabel_BINARY_DIR}/OpenBabel3_EXPORTS.cmake")
 # Ensure a fresh file is made each time CMake is run

--- a/openbabel-3.pc.cmake
+++ b/openbabel-3.pc.cmake
@@ -2,7 +2,7 @@ prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${exec_prefix}/@LIB_INSTALL_DIR@
 includedir=${prefix}/include
-pkgincludedir=${includedir}/openbabel-2.0
+pkgincludedir=${includedir}/openbabel@BABEL_MAJ_VER@
 
 Name: Open Babel library
 Description: libopenbabel


### PR DESCRIPTION
pkgconf file still points to `include/openbabel-2.0`; use `BABEL_MAJ_VER` for convenience.