### PR TITLE
Fix the import of Tkinter in Python 3+

### DIFF
--- a/scripts/python/openbabel/pybel.py
+++ b/scripts/python/openbabel/pybel.py
@@ -51,7 +51,10 @@ else:
     from . import openbabel as ob
     _obfuncs = _obconsts = ob
     try:
-        from six.moves import tkinter as tk
+        if sys.version_info[0] >= 3:
+            import tkinter as tk
+        else:
+            import Tkinter as tk
         from PIL import Image as PIL
         from PIL import ImageTk as piltk
     except ImportError:  # pragma: no cover

--- a/scripts/python/openbabel/pybel.py
+++ b/scripts/python/openbabel/pybel.py
@@ -51,7 +51,7 @@ else:
     from . import openbabel as ob
     _obfuncs = _obconsts = ob
     try:
-        import Tkinter as tk
+        from six.moves import tkinter as tk
         from PIL import Image as PIL
         from PIL import ImageTk as piltk
     except ImportError:  # pragma: no cover

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -126,6 +126,7 @@ setup(
     zip_safe=False,
     cmdclass={'build': CustomBuild, 'build_ext': CustomBuildExt, 'install': CustomInstall, 'sdist': CustomSdist},
     packages=['openbabel'],
+    install_requires=[six],
     ext_modules=[obextension],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -126,7 +126,6 @@ setup(
     zip_safe=False,
     cmdclass={'build': CustomBuild, 'build_ext': CustomBuildExt, 'install': CustomInstall, 'sdist': CustomSdist},
     packages=['openbabel'],
-    install_requires=[six],
     ext_modules=[obextension],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
While following the example at https://open-babel.readthedocs.io/en/latest/UseTheLibrary/PythonInstall.html#test-the-installation, noticed that the `mol.draw()` step fails on importing of `Tkinter` in Python 3.7. The module was renamed to `tkinter` in Python 3+ versions, and the `six` library supports the proper handling of the change: https://six.readthedocs.io/#module-six.moves (thanks to @tacaswell for the reference). I added `six` as the install requirement.