### PR TITLE
Fix maeparser compile error with some Boost configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -478,7 +478,7 @@ endif()
 #cjh
 
 
-find_package(Boost)
+find_package(Boost COMPONENTS filesystem iostreams unit_test_framework)
 if(Boost_FOUND AND BUILD_SHARED)
     include_directories(${Boost_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
     option(WITH_MAEPARSER "Build Maestro support" ON)


### PR DESCRIPTION
When working on the Windows conda-forge versions, I got a compile error on the maeparser code (https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=90306&view=logs&jobId=171a126d-c574-5c8c-1269-ff3b989e923d&taskId=7225e372-3a5e-5b11-c153-719d50bbeacd&lineStart=510&lineEnd=528&colStart=1&colEnd=1) due to a mismatch between the calls to find_package in OpenBabel and Maeparser. In OB, there was a check for plain Boost to decide if Maeparser should be built but in the building of Maeparser, there were some component required. This PR will check for those components also in the OB code. That way, if the required components are missing, OB will just drop mae support instead of failing to compile.

There are still several checks for Boost libraries in CmakeLists.txt, leading to rather unhelpful logs with alternating "Boost found" and "Boost NOT found" messages in unfortunate cases. There could probably be done more to alleviate this or at least be more clear in the error messages but I'll leave that to someone more experienced with Cmake.