### PR TITLE
Fix issue #2095, caused by incorrect application of protonated SMARTS…

### DIFF
--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -377,9 +377,14 @@ bool AliasData::AddAliases(OBMol* pmol)
           }
           else
           {
-            AllExAtoms.insert(idx);
-            int id  =(pmol->GetAtom(idx))->GetId();
-            ad->AddExpandedAtom(id);
+            OBAtom* a = pmol->GetAtom(idx);
+            // atom might not be present in original molecule, because SMARTS are all with hydrogens added
+            // original molecule might lack them
+            if (a != NULL) {
+              AllExAtoms.insert(idx);
+              int id  = a->GetId();
+              ad->AddExpandedAtom(id);
+            }
           }
         }
         if(ad)

--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -344,9 +344,13 @@ bool AliasData::AddAliases(OBMol* pmol)
     LoadFile(smtable);
   set<int> AllExAtoms;
   SmartsTable::iterator iter;
+  // create protonated copy of the molecule for mathing against SMARTS that are all protonated
+  OBMol* protonated = new OBMol(*pmol);
+  unsigned int pmol_atom_count = pmol->NumAtoms();
+  protonated->AddHydrogens();
   for(iter=smtable.begin();iter!=smtable.end();++iter)
   {
-    if((*iter).second->Match(*pmol))
+    if((*iter).second->Match(*protonated))
     {
       vector<std::vector<int> > mlist = (*iter).second->GetUMapList();
       for(unsigned imatch=0;imatch<mlist.size();++imatch) //each match
@@ -357,6 +361,13 @@ bool AliasData::AddAliases(OBMol* pmol)
         for(unsigned iatom=1; iatom<mlist[imatch].size();++iatom)//each atom in match
         {
           int idx = mlist[imatch][iatom];
+          // assume that all atoms added during protonation are added 'on top' of the non-protonated molecule,
+          // so they have ids above pmol_atom_count
+          if (idx > pmol_atom_count) {
+            assert(protonated->GetAtom(idx)->GetAtomicNum() == OBElements::Hydrogen);
+            continue;
+          }
+
           if(AllExAtoms.count(idx))
           {
             //atom already appears in an alias so abandon this (smaller) alias
@@ -376,6 +387,7 @@ bool AliasData::AddAliases(OBMol* pmol)
       }
     }
   }
+  delete protonated;
   return true;
 }
 

--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -344,13 +344,9 @@ bool AliasData::AddAliases(OBMol* pmol)
     LoadFile(smtable);
   set<int> AllExAtoms;
   SmartsTable::iterator iter;
-  // create protonated copy of the molecule for mathing against SMARTS that are all protonated
-  OBMol* protonated = new OBMol(*pmol);
-  unsigned int pmol_atom_count = pmol->NumAtoms();
-  protonated->AddHydrogens();
   for(iter=smtable.begin();iter!=smtable.end();++iter)
   {
-    if((*iter).second->Match(*protonated))
+    if((*iter).second->Match(*pmol))
     {
       vector<std::vector<int> > mlist = (*iter).second->GetUMapList();
       for(unsigned imatch=0;imatch<mlist.size();++imatch) //each match
@@ -361,12 +357,6 @@ bool AliasData::AddAliases(OBMol* pmol)
         for(unsigned iatom=1; iatom<mlist[imatch].size();++iatom)//each atom in match
         {
           int idx = mlist[imatch][iatom];
-          // assume that all atoms added during protonation are added 'on top' of the non-protonated molecule,
-          // so they have ids above pmol_atom_count
-          if (idx > pmol_atom_count) {
-            assert(protonated->GetAtom(idx)->GetAtomicNum() == OBElements::Hydrogen);
-            continue;
-          }
 
           if(AllExAtoms.count(idx))
           {
@@ -392,7 +382,6 @@ bool AliasData::AddAliases(OBMol* pmol)
       }
     }
   }
-  delete protonated;
   return true;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,12 +15,13 @@ add_definitions(-DFORMATDIR="${FORMATDIR}/")
 
 ################ Add new tests here
 set (cpptests
-     automorphism builder canonconsistent canonfragment canonstable carspacegroup cifspacegroup
+     alias automorphism builder canonconsistent canonfragment canonstable carspacegroup cifspacegroup
      cistrans conversion graphsym gzip addh
      implicitH lssr isomorphism multicml regressions rotor shuffle smiles spectrophore
      squareplanar stereo stereoperception tautomer tetrahedral
      tetranonplanar tetraplanar uniqueid
     )
+set (alias_parts 1)
 set (automorphism_parts 1 2 3 4 5 6 7 8 9 10)
 set (builder_parts 1 2 3 4 5)
 set (canonconsistent_parts  1 2 3)

--- a/test/aliastest.cpp
+++ b/test/aliastest.cpp
@@ -1,0 +1,124 @@
+/**********************************************************************
+aliastest.cpp - unit testing code for alias.h and alias.cpp
+Copyright (C) 2019 by Alex Ustinov
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************/
+#include "obtest.h"
+
+#include <openbabel/mol.h>
+#include <openbabel/obconversion.h>
+#include <openbabel/alias.h>
+
+using namespace std;
+using namespace OpenBabel;
+
+// a class for a test case should contain smiles of the molecule, number of aliases that
+// are expected to be produced, and number of irreducible atoms that are not parts of aliases
+// note this test uses standard superatom.txt file shipped with OpenBabel
+/*
+CO2Et    EtO2C    C(=O)OCC
+COOEt    EtOOC    C(=O)OCC
+OiBu     iBuO     OCC(C)C
+tBu      tBu      C(C)(C)C
+nBu      nBu      CCCC
+iPr      iPr      C(C)C
+nPr      nPr      CCC
+Et       Et       CC
+NCF3     F3CN     NC(F)(F)F
+CF3      F3C      C(F)(F)F
+CCl3     Cl3C     C(Cl)(Cl)Cl
+CN       NC       C#N
+NC       CN       [N+]#[C-]
+N(OH)CH3 CH3(OH)N N(O)C
+NO2      O2N      N(=O)=O
+NO2    O2N      [N+]([O-])=O
+NO       ON       N=O
+SO3H     HO3S     S(=O)(=O)O
+COOH     HOOC     C(=O)O                blue
+OEt      EtO      OCC
+OAc      AcO      OC(=O)C
+NHAc     AcNH     NC(=O)C
+Ac       Ac       C(=O)C
+CHO      OHC      C=O
+NMe      MeN      NC
+SMe      MeS      SC
+OMe      MeO      OC
+COO-     -OOC     C(=O)[O-]
+*/
+
+class AliasTestExample {
+  string _smiles;
+  unsigned int _num_aliases;
+  unsigned int _num_irreducibles;
+public:
+  AliasTestExample(const string smiles, const unsigned int num_aliases, const unsigned int num_irreducibles):
+    _smiles(smiles), _num_aliases(num_aliases), _num_irreducibles(num_irreducibles) {};
+  void test() {
+    OBMol mol;
+    AliasData ad;
+    OBConversion conv;
+    cout << _smiles << endl;
+    OB_REQUIRE( conv.SetInFormat("smi") );
+    OB_REQUIRE( conv.ReadString(&mol, _smiles) );
+    cout << mol.NumAtoms() << endl;
+    OB_ASSERT( ad.AddAliases(&mol) == (_num_aliases != 0) );
+    AliasData::RevertToAliasForm(mol);
+    OB_ASSERT( mol.NumAtoms() == _num_irreducibles );
+    cout << mol.NumAtoms() << endl;
+    OB_REQUIRE( conv.SetOutFormat("smi") );
+    cout << conv.WriteString(&mol) << endl;
+  }
+};
+
+void testAliases()
+{
+  AliasTestExample test_set[] = {
+    // methyl tert-butyl ether -> COtBu
+    AliasTestExample("COC(C)(C)C", 1, 2),
+    // diethylmalonate -> EtO2CCCO2Et
+    AliasTestExample("CCOC(=O)CC(=O)OCC", 2, 1),
+    // thioanisole -> PhSMe
+    AliasTestExample("c1ccccc1SC", 1, 2)
+  };
+
+  for (auto i : test_set) {
+    i.test();
+  }
+  cout << endl;
+}
+
+int aliastest(int argc, char* argv[])
+{
+  int defaultchoice = 1;
+
+  int choice = defaultchoice;
+
+  if (argc > 1) {
+    if(sscanf(argv[1], "%d", &choice) != 1) {
+      printf("Couldn't parse that input as a number\n");
+      return -1;
+    }
+  }
+  switch(choice) {
+  case 1:
+    testAliases();
+    break;
+  case 2:
+    break;
+  case 3:
+    break;
+  default:
+    cout << "Test number " << choice << " does not exist!\n";
+    return -1;
+  }
+
+  return 0;
+}

--- a/test/aliastest.cpp
+++ b/test/aliastest.cpp
@@ -15,78 +15,67 @@ GNU General Public License for more details.
 
 #include <openbabel/mol.h>
 #include <openbabel/obconversion.h>
+#include <openbabel/atom.h>
+#include <openbabel/obiter.h>
 #include <openbabel/alias.h>
 
 using namespace std;
 using namespace OpenBabel;
 
 // a class for a test case should contain smiles of the molecule, number of aliases that
-// are expected to be produced, and number of irreducible atoms that are not parts of aliases
-// note this test uses standard superatom.txt file shipped with OpenBabel
-/*
-CO2Et    EtO2C    C(=O)OCC
-COOEt    EtOOC    C(=O)OCC
-OiBu     iBuO     OCC(C)C
-tBu      tBu      C(C)(C)C
-nBu      nBu      CCCC
-iPr      iPr      C(C)C
-nPr      nPr      CCC
-Et       Et       CC
-NCF3     F3CN     NC(F)(F)F
-CF3      F3C      C(F)(F)F
-CCl3     Cl3C     C(Cl)(Cl)Cl
-CN       NC       C#N
-NC       CN       [N+]#[C-]
-N(OH)CH3 CH3(OH)N N(O)C
-NO2      O2N      N(=O)=O
-NO2    O2N      [N+]([O-])=O
-NO       ON       N=O
-SO3H     HO3S     S(=O)(=O)O
-COOH     HOOC     C(=O)O                blue
-OEt      EtO      OCC
-OAc      AcO      OC(=O)C
-NHAc     AcNH     NC(=O)C
-Ac       Ac       C(=O)C
-CHO      OHC      C=O
-NMe      MeN      NC
-SMe      MeS      SC
-OMe      MeO      OC
-COO-     -OOC     C(=O)[O-]
-*/
+// are expected to be produced, and number of unaliasable atoms that are not parts of aliases
+// note this test uses standard superatom.txt file included in OpenBabel
 
 class AliasTestExample {
   string _smiles;
   unsigned int _num_aliases;
-  unsigned int _num_irreducibles;
+  unsigned int _num_nonaliased;
 public:
-  AliasTestExample(const string smiles, const unsigned int num_aliases, const unsigned int num_irreducibles):
-    _smiles(smiles), _num_aliases(num_aliases), _num_irreducibles(num_irreducibles) {};
+  AliasTestExample(const string smiles, const unsigned int num_aliases, const unsigned int num_nonaliased):
+    _smiles(smiles), _num_aliases(num_aliases), _num_nonaliased(num_nonaliased) {};
+
+  // this will create aliases in the molecule, then remove all atoms present in aliases,
+  // count aliases and atoms that are not present in aliases, and compare with the expected result
   void test() {
     OBMol mol;
     AliasData ad;
     OBConversion conv;
-    cout << _smiles << endl;
     OB_REQUIRE( conv.SetInFormat("smi") );
     OB_REQUIRE( conv.ReadString(&mol, _smiles) );
-    cout << mol.NumAtoms() << endl;
-    OB_ASSERT( ad.AddAliases(&mol) == (_num_aliases != 0) );
+    ad.AddAliases(&mol);
     AliasData::RevertToAliasForm(mol);
-    OB_ASSERT( mol.NumAtoms() == _num_irreducibles );
-    cout << mol.NumAtoms() << endl;
-    OB_REQUIRE( conv.SetOutFormat("smi") );
-    cout << conv.WriteString(&mol) << endl;
+    unsigned int alias_count = 0;
+    unsigned int nonaliased_count = 0;
+
+    FOR_ATOMS_OF_MOL(a, mol)
+    {
+      AliasData* ad = NULL;
+      if ( static_cast<AliasData*>(a->GetData(AliasDataType)) )
+        alias_count++;
+      else
+        nonaliased_count++;
+    }
+    //cout << "Testing smiles " << _smiles << endl;
+    //cout << "number of aliases " << alias_count << ", number of nonaliased atoms " << nonaliased_count << endl;
+
+    OB_ASSERT( nonaliased_count == _num_nonaliased );
+    OB_ASSERT( alias_count == _num_aliases );
   }
 };
 
 void testAliases()
 {
   AliasTestExample test_set[] = {
-    // methyl tert-butyl ether -> COtBu
-    AliasTestExample("COC(C)(C)C", 1, 2),
+    // methyl tert-butyl ether -> MeOtBu
+    AliasTestExample("COC(C)(C)C", 2, 0),
     // diethylmalonate -> EtO2CCCO2Et
     AliasTestExample("CCOC(=O)CC(=O)OCC", 2, 1),
     // thioanisole -> PhSMe
-    AliasTestExample("c1ccccc1SC", 1, 2)
+    AliasTestExample("c1ccccc1SC", 1, 6),
+    // oxalate dianion -> -O2CCO2-
+    AliasTestExample("[O-]C(=O)C(=O)[O-]", 2, 0),
+    // diphenyl - nothing to alias
+    AliasTestExample("c1ccccc1c2ccccc2", 0, 12)
   };
 
   for (auto i : test_set) {
@@ -110,10 +99,6 @@ int aliastest(int argc, char* argv[])
   switch(choice) {
   case 1:
     testAliases();
-    break;
-  case 2:
-    break;
-  case 3:
     break;
   default:
     cout << "Test number " << choice << " does not exist!\n";

--- a/test/aliastest.cpp
+++ b/test/aliastest.cpp
@@ -86,6 +86,13 @@ void testAliases()
 
 int aliastest(int argc, char* argv[])
 {
+  // Define location of file formats for testing
+#ifdef FORMATDIR
+    char env[BUFF_SIZE];
+    snprintf(env, BUFF_SIZE, "BABEL_LIBDIR=%s", FORMATDIR);
+    putenv(env);
+#endif
+
   int defaultchoice = 1;
 
   int choice = defaultchoice;


### PR DESCRIPTION
alias.cpp contains code that replaces some groups defined in superatom.txt file, with the corresponding aliases, like C(=O)C with Ac. The aliases from superatom.txt are always considered protonated, and implicit hydrogens are added to them to avoid replacing fragments in the middle of the molecule, so e.g. C(=O)CC should not be replaced with Ac. However, the molecule of interest can lack implicit hydrogens. In case of non-protonated molecules, out of range error can happen here:

 `int id  =(pmol->GetAtom(idx))->GetId();`

when it tries to find and remove all atoms found in alias including hydrogens lacking in the molecule. So idx can easily exceed the number of atoms in pmol. It causes out of bounds error and segfault as shown in my minimal example in issue description. Guess that incorrect behavior rather than segfault can also be a result.
The fix creates a protonated copy of the molecule to find numbers of all atoms that should be stripped and replaced with aliases. Hydrogens that have numbers above number of atoms in original molecule are ignored. This should ensure that hydrogens present in the original molecule are retained.