### PR TITLE
Support #0 in SMARTS so that asterisks can be matched

### DIFF
--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -656,8 +656,6 @@ namespace OpenBabel
             LexPtr--;
             return( (AtomExpr*)0 );
           }
-        else if( !index )
-          return( (AtomExpr*)0 );
         return( GenerateElement(index) );
 
       case('$'):

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -54,6 +54,13 @@ class PybelWrapper(PythonBindings):
 
 class TestSuite(PythonBindings):
 
+    def testSmartsSupportsHashZero(self):
+        """Ensure that we can match asterisks in SMILES with SMARTS"""
+        mol = pybel.readstring("smi", "*O")
+        # The following used to raise an OSError (SMARTS parse failure)
+        matches = pybel.Smarts("[#0]O").findall(mol)
+        self.assertEqual(matches, [(1, 2)])
+
     def testInChIIsotopes(self):
         """Ensure that we correctly set and read isotopes in InChIs"""
         with open(os.path.join(here, "inchi", "inchi_isotopes.txt")) as inp:


### PR DESCRIPTION
The SMARTS parser did not support #0 to indicate an asterisk. This PR adds support...by removing two lines from the source code. :-)