### PR TITLE
Set MAEPARSER_BUILD_SHARED_LIBS (fix #2089)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,13 +479,16 @@ endif()
 
 
 find_package(Boost COMPONENTS filesystem iostreams unit_test_framework)
-if(Boost_FOUND AND BUILD_SHARED)
-    include_directories(${Boost_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
-    option(WITH_MAEPARSER "Build Maestro support" ON)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
+  option(WITH_MAEPARSER "Build Maestro support" ON)
+  if(BUILD_SHARED)
     option(WITH_COORDGEN "Build Coordgen support" ON)
-else()
-    option(WITH_MAEPARSER "Build Maestro support" OFF)
+  else()
     option(WITH_COORDGEN "Build Coordgen support" OFF)
+  endif()
+else()
+  option(WITH_COORDGEN "Build Coordgen support" OFF)
 endif()
 
 if(WITH_MAEPARSER)
@@ -501,6 +504,8 @@ if(WITH_MAEPARSER)
       set(MAEPARSER_VERSION "master" CACHE STRING "Maeparser fallback version to download")
 
       set(MAEPARSER_DIR "${openbabel_SOURCE_DIR}/external/maeparser-${MAEPARSER_VERSION}")
+
+      option(MAEPARSER_BUILD_SHARED_LIBS "Build maeparser as a shared library" ${BUILD_SHARED})
 
       # Do not build the test, as it will be put into the bin dir, where it won't be found by the test runner.
       set(MAEPARSER_BUILD_TESTS OFF CACHE BOOL "Disable Maeparser tests")


### PR DESCRIPTION
Fix #2089.

See https://github.com/schrodinger/maeparser/blob/v1.2.3/CMakeLists.txt#L8
for the option.
maeparser will be build if Boost_FOUND.