### PR TITLE
Fixed warnings in libinchi

### DIFF
--- a/src/formats/libinchi/ichican2.c
+++ b/src/formats/libinchi/ichican2.c
@@ -3071,9 +3071,9 @@ L8: /* here nu is discrete: check rho for being a bettere leaf or isomorphism */
     /*if ( !lab || qzb_rho < 0 || !QZFIX_OK(qzb_rho_fix) )*/
     if ( !lab || ((qzb_rho < 0) && ( !pzb_rho_fix || qzb_rho_fix > 0 )) )
         goto L6;
-    if ( pzb_rho_fix && kLeast_rho_fix && 0 == qzb_rho_fix ) {
+    if ( pzb_rho_fix && MAX_LAYERS > 0 && 0 == qzb_rho_fix ) {
         /* check for the rejection condition: Lambda > zb_rho_fix */
-        if ( kLeast_rho_fix ) {
+        if ( MAX_LAYERS > 0 ) {
             int qzb_rho_fix_alt;
             qzb_rho_fix     = CtFullCompareLayers( kLeast_rho_fix );
             /* for debug only */
@@ -3111,7 +3111,7 @@ L8: /* here nu is discrete: check rho for being a bettere leaf or isomorphism */
     /* !!! we should never come here if G(nu) != G(rho): CtPartCompare must be enough !!! */
     
     /* if ( G(nu) > G(rho) ) goto L9; */
-    if ( kLeast_rho ) {
+    if ( MAX_LAYERS > 0 ) {
         int cur_qzb_alt;
         qzb_rho =     CtFullCompareLayers( kLeast_rho );
         /* for debug only */

--- a/src/formats/libinchi/ichicano.c
+++ b/src/formats/libinchi/ichicano.c
@@ -176,8 +176,7 @@ long InchiTimeMsecDiff( inchiTime *TickEnd, inchiTime *TickStart )
         FillMaxMinClock( );
         if ( !TickEnd || !TickStart )
             return 0;
-        if ( (TickEnd->clockTime >= 0 && TickStart->clockTime >= 0) ||
-             (TickEnd->clockTime <= 0 && TickStart->clockTime <= 0)) {
+        if ( (TickEnd->clockTime <= 0 && TickStart->clockTime <= 0)) {
             delta = TickEnd->clockTime - TickStart->clockTime;
         } else
         if ( TickEnd->clockTime >= HalfMaxPositiveClock &&
@@ -257,8 +256,7 @@ int bInchiTimeIsOver( inchiTime *TickStart )
         if ( !TickStart )
             return 0;
         clockCurrTime = InchiClock();
-        if ( (clockCurrTime >= 0 && TickStart->clockTime >= 0) ||
-             (clockCurrTime <= 0 && TickStart->clockTime <= 0)) {
+        if ( (clockCurrTime <= 0 && TickStart->clockTime <= 0)) {
             return (clockCurrTime > TickStart->clockTime);
         } else
         if ( clockCurrTime >= HalfMaxPositiveClock &&


### PR DESCRIPTION
The stack array kLeast_rho_fix is initiated as an array with
MAX_LAYERS entries. It was used as a pointer in statements to
test whether the pointer is NULL. The clang compiler did not
like this and therefore an alternative test for MAX_LAYERS>0
is used.