### PR TITLE
Support kekulization of aromatic sulfoxides

### DIFF
--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -74,8 +74,9 @@ namespace OpenBabel
       if (atom->GetTotalDegree() == 3 && atom->GetFormalCharge() == 0)
         return true;
       break;
-    case 16: // e.g. Cs1(=O)ccccn1
-      if (atom->GetTotalDegree() == 4 && atom->GetFormalCharge() == 0)
+    case 16: // e.g. Cs1(=O)ccccn1 but not O=s1(=O)cccn1
+      if (atom->GetTotalDegree() == 4 && atom->GetFormalCharge() == 0
+          && atom->GetTotalValence() < 6)
         return true;
       break;
     }

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -291,6 +291,8 @@ H          0.74700        0.50628       -0.64089
         # as we write them)
         data = [("Cs1(=O)ccccn1",
                  "CS1(=O)=NC=CC=C1"),
+                ("O=s1(=O)cccn1",
+                 "O=S1(=O)C=CC=N1"),
                 ("n1c2-c(c3cccc4cccc2c34)n(=N)c2ccccc12",
                  "n1c2-c(c3cccc4cccc2c34)n(=N)c2ccccc12")]
         for inp, out in data:


### PR DESCRIPTION
Previously ```O=s1(=O)cccn1``` caused a kekulization failure. Now it's read as ```O=S1(=O)C=CC=N1```.