### PR TITLE
Add the --neutralize operation to convert charged atoms to neutral

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ set(ops
   ops/gen3d.cpp
   ops/largest.cpp
   ops/loader.cpp
+  ops/neutralize.cpp
   ops/opsplit.cpp
   ops/optransform.cpp
   ops/partialcharges.cpp

--- a/src/ops/neutralize.cpp
+++ b/src/ops/neutralize.cpp
@@ -1,0 +1,127 @@
+/**********************************************************************
+neutralize.cpp - The option --neutralize neutralizes charged atoms
+
+Copyright (C) 2020 by Noel O'Boyle
+
+This file is part of the Open Babel project.
+For more information, see <http://openbabel.org/>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation version 2 of the License.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+***********************************************************************/
+#include <openbabel/babelconfig.h>
+#include <openbabel/op.h>
+#include <openbabel/mol.h>
+#include <openbabel/obiter.h>
+#include <openbabel/atom.h>
+
+namespace OpenBabel
+{
+
+class OpNeutralize : public OBOp
+{
+public:
+  OpNeutralize(const char* ID) : OBOp(ID, false){};
+  const char* Description() {
+    return "Neutralize +1 and -1 charges\n\n"
+
+      "Note: this method accepts an optional argument 'changed' which is\n"
+      "described below.\n\n"
+
+      "This method uses a simple procedure to generate the neutral form of a\n"
+      "molecule. It does not attempt to balance charges but simply to convert\n"
+      "all atoms with a +1 or -1 charge to neutral by addition or subtraction\n"
+      "of H+.\n\n"
+
+      "To a first approximation the procedure is simply to identify all atoms with\n"
+      "either a +1 or -1 charge, set their charges to zero and adjust their\n"
+      "hydrogen counts by -1 or +1 (i.e. we are adding/removing H+). The first\n"
+      "minor issue is that +1 charged atoms must have a hydrogen, or otherwise\n"
+      "we can't remove H+. The second issue is that we must avoid altering\n"
+      "charge-separated representations of multiple bonds, such as nitro which\n"
+      "is often represented as [N+](=O)[O-]. It does this by checking whether a\n"
+      "neighbor atom has a negative charge (for the +1 atoms) or a positive\n"
+      "charge (for the -1 atoms).\n\n"
+
+      "If specified, the optional argument 'changed' causes the method to return\n"
+      "True if the molecule was changed by the neutralize operation, and False\n"
+      "otherwise. This is mostly useful if using the API, but for command-line\n"
+      "usage (e.g. via obabel) this filters out molecules that are unchanged\n"
+      "by the operation and only retains those that are changed.";
+  }
+
+  virtual bool WorksWith(OBBase* pOb)const{ return dynamic_cast<OBMol*>(pOb)!=NULL; }
+  virtual bool Do(OBBase* pOb, const char* OptionText=NULL, OpMap* pOptions=NULL, OBConversion* pConv=NULL);
+  bool NoNegativelyChargedNbr(OBAtom *atm);
+  bool NoPositivelyChargedNbr(OBAtom *atm);
+};
+
+/////////////////////////////////////////////////////////////////
+OpNeutralize theOpNeutralize("neutralize"); //Global instance
+
+/////////////////////////////////////////////////////////////////
+bool OpNeutralize::Do(OBBase* pOb, const char* OptionText, OpMap* pOptions, OBConversion* pConv)
+{
+  OBMol* pmol = dynamic_cast<OBMol*>(pOb);
+  if(!pmol)
+    return false;
+  
+  const char *p = OptionText;
+  // If "changed" is given as an option, then return true if the molecule was altered
+  // by neutralizing some charges, and false if left unchanged.
+  bool report_changes = (p && p[0] == 'c' && p[1] == 'h' && p[2] == 'a' && p[3] == 'n' &&
+                              p[4] == 'g' && p[5] == 'e' && p[6] == 'd' && p[7] == '\0');
+  
+  bool changed = false;
+  FOR_ATOMS_OF_MOL(atmit, pmol) {
+    OBAtom* atm = &*atmit;
+    int chg = atm->GetFormalCharge();
+    unsigned char hcount;
+    switch(chg) {
+    case 1:
+      hcount = atm->GetImplicitHCount();
+      if (hcount >= 1 && NoNegativelyChargedNbr(atm)) {
+        atm->SetFormalCharge(0);
+        atm->SetImplicitHCount(hcount - 1);
+        changed = true;
+      }
+      break;
+    case -1:
+      hcount = atm->GetImplicitHCount();
+      if (NoPositivelyChargedNbr(atm)) {
+        atm->SetFormalCharge(0);
+        atm->SetImplicitHCount(hcount + 1);
+        changed = true;
+      }
+      break;
+    }
+  }
+
+  return report_changes ? changed : true;
+}
+
+bool OpNeutralize::NoNegativelyChargedNbr(OBAtom *atm)
+{
+  FOR_NBORS_OF_ATOM(nbr, atm) {
+    if (nbr->GetFormalCharge() < 0)
+      return false;
+  }
+  return true;
+}
+
+bool OpNeutralize::NoPositivelyChargedNbr(OBAtom *atm)
+{
+  FOR_NBORS_OF_ATOM(nbr, atm) {
+    if (nbr->GetFormalCharge() > 0)
+      return false;
+  }
+  return true;
+}
+
+}//namespace

--- a/src/ops/neutralize.cpp
+++ b/src/ops/neutralize.cpp
@@ -31,10 +31,7 @@ public:
   const char* Description() {
     return "Neutralize +1 and -1 charges\n\n"
 
-      "Note: this method accepts an optional argument 'changed' which is\n"
-      "described below.\n\n"
-
-      "This method uses a simple procedure to generate the neutral form of a\n"
+      "Neutralize uses a simple procedure to generate the neutral form of a\n"
       "molecule. It does not attempt to balance charges but simply to convert\n"
       "all atoms with a +1 or -1 charge to neutral by addition or subtraction\n"
       "of H+.\n\n"
@@ -71,7 +68,10 @@ bool OpNeutralize::Do(OBBase* pOb, const char* OptionText, OpMap* pOptions, OBCo
   OBMol* pmol = dynamic_cast<OBMol*>(pOb);
   if(!pmol)
     return false;
-  
+
+  // The algorithm assumes that hydrogens are suppressed
+  pmol->DeleteHydrogens();
+
   const char *p = OptionText;
   // If "changed" is given as an option, then return true if the molecule was altered
   // by neutralizing some charges, and false if left unchanged.

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -333,6 +333,29 @@ H          0.74700        0.50628       -0.64089
         for smi in smis:
             pybel.readstring("smi", smi)
 
+    def testNeutralize(self):
+        """Test the --neutralize operation and its 'changed' option"""
+        neutralize = ob.OBOp.FindType("neutralize")
+        self.assertTrue(neutralize is not None)
+        data = [("C(=O)[O-]", "C(=O)O"),
+                ("C[NH3+]", "CN"),
+                ("C[N+](=O)[O-]", None),
+                ("c1ccc[n+]([O-])c1", None), # pyridine N-oxide
+                ("CC", None),
+                ]
+        for i in range(2):
+            option = "changed" if i==1 else ""
+            for before, after in data:
+                ans = before if not after else after
+                mol = pybel.readstring("smi", before).OBMol
+                changed = neutralize.Do(mol, option)
+                result = pybel.Molecule(mol).write("smi").rstrip()
+                self.assertEqual(ans, result)
+                if not option:
+                    self.assertEqual(True, changed)
+                else:
+                    self.assertEqual(True if after else False, changed)
+
     def testImplicitCisDblBond(self):
         """Ensure that dbl bonds in rings of size 8 or less are always
         implicitly cis"""


### PR DESCRIPTION
Together with the ``-r`` option for "strip all but the largest component", neutralize is often an essential first step for standardising a dataset of molecules (especially as provided by vendors).

Here's the help text from ```obabel -L neutralize``` (some additional background at https://baoilleach.blogspot.com/2019/12/no-charge-simple-approach-to.html):

```
One of the ops
neutralize    Neutralize +1 and -1 charges

Note: this method accepts an optional argument 'changed' which is
described below.

This method uses a simple procedure to generate the neutral form of a
molecule. It does not attempt to balance charges but simply to convert
all atoms with a +1 or -1 charge to neutral by addition or subtraction
of H+.

To a first approximation the procedure is simply to identify all atoms with
either a +1 or -1 charge, set their charges to zero and adjust their
hydrogen counts by -1 or +1 (i.e. we are adding/removing H+). The first
minor issue is that +1 charged atoms must have a hydrogen, or otherwise
we can't remove H+. The second issue is that we must avoid altering
charge-separated representations of multiple bonds, such as nitro which
is often represented as [N+](=O)[O-]. It does this by checking whether a
neighbor atom has a negative charge (for the +1 atoms) or a positive
charge (for the -1 atoms).

If specified, the optional argument 'changed' causes the method to return
True if the molecule was changed by the neutralize operation, and False
otherwise. This is mostly useful if using the API, but for command-line
usage (e.g. via obabel) this filters out molecules that are unchanged
by the operation and only retains those that are changed.
```