### PR TITLE
Update for Open Babel 3

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -21,9 +21,6 @@ install Open Babel on most systems.  If you are using unique install locations
 and/or libraries are not automatically detected please consult the 'Advanced'
 section.
 
-The following instructions assume that the Open Babel source distribution is in
-the directory ~/openbabel-2.4.0.
-
 1. Create a 'build' directory:
 
    mkdir build

--- a/OpenBabel3Config.cmake.in
+++ b/OpenBabel3Config.cmake.in
@@ -1,15 +1,15 @@
-# The OpenBabel2 config file. To get the targets include the exports file.
-get_filename_component(OpenBabel2_INSTALL_PREFIX "${OpenBabel2_DIR}@REL_REF@"
+# The OpenBabel3 config file. To get the targets include the exports file.
+get_filename_component(OpenBabel3_INSTALL_PREFIX "${OpenBabel3_DIR}@REL_REF@"
   ABSOLUTE)
 
-set(OpenBabel2_VERSION_MAJOR   "@BABEL_MAJ_VER@")
-set(OpenBabel2_VERSION_MINOR   "@BABEL_MIN_VER@")
-set(OpenBabel2_VERSION_PATCH   "@BABEL_PATCH_VER@")
-set(OpenBabel2_VERSION         "@BABEL_VERSION@")
+set(OpenBabel3_VERSION_MAJOR   "@BABEL_MAJ_VER@")
+set(OpenBabel3_VERSION_MINOR   "@BABEL_MIN_VER@")
+set(OpenBabel3_VERSION_PATCH   "@BABEL_PATCH_VER@")
+set(OpenBabel3_VERSION         "@BABEL_VERSION@")
 
-set(OpenBabel2_INCLUDE_DIRS "@OpenBabel2_INCLUDE_DIRS@")
-set(OpenBabel2_EXPORTS_FILE "@OB_EXPORTS_FILE@")
-set(OpenBabel2_ENABLE_VERSIONED_FORMATS "@ENABLE_VERSIONED_FORMATS@")
+set(OpenBabel3_INCLUDE_DIRS "@OpenBabel3_INCLUDE_DIRS@")
+set(OpenBabel3_EXPORTS_FILE "@OB_EXPORTS_FILE@")
+set(OpenBabel3_ENABLE_VERSIONED_FORMATS "@ENABLE_VERSIONED_FORMATS@")
 
 # Include the exports file to import the exported OpenBabel targets
-include("${OpenBabel2_EXPORTS_FILE}")
+include("${OpenBabel3_EXPORTS_FILE}")

--- a/OpenBabel3ConfigVersion.cmake.in
+++ b/OpenBabel3ConfigVersion.cmake.in
@@ -1,4 +1,4 @@
-# OpenBabel2 CMake version file - http://www.openbabel.org/
+# OpenBabel3 CMake version file - http://www.openbabel.org/
 
 set(PACKAGE_VERSION @BABEL_MAJ_VER@.@BABEL_MIN_VER@.@BABEL_PATCH_VER@)
 

--- a/doc/examples/static_executable/CMakeLists.txt
+++ b/doc/examples/static_executable/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # This script can be used to create static executables linking to the static
-# OpenBabel2 library.
+# OpenBabel3 library.
 #
 # This script requires OpenBabel to be build and installed. For example:
 #
-#  cd openbabel-2.3
+#  cd openbabel
 #  mkdir build
 #  cd build
 #  cmake -DBUILD_SHARED=OFF -DCMAKE_INSTALL_PREFIX=/home/me/some/path ..
@@ -16,7 +16,7 @@
 #  cd myproject
 #  mkdir build
 #  cd build
-#  cmake -DOpenBabel2_DIR=/home/me/some/path/lib/openbabel ..
+#  cmake -DOpenBabel3_DIR=/home/me/some/path/lib/openbabel ..
 #  make
 #
 # All plugins are inside the static libopenbabel.a but the symbols for the
@@ -53,17 +53,17 @@ else()
   set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 endif()
 
-# Set the path containing OpenBabel2Config.cmake, needed for find_package below.
-find_path(OpenBabel2_DIR OpenBabel2Config.cmake PATHS
-          ${OpenBabel2_DIR}
+# Set the path containing OpenBabel3Config.cmake, needed for find_package below.
+find_path(OpenBabel3_DIR OpenBabel3Config.cmake PATHS
+          ${OpenBabel3_DIR}
           "/usr/lib/openbabel"
          "/usr/local/lib/openbabel")
 
 #
-# Find and setup OpenBabel2.
+# Find and setup OpenBabel3.
 #
-find_package(OpenBabel2 REQUIRED)
-include_directories(${OpenBabel2_INCLUDE_DIRS})
+find_package(OpenBabel3 REQUIRED)
+include_directories(${OpenBabel3_INCLUDE_DIRS})
 
 # Dependencies
 find_package(LibXml2)

--- a/doc/obabel.1
+++ b/doc/obabel.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obabel 1 URM
 .Sh NAME
 .Nm obabel

--- a/doc/obchiral.1
+++ b/doc/obchiral.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obchiral 1 URM
 .Sh NAME
 .Nm obchiral

--- a/doc/obconformer.1
+++ b/doc/obconformer.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obconformer 1 URM
 .Sh NAME
 .Nm obconformer

--- a/doc/obdistgen.1
+++ b/doc/obdistgen.1
@@ -1,5 +1,5 @@
-.Dd October 26, 2017
-.Os "Open Babel" 2.4.1
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obdistgen 1 URM
 .Sh NAME
 .Nm obdistgen

--- a/doc/obenergy.1
+++ b/doc/obenergy.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obenergy 1 URM
 .Sh NAME
 .Nm obenergy

--- a/doc/obfit.1
+++ b/doc/obfit.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obfit 1 URM
 .Sh NAME
 .Nm obfit

--- a/doc/obgen.1
+++ b/doc/obgen.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obgen 1 URM
 .Sh NAME
 .Nm obgen

--- a/doc/obgrep.1
+++ b/doc/obgrep.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obgrep 1 URM
 .Sh NAME
 .Nm obgrep

--- a/doc/obgui.1
+++ b/doc/obgui.1
@@ -1,5 +1,5 @@
-.Dd June 2, 2012
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obgui 1 URM
 .Sh NAME
 .Nm obgui

--- a/doc/obminimize.1
+++ b/doc/obminimize.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obminimize 1 URM
 .Sh NAME
 .Nm obminimize

--- a/doc/obprobe.1
+++ b/doc/obprobe.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obprobe 1 URM
 .Sh NAME
 .Nm obprobe

--- a/doc/obprop.1
+++ b/doc/obprop.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obprop 1 URM
 .Sh NAME
 .Nm obprop

--- a/doc/obrms.1
+++ b/doc/obrms.1
@@ -1,5 +1,5 @@
-.Dd October 26, 2017
-.Os "Open Babel" 2.4.1
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obrms 1 URM
 .Sh NAME
 .Nm obrms

--- a/doc/obrotamer.1
+++ b/doc/obrotamer.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obrotamer 1 URM
 .Sh NAME
 .Nm obrotamer

--- a/doc/obrotate.1
+++ b/doc/obrotate.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obrotate 1 URM
 .Sh NAME
 .Nm obrotate

--- a/doc/obspectrophore.1
+++ b/doc/obspectrophore.1
@@ -1,5 +1,5 @@
-.Dd June 2, 2012
-.Os "Open Babel" 2.3
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obspectrophore 1 URM
 .Sh NAME
 .Nm obspectrophore

--- a/doc/obsym.1
+++ b/doc/obsym.1
@@ -1,5 +1,5 @@
-.Dd October 26, 2017
-.Os "Open Babel" 2.4.1
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obsym 1 URM
 .Sh NAME
 .Nm obsym

--- a/doc/obtautomer.1
+++ b/doc/obtautomer.1
@@ -1,5 +1,5 @@
-.Dd October 26, 2017
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obtautomer 1 URM
 .Sh NAME
 .Nm obtautomer

--- a/doc/obthermo.1
+++ b/doc/obthermo.1
@@ -1,5 +1,5 @@
-.Dd October 26, 2017
-.Os "Open Babel" 2.4.1
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt obthermo 1 URM
 .Sh NAME
 .Nm obthermo

--- a/doc/roundtrip.1
+++ b/doc/roundtrip.1
@@ -1,5 +1,5 @@
-.Dd July 4, 2008
-.Os "Open Babel" 2.2
+.Dd Oct 10, 2019
+.Os "Open Babel" 3.0
 .Dt roundtrip 1 URM
 .Sh NAME
 .Nm roundtrip

--- a/scripts/java/README
+++ b/scripts/java/README
@@ -13,7 +13,7 @@ http://openbabel.org/wiki/Java
 
   First of all, set some environment variables (remember to change the paths to correspond to your system):
 $ export JAVA_HOME=/home/noel/Tools/jdk1.5.0_15
-$ export OB_JAVADIR=/home/noel/Tools/openbabel-2.2.0/scripts/java
+$ export OB_JAVADIR=/home/noel/Tools/openbabel-3.0.0/scripts/java
 $ export OB_LIBDIR=/home/noel/tree/lib # The install location of libopenbabel.so
 
   Next, compile the Java bindings:

--- a/scripts/perl/META.yml
+++ b/scripts/perl/META.yml
@@ -1,7 +1,7 @@
 # http://module-build.sourceforge.net/META-spec.html
 #XXXXXXX This is a prototype!!!  It will change in the future!!! XXXXX#
 name:         Chemistry-OpenBabel
-version:      1.3
+version:      1.4
 version_from: 
 installdirs:  site
 requires:

--- a/scripts/perl/README
+++ b/scripts/perl/README
@@ -1,4 +1,4 @@
-Chemistry::OpenBabel version 1.3
+Chemistry::OpenBabel version 1.4
 ================================
 
 This module provides a Perl interface to the Open Babel chemistry library. 
@@ -34,7 +34,7 @@ installed Open Babel):
 DEPENDENCIES
 
      perl-5.6.0 or a more recent version.
-     openbabel-2.1 or a more recent version.
+     openbabel-3 or a more recent version.
 
 Note that if you are trying to build/run this Perl code in the Open
 Babel source/build directory BEFORE you install Open Babel, you may

--- a/scripts/python/README.rst
+++ b/scripts/python/README.rst
@@ -30,7 +30,7 @@ Dependencies
 ------------
 
 -  Python 2.4 or a more recent version.
--  Open Babel 2.3.0 or a more recent version.
+-  Open Babel 3 or a more recent version.
 
 Installation
 ------------
@@ -45,8 +45,8 @@ Installation
 
 ::
 
-    tar -xzvf openbabel-1.8.1.tar.gz
-    cd openbabel-1.8.1
+    tar -xzvf openbabel-3-0-0.tar.gz
+    cd openbabel-openbabel-3-0-0
     python setup.py install
     
 **Option 3**: While building Open Babel itself.

--- a/src/doxygen_pages.cpp
+++ b/src/doxygen_pages.cpp
@@ -13,22 +13,22 @@ namespace OpenBabel {
  * common dependencies. A module to find openbabel is included in the
  * release or can be copied below. The filename of modules to find
  * packages must start with Find. For example, the default filename for
- * the openbabel module is FindOpenBabel2.cmake. This file is usually
+ * the openbabel module is FindOpenBabel3.cmake. This file is usually
  * placed in the cmake/modules directory of your project. This path must
  * be specified by setting the CMAKE_MODULE_PATH variable. Next,  calling
  * find_package will execute the module to find openbabel and set 3
  * variables.
  *
- * @li OPENBABEL2_FOUND
- * @li OPENBABEL2_INCLUDE_DIR
- * @li OPENBABEL2_LIBRARIES
+ * @li OPENBABEL3_FOUND
+ * @li OPENBABEL3_INCLUDE_DIR
+ * @li OPENBABEL3_LIBRARIES
  *
  * The find_package command allows you to specify the package is required
  * and cmake will handle this further. If openbabel is optional, the
  * first variable can be used in your cmake logic to optionally build the
  * additional code. Since find_package only sets variables, you still
- * need to call include_directories with OPENBABEL2_INCLUDE_DIR in the
- * argument list. The OPENBABEL2_LIBRARIES variable can be used directly
+ * need to call include_directories with OPENBABEL3_INCLUDE_DIR in the
+ * argument list. The OPENBABEL3_LIBRARIES variable can be used directly
  * in your target_link_libraries command.
  *
  * Below is a minimal but working example of a project. For simplicity,
@@ -49,15 +49,15 @@ project(myproject)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 # find and setup openbabel
-find_package(OpenBabel2 REQUIRED)
-include_directories(${OPENBABEL2_INCLUDE_DIR})
+find_package(OpenBabel3 REQUIRED)
+include_directories(${OPENBABEL3_INCLUDE_DIR})
 
 # create a list of source files (easier to maintain)
 set(sources main.cpp)
 
 # the executable
 add_executable(myexe ${sources})
-target_link_libraries(myexe ${OPENBABEL2_LIBRARIES})
+target_link_libraries(myexe ${OPENBABEL3_LIBRARIES})
 install(TARGETS myexe DESTINATION bin)
    @endcode
    @b main.cpp
@@ -76,105 +76,105 @@ int main()
 }
    @endcode
 
-   @b cmake/modules/FindOpenBabel2.cmake
+   @b cmake/modules/FindOpenBabel3.cmake
    @code
-# - Try to find OpenBabel2
+# - Try to find OpenBabel3
 # Once done this will define
 #
-#  OPENBABEL2_FOUND - system has OpenBabel2
-#  OPENBABEL2_INCLUDE_DIR - the OpenBabel2 include directory
-#  OPENBABEL2_LIBRARIES - Link these to use OpenBabel2
+#  OPENBABEL3_FOUND - system has OpenBabel3
+#  OPENBABEL3_INCLUDE_DIR - the OpenBabel3 include directory
+#  OPENBABEL3_LIBRARIES - Link these to use OpenBabel3
 #
 # Copyright (c) 2006, 2007 Carsten Niehaus, <cniehaus@gmx.de>
 # Copyright (C) 2008 Marcus D. Hanwell <marcus@cryos.org>
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
-if (OPENBABEL2_INCLUDE_DIR AND OPENBABEL2_LIBRARIES AND OPENBABEL2_VERSION_MET)
+if (OPENBABEL3_INCLUDE_DIR AND OPENBABEL3_LIBRARIES AND OPENBABEL3_VERSION_MET)
   # in cache already
-  set(OPENBABEL2_FOUND TRUE)
+  set(OPENBABEL3_FOUND TRUE)
 
-else (OPENBABEL2_INCLUDE_DIR AND OPENBABEL2_LIBRARIES AND OPENBABEL2_VERSION_MET)
+else (OPENBABEL3_INCLUDE_DIR AND OPENBABEL3_LIBRARIES AND OPENBABEL3_VERSION_MET)
   if(NOT WIN32)
 
     # Use the newer PkgConfig stuff
     find_package(PkgConfig REQUIRED)
-    pkg_check_modules(OPENBABEL2 openbabel-2.0>=2.2.0)
+    pkg_check_modules(OPENBABEL3 openbabel-3>=3.0.0)
 
     # Maintain backwards compatibility with previous version of module
-    if(OPENBABEL2_FOUND STREQUAL "1")
-      set(OPENBABEL2_VERSION_MET TRUE)
-      set(OPENBABEL2_INCLUDE_DIR ${OPENBABEL2_INCLUDE_DIRS})
-    endif(OPENBABEL2_FOUND STREQUAL "1")
+    if(OPENBABEL3_FOUND STREQUAL "1")
+      set(OPENBABEL3_VERSION_MET TRUE)
+      set(OPENBABEL3_INCLUDE_DIR ${OPENBABEL3_INCLUDE_DIRS})
+    endif(OPENBABEL3_FOUND STREQUAL "1")
 
   else(NOT WIN32)
-    set(OPENBABEL2_VERSION_MET TRUE)
+    set(OPENBABEL3_VERSION_MET TRUE)
   endif(NOT WIN32)
 
-  if(OPENBABEL2_VERSION_MET)
+  if(OPENBABEL3_VERSION_MET)
 
     if(WIN32)
-      if(NOT OPENBABEL2_INCLUDE_DIR)
-        find_path(OPENBABEL2_INCLUDE_DIR openbabel-2.0/openbabel/obconversion.h
+      if(NOT OPENBABEL3_INCLUDE_DIR)
+        find_path(OPENBABEL3_INCLUDE_DIR openbabel-3/openbabel/obconversion.h
           PATHS
           ${_obIncDir}
           ${GNUWIN32_DIR}/include
-          $ENV{OPENBABEL2_INCLUDE_DIR}
+          $ENV{OPENBABEL3_INCLUDE_DIR}
         )
-        if(OPENBABEL2_INCLUDE_DIR)
-          set(OPENBABEL2_INCLUDE_DIR ${OPENBABEL2_INCLUDE_DIR}/openbabel-2.0)
-        endif(OPENBABEL2_INCLUDE_DIR)
-      endif(NOT OPENBABEL2_INCLUDE_DIR)
+        if(OPENBABEL3_INCLUDE_DIR)
+          set(OPENBABEL3_INCLUDE_DIR ${OPENBABEL3_INCLUDE_DIR}/openbabel-3)
+        endif(OPENBABEL3_INCLUDE_DIR)
+      endif(NOT OPENBABEL3_INCLUDE_DIR)
     endif(WIN32)
 
-    find_library(OPENBABEL2_LIBRARIES NAMES openbabel openbabel-2
+    find_library(OPENBABEL3_LIBRARIES NAMES openbabel openbabel-3
       PATHS
       ${_obLinkDir}
       ${GNUWIN32_DIR}/lib
-      $ENV{OPENBABEL2_LIBRARIES}
+      $ENV{OPENBABEL3_LIBRARIES}
     )
-  endif(OPENBABEL2_VERSION_MET)
+  endif(OPENBABEL3_VERSION_MET)
 
-  if(OPENBABEL2_INCLUDE_DIR AND OPENBABEL2_LIBRARIES AND OPENBABEL2_VERSION_MET)
-    set(OPENBABEL2_FOUND TRUE)
-  endif(OPENBABEL2_INCLUDE_DIR AND OPENBABEL2_LIBRARIES AND OPENBABEL2_VERSION_MET)
+  if(OPENBABEL3_INCLUDE_DIR AND OPENBABEL3_LIBRARIES AND OPENBABEL3_VERSION_MET)
+    set(OPENBABEL3_FOUND TRUE)
+  endif(OPENBABEL3_INCLUDE_DIR AND OPENBABEL3_LIBRARIES AND OPENBABEL3_VERSION_MET)
 
-  if (OPENBABEL2_FOUND)
-    if (NOT OpenBabel2_FIND_QUIETLY)
-      message(STATUS "Found OpenBabel 2.2 or later: ${OPENBABEL2_LIBRARIES}")
-    endif (NOT OpenBabel2_FIND_QUIETLY)
-  else (OPENBABEL2_FOUND)
-    if (OpenBabel2_FIND_REQUIRED)
-      message(FATAL_ERROR "Could NOT find OpenBabel 2.2 or later ")
-    endif (OpenBabel2_FIND_REQUIRED)
-  endif (OPENBABEL2_FOUND)
+  if (OPENBABEL3_FOUND)
+    if (NOT OpenBabel3_FIND_QUIETLY)
+      message(STATUS "Found OpenBabel 3.0 or later: ${OPENBABEL3_LIBRARIES}")
+    endif (NOT OpenBabel3_FIND_QUIETLY)
+  else (OPENBABEL3_FOUND)
+    if (OpenBabel3_FIND_REQUIRED)
+      message(FATAL_ERROR "Could NOT find OpenBabel 3.0 or later ")
+    endif (OpenBabel3_FIND_REQUIRED)
+  endif (OPENBABEL3_FOUND)
 
-  mark_as_advanced(OPENBABEL2_INCLUDE_DIR OPENBABEL2_LIBRARIES)
+  mark_as_advanced(OPENBABEL3_INCLUDE_DIR OPENBABEL3_LIBRARIES)
 
-endif (OPENBABEL2_INCLUDE_DIR AND OPENBABEL2_LIBRARIES AND OPENBABEL2_VERSION_MET)
+endif (OPENBABEL3_INCLUDE_DIR AND OPENBABEL3_LIBRARIES AND OPENBABEL3_VERSION_MET)
 
-# Search for Open Babel2 executable
-if(OPENBABEL2_EXECUTABLE)
+# Search for Open Babel3 executable
+if(OPENBABEL3_EXECUTABLE)
 
   # in cache already
-  set(OPENBABEL2_EXECUTABLE_FOUND TRUE)
+  set(OPENBABEL3_EXECUTABLE_FOUND TRUE)
 
-else(OPENBABEL2_EXECUTABLE)
-  find_program(OPENBABEL2_EXECUTABLE NAMES babel
+else(OPENBABEL3_EXECUTABLE)
+  find_program(OPENBABEL3_EXECUTABLE NAMES babel
     PATHS
-    [HKEY_CURRENT_USER\\SOFTWARE\\OpenBabel\ 2.2.0]
-    $ENV{OPENBABEL2_EXECUTABLE}
+    [HKEY_CURRENT_USER\\SOFTWARE\\OpenBabel\ 3]
+    $ENV{OPENBABEL3_EXECUTABLE}
   )
 
-  if(OPENBABEL2_EXECUTABLE)
-    set(OPENBABEL2_EXECUTABLE_FOUND TRUE)
-  endif(OPENBABEL2_EXECUTABLE)
+  if(OPENBABEL3_EXECUTABLE)
+    set(OPENBABEL3_EXECUTABLE_FOUND TRUE)
+  endif(OPENBABEL3_EXECUTABLE)
 
-  if(OPENBABEL2_EXECUTABLE_FOUND)
-    message(STATUS "Found OpenBabel2 executable: ${OPENBABEL2_EXECUTABLE}")
-  endif(OPENBABEL2_EXECUTABLE_FOUND)
+  if(OPENBABEL3_EXECUTABLE_FOUND)
+    message(STATUS "Found OpenBabel3 executable: ${OPENBABEL3_EXECUTABLE}")
+  endif(OPENBABEL3_EXECUTABLE_FOUND)
 
-endif(OPENBABEL2_EXECUTABLE)
+endif(OPENBABEL3_EXECUTABLE)
    @endcode
  *
  */


### PR DESCRIPTION
- Update INSTALL and READMEs under scripts/
    - perl
        - assume perl-binding version is different from Open Babel's
    - python
        - assume tarball from github release page
        - note: `python scripts/python/setup.py install` does not work since `__init__.py` is missing
- Update version and release date of man
- Update variables in CMake files to version 3
- Update scripts/python/setup.py
