### PR TITLE
Find or build maeparser & coordgen libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
  - sudo apt-get update -qq
 
 install:
- - sudo apt-get install -qq swig libeigen3-dev
+ - sudo apt-get install -qq swig libeigen3-dev libboost-all-dev
 
 before_script:
  - mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ if(WITH_MAEPARSER)
 
     else()
 
-      set(MAEPARSER_VERSION "v1.2.2" CACHE STRING "Maeparser fallback version to download")
+      set(MAEPARSER_VERSION "master" CACHE STRING "Maeparser fallback version to download")
 
       set(MAEPARSER_DIR "${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION}")
 
@@ -517,10 +517,7 @@ if(WITH_MAEPARSER)
           execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf "maeparser-${MAEPARSER_VERSION}.tar.gz"
               WORKING_DIRECTORY "${MAEPARSER_DIR}")
 
-          message(STATUS "${MAEPARSER_DIR}")
-
           find_path(MAEPARSER_UNPACK_DIR "CMakeLists.txt" PATH "${MAEPARSER_DIR}/*" NO_DEFAULT_PATH)
-          message(STATUS ${MAEPARSER_UNPACK_DIR})
 
           if(MAEPARSER_UNPACK_DIR)
             file(RENAME "${MAEPARSER_UNPACK_DIR}" "${MAEPARSER_DIR}/maeparser")
@@ -558,7 +555,7 @@ if(WITH_COORDGEN)
 
     else()
 
-      set(COORDGEN_VERSION "v1.3.2" CACHE STRING "Coordgen fallback version to download")
+      set(COORDGEN_VERSION "master" CACHE STRING "Coordgen fallback version to download")
 
       set(COORDGEN_DIR "${openbabel_SOURCE_DIR}/external/coordgen-${COORDGEN_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,31 +482,123 @@ find_package(Boost)
 if(Boost_FOUND AND BUILD_SHARED)
     include_directories(${Boost_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
     option(WITH_MAEPARSER "Build Maestro support" ON)
+    option(WITH_COORDGEN "Build Coordgen support" ON)
 else()
     option(WITH_MAEPARSER "Build Maestro support" OFF)
+    option(WITH_COORDGEN "Build Coordgen support" OFF)
+endif()
+
+if(WITH_MAEPARSER)
+
+    find_package(maeparser MODULE QUIET)
+
+    if (maeparser_FOUND)
+
+      message(STATUS "Maestro formats will be supported. Using MaeParser libraries at ${maeparser_LIBRARIES}.")
+
+    else()
+
+      set(MAEPARSER_VERSION "master")
+
+      set(MAEPARSER_DIR "${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION}")
+
+      # Do not build the test, as it will be put into the bin dir, where it won't be found by the test runner.
+      set(MAEPARSER_BUILD_TESTS OFF CACHE BOOL "Disable Maeparser tests")
+
+      if(EXISTS "${MAEPARSER_DIR}/maeparser/CMakeLists.txt")
+
+        message(STATUS "Building existing MaeParser '${MAEPARSER_VERSION}' source at ${MAEPARSER_DIR}.")
+
+      else()
+
+          file(DOWNLOAD "https://github.com/schrodinger/maeparser/archive/${MAEPARSER_VERSION}.tar.gz"
+              "${MAEPARSER_DIR}/maeparser-${MAEPARSER_VERSION}.tar.gz")
+
+          execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf "maeparser-${MAEPARSER_VERSION}.tar.gz"
+              WORKING_DIRECTORY "${MAEPARSER_DIR}")
+
+          file(RENAME "${MAEPARSER_DIR}/maeparser-${MAEPARSER_VERSION}" "${MAEPARSER_DIR}/maeparser")
+
+          if(EXISTS "${MAEPARSER_DIR}/maeparser/CMakeLists.txt")
+            message(STATUS "Downloaded MaeParser '${MAEPARSER_VERSION}' to ${MAEPARSER_DIR}.")
+          else()
+            message(FATAL_ERROR "Failed getting or unpacking Maeparser '${MAEPARSER_VERSION}'.")
+          endif()
+
+      endif()
+
+      add_subdirectory("${MAEPARSER_DIR}/maeparser")
+
+      set(maeparser_INCLUDE_DIRS "${MAEPARSER_DIR}")
+      set(maeparser_LIBRARIES maeparser)
+
+      message(STATUS "Maestro formats will be supported. Using MaeParser '${MAEPARSER_VERSION}' at ${MAEPARSER_DIR}")
+
+    endif()
+
+    include_directories(${maeparser_INCLUDE_DIRS})
+    set(libs ${libs} ${maeparser_LIBRARIES})
+
+else()
+    message(STATUS "Maestro formats will NOT be supported. Please install Boost to enable Maestro formats.")
 endif()
 
 
-if(WITH_MAEPARSER)
-    set (CMAKE_CXX_STANDARD 11)
+if(WITH_COORDGEN)
 
-    set(MAEPARSER_VERSION 1.1)
-    if(NOT EXISTS "${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION}")
-        file(DOWNLOAD "https://github.com/schrodinger/maeparser/archive/v${MAEPARSER_VERSION}.tar.gz"
-            "${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION}.tar.gz" STATUS status)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
-            ${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION}.tar.gz
-            WORKING_DIRECTORY ${openbabel_SOURCE_DIR}/external)
-        message(STATUS "Downloaded MaeParser to ${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION}.")
+    find_package(coordgen MODULE QUIET)
+
+    if (coordgen_FOUND)
+
+      message(STATUS "Coordinate generation with Coordgen will be supported. Using Coordgen libraries at ${coordgen_LIBRARIES}.")
+
+    else()
+
+      set(COORDGEN_VERSION "master")
+
+      set(COORDGEN_DIR "${openbabel_SOURCE_DIR}/external/coordgen-${COORDGEN_VERSION}")
+
+      # These won't work, since openbabel relocates them to the "bin" dir
+      set(COORDGEN_BUILD_TESTS OFF CACHE BOOL "Disable building Coordgen tests")
+      set(COORDGEN_BUILD_EXAMPLE OFF CACHE BOOL "Disable building Coordgen example")
+
+      if(EXISTS "${COORDGEN_DIR}/coordgen/CMakeLists.txt")
+
+        message(STATUS "Building existing Coordgen '${COORDGEN_VERSION}' source at ${COORDGEN_DIR}.")
+
+      else()
+
+          file(DOWNLOAD "https://github.com/schrodinger/coordgenlibs/archive/${COORDGEN_VERSION}.tar.gz"
+              "${COORDGEN_DIR}/coordgenlibs-${COORDGEN_VERSION}.tar.gz")
+
+          execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf "coordgenlibs-${COORDGEN_VERSION}.tar.gz"
+              WORKING_DIRECTORY "${COORDGEN_DIR}")
+
+          file(RENAME "${COORDGEN_DIR}/coordgenlibs-${COORDGEN_VERSION}" "${COORDGEN_DIR}/coordgen")
+
+          if(EXISTS "${COORDGEN_DIR}/coordgen/CMakeLists.txt")
+            message(STATUS "Downloaded Coordgen '${COORDGEN_VERSION}' to ${COORDGEN_DIR}.")
+          else()
+            message(FATAL_ERROR "Failed getting or unpacking Coordgen '${COORDGEN_VERSION}'.")
+          endif()
+
+      endif()
+
+      add_subdirectory("${COORDGEN_DIR}/coordgen")
+
+      set(coordgen_INCLUDE_DIRS "${COORDGEN_DIR}")
+      set(coordgen_LIBRARIES coordgen)
+
+
+      message(STATUS "Coordinate generation with Coordgen will be supported Using Coordgen '${COORDGEN_VERSION}' at ${COORDGEN_DIR}")
+
     endif()
-    set(MAEPARSER_DIR ${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION})
-    add_subdirectory(${MAEPARSER_DIR})
-    include_directories(${MAEPARSER_DIR})
-    set(libs ${libs} maeparser)
 
-    message(STATUS "Maestro formats will be supported. Using MaeParser ${MAEPARSER_VERSION} at ${MAEPARSER_INCLUDE_DIRS}")
+    include_directories(${coordgen_INCLUDE_DIRS})
+    set(libs ${libs} ${coordgen_LIBRARIES})
+
 else()
-    message(STATUS "Maestro formats will NOT be supported. Please install Boost to enable Maestro formats.")
+    message(STATUS "Coordinate generation with Coordgen will NOT be supported. Please install Boost to enable Maestro formats.")
 endif()
 
 option(WITH_JSON "Build JSON support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ if(WITH_MAEPARSER)
 
     else()
 
-      set(MAEPARSER_VERSION "master")
+      set(MAEPARSER_VERSION "v1.2.2" CACHE STRING "Maeparser fallback version to download")
 
       set(MAEPARSER_DIR "${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION}")
 
@@ -517,9 +517,13 @@ if(WITH_MAEPARSER)
           execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf "maeparser-${MAEPARSER_VERSION}.tar.gz"
               WORKING_DIRECTORY "${MAEPARSER_DIR}")
 
-          file(RENAME "${MAEPARSER_DIR}/maeparser-${MAEPARSER_VERSION}" "${MAEPARSER_DIR}/maeparser")
+          message(STATUS "${MAEPARSER_DIR}")
 
-          if(EXISTS "${MAEPARSER_DIR}/maeparser/CMakeLists.txt")
+          find_path(MAEPARSER_UNPACK_DIR "CMakeLists.txt" PATH "${MAEPARSER_DIR}/*" NO_DEFAULT_PATH)
+          message(STATUS ${MAEPARSER_UNPACK_DIR})
+
+          if(MAEPARSER_UNPACK_DIR)
+            file(RENAME "${MAEPARSER_UNPACK_DIR}" "${MAEPARSER_DIR}/maeparser")
             message(STATUS "Downloaded MaeParser '${MAEPARSER_VERSION}' to ${MAEPARSER_DIR}.")
           else()
             message(FATAL_ERROR "Failed getting or unpacking Maeparser '${MAEPARSER_VERSION}'.")
@@ -554,7 +558,7 @@ if(WITH_COORDGEN)
 
     else()
 
-      set(COORDGEN_VERSION "master")
+      set(COORDGEN_VERSION "v1.3.2" CACHE STRING "Coordgen fallback version to download")
 
       set(COORDGEN_DIR "${openbabel_SOURCE_DIR}/external/coordgen-${COORDGEN_VERSION}")
 
@@ -574,9 +578,10 @@ if(WITH_COORDGEN)
           execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf "coordgenlibs-${COORDGEN_VERSION}.tar.gz"
               WORKING_DIRECTORY "${COORDGEN_DIR}")
 
-          file(RENAME "${COORDGEN_DIR}/coordgenlibs-${COORDGEN_VERSION}" "${COORDGEN_DIR}/coordgen")
+          find_path(COORDGEN_UNPACK_DIR "CMakeLists.txt" PATH "${COORDGEN_DIR}/*" NO_DEFAULT_PATH)
 
-          if(EXISTS "${COORDGEN_DIR}/coordgen/CMakeLists.txt")
+          if(COORDGEN_UNPACK_DIR)
+            file(RENAME "${COORDGEN_UNPACK_DIR}" "${COORDGEN_DIR}/coordgen")
             message(STATUS "Downloaded Coordgen '${COORDGEN_VERSION}' to ${COORDGEN_DIR}.")
           else()
             message(FATAL_ERROR "Failed getting or unpacking Coordgen '${COORDGEN_VERSION}'.")

--- a/cmake/modules/Findcoordgen.cmake
+++ b/cmake/modules/Findcoordgen.cmake
@@ -1,0 +1,46 @@
+# Try to find Schrodinger's CoorgGen libraries.
+#
+# Different version handling is not yet supported
+#
+# Once found, this will find and define the following variables:
+#
+# coordgen_INCLUDE_DIRS   - CoordGen's includes directory
+# coordgen_LIBRARIES      - CoordGen's shared libraries
+# coordgen_TEMPLATE_FILE  - CoordGen templates file
+#
+#
+
+include(FindPackageHandleStandardArgs)
+
+find_path(coordgen_INCLUDE_DIRS
+    NAMES "coordgen/sketcherMinimizer.h"
+    HINTS ${coordgen_DIR}
+    PATH_SUFFIXES "include"
+    DOC "include path for coordgen"
+)
+message(STATUS "coordgen include dir set as ${coordgen_INCLUDE_DIRS}")
+
+find_library(coordgen_LIBRARIES
+    NAMES coordgen coordgenlibs
+    HINTS ${coordgen_DIR}
+    PATH_SUFFIXES "lib"
+    DOC "libraries for coordgen"
+)
+message(STATUS "coordgen libraries set as '${coordgen_LIBRARIES}'")
+
+# Just in case, add parent directory above libraries to templates search hints
+get_filename_component(libs_parent_dir ${coordgen_LIBRARIES} PATH)
+find_file(coordgen_TEMPLATE_FILE
+    NAMES templates.mae
+    HINTS ${coordgen_DIR} ${libs_parent_dir}
+    PATH_SUFFIXES "share" "share/coordgen"
+    DOC "templates file for coordgen"
+)
+message(STATUS "coordgen templates file set as '${coordgen_TEMPLATE_FILE}'")
+
+find_package_handle_standard_args(coordgen FOUND_VAR coordgen_FOUND
+                                  REQUIRED_VARS coordgen_INCLUDE_DIRS
+                                  coordgen_LIBRARIES coordgen_TEMPLATE_FILE)
+
+
+

--- a/cmake/modules/Findmaeparser.cmake
+++ b/cmake/modules/Findmaeparser.cmake
@@ -1,0 +1,32 @@
+# Try to find Schrodinger's MAEParser libraries.
+#
+# Different version handling is not yet supported
+#
+# Once found, this will find and define the following variables:
+#
+# maeparser_INCLUDE_DIRS  - maeparser's includes directory
+# maeparser_LIBRARIES     - maeparser's shared libraries
+#
+#
+
+include(FindPackageHandleStandardArgs)
+
+find_path(maeparser_INCLUDE_DIRS
+    NAMES "maeparser/Reader.hpp"
+    HINTS ${maeparser_DIR}
+    PATH_SUFFIXES "include"
+    DOC "include path for maeparser"
+)
+message(STATUS "maeparser include dir set as '${maeparser_INCLUDE_DIRS}'")
+
+find_library(maeparser_LIBRARIES
+    NAMES maeparser
+    HINTS ${maeparser_DIR}
+    PATH_SUFFIXES "lib"
+    DOC "libraries for maeparser"
+)
+message(STATUS "maeparser libraries set as '${maeparser_LIBRARIES}'")
+
+find_package_handle_standard_args(maeparser FOUND_VAR maeparser_FOUND
+                                  REQUIRED_VARS maeparser_INCLUDE_DIRS
+                                  maeparser_LIBRARIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SOVERSION 6)
 set(LIBRARY_VERSION 6.0.0)
 
 
-find_package(Boost 1.45.0 COMPONENTS system) 
+find_package(Boost 1.45.0 COMPONENTS system)
 
 
 
@@ -248,8 +248,8 @@ add_library(openbabel ${BUILD_TYPE}
   )
 
 target_link_libraries(openbabel ${libs})
-if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS}) 
+if(Boost_FOUND AND (BUILD_SHARED OR BUILD_MIXED))
+    include_directories(${Boost_INCLUDE_DIRS})
     target_link_libraries(openbabel ${Boost_LIBRARIES} )
     find_package(Threads REQUIRED)
     if(THREADS_HAVE_PTHREAD_ARG)

--- a/src/formats/maeformat.cpp
+++ b/src/formats/maeformat.cpp
@@ -29,9 +29,9 @@ GNU General Public License for more details.
 #include <iostream>
 #include <map>
 
-#include <MaeConstants.hpp>
-#include <Reader.hpp>
-#include <Writer.hpp>
+#include <maeparser/MaeConstants.hpp>
+#include <maeparser/Reader.hpp>
+#include <maeparser/Writer.hpp>
 
 using namespace std;
 using namespace schrodinger::mae;


### PR DESCRIPTION
This is meant as an improvement: with these changes, CMake first checks if there is a build of Schrödinger's maeparser and coordgen libraries that can be used in openbabel's build. If there isn't, then, this patch downloads the sources and builds them.

This means that it addresses #2015.

Some notes:
- CMake will, by default, look in standard library and include directories for the built library and the required headers. Other directories can be specified for the lookup by using "maeparser_DIR" and "coordgen_DIR".
- By default, the "master" branch of maeparser and coordgen will be downloaded from GitHub. This can be changed using the "MAEPARSER_VERSION" and "COORDGEN_VERSION" variables, pointing them to specific tags, branches or commits.
- If sources are already present at the directory where CMake would put them, the download step will be skipped, and the available sources will be used.
- Both maeparser and coordgen test executables will not be built. In case they are, ctest won't be able to find them, since they will be put in the "bin" directory, together with the rest of the openbabel executables.
- Boost threads need to be disabled in case of a static build, or the build will fail (I haven't investigated this too much, but probably the Boost libraries are not built using --static-libgcc.