### PR TITLE
Fix for segault (with regression test)

### DIFF
--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -517,8 +517,8 @@ namespace OpenBabel
             bondB = &*bitB;
           }
         }
-        if(otherOxygenOrSulfur->GetFormalCharge() != 0) continue; //formal charge already set on one
         if (!otherOxygenOrSulfur) continue;
+        if(otherOxygenOrSulfur->GetFormalCharge() != 0) continue; //formal charge already set on one
 
         // Now set as C(=O)O
         bondA->SetAromatic(false);

--- a/test/files/5sun_protein.mol2
+++ b/test/files/5sun_protein.mol2
@@ -1,0 +1,12851 @@
+#	Name:			<unnamed>
+#	Creating user name:	vkhoa
+#	Creation time:		Thu Feb 28 14:17:53 2019
+
+#	Modifying user name:	vkhoa
+#	Modification time:	Thu Feb 28 14:17:53 2019
+
+@<TRIPOS>MOLECULE
+****
+ 6185  6248   390     1     2
+BIOPOLYMER
+NO_CHARGES
+
+
+@<TRIPOS>DICT
+BIOPOLYMER macromol
+@<TRIPOS>ATOM
+      1 N          10.6400  -17.9060   44.5540 N.am      1 LYS3        0.0000 BACKBONE|DICT|DIRECT
+      2 CA         11.5460  -16.7820   44.7570 C.3       1 LYS3        0.0000 BACKBONE|DICT|DIRECT
+      3 C          12.3310  -16.5160   43.4690 C.2       1 LYS3        0.0000 BACKBONE|DICT|DIRECT
+      4 O          11.8150  -16.7470   42.3750 O.2       1 LYS3        0.0000 BACKBONE|DICT|DIRECT
+      5 CB         12.4840  -17.0580   45.9320 C.3       1 LYS3        0.0000 DICT
+      6 CG         12.8440  -15.8200   46.7410 C.3       1 LYS3        0.0000 DICT
+      7 CD         13.6780  -16.1850   47.9530 C.3       1 LYS3        0.0000 DICT
+      8 CE         13.9800  -14.9650   48.8030 C.3       1 LYS3        0.0000 DICT
+      9 NZ         14.6320  -15.3460   50.0860 N.4       1 LYS3        0.0000 DICT
+     10 H          10.6960  -18.7070   45.1500 H         1 LYS3        0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+     11 HA         11.0020  -15.9710   44.9700 H         1 LYS3        0.0000 BACKBONE|DICT|DIRECT
+     12 HB2        13.3280  -17.4560   45.5730 H         1 LYS3        0.0000 DICT
+     13 HB3        12.0390  -17.7140   46.5420 H         1 LYS3        0.0000 DICT
+     14 HG2        12.0030  -15.3730   47.0460 H         1 LYS3        0.0000 DICT
+     15 HG3        13.3650  -15.1920   46.1630 H         1 LYS3        0.0000 DICT
+     16 HD2        14.5400  -16.5890   47.6460 H         1 LYS3        0.0000 DICT
+     17 HD3        13.1760  -16.8500   48.5050 H         1 LYS3        0.0000 DICT
+     18 HE2        13.1240  -14.4870   49.0020 H         1 LYS3        0.0000 DICT
+     19 HE3        14.5910  -14.3580   48.2950 H         1 LYS3        0.0000 DICT
+     20 HZ1        14.8180  -14.5230   50.6230 H         1 LYS3        0.0000 DICT|ESSENTIAL
+     21 HZ2        14.0250  -15.9500   50.6020 H         1 LYS3        0.0000 DICT|ESSENTIAL
+     22 HZ3        15.4910  -15.8210   49.8950 H         1 LYS3        0.0000 DICT|ESSENTIAL
+     23 N          13.5670  -16.0370   43.5940 N.am      2 LYS4        0.0000 BACKBONE|DICT|DIRECT
+     24 CA         14.3650  -15.6450   42.4410 C.3       2 LYS4        0.0000 BACKBONE|DICT|DIRECT
+     25 C          15.6240  -16.4910   42.3110 C.2       2 LYS4        0.0000 BACKBONE|DICT|DIRECT
+     26 O          16.1730  -16.9860   43.2990 O.2       2 LYS4        0.0000 BACKBONE|DICT|DIRECT
+     27 CB         14.7700  -14.1660   42.5080 C.3       2 LYS4        0.0000 DICT
+     28 CG         13.6880  -13.2210   42.9800 C.3       2 LYS4        0.0000 DICT
+     29 CD         14.2370  -11.8170   43.1400 C.3       2 LYS4        0.0000 DICT
+     30 CE         13.1270  -10.8040   42.9990 C.3       2 LYS4        0.0000 DICT
+     31 NZ         12.1450  -11.2710   41.9940 N.4       2 LYS4        0.0000 DICT
+     32 H          13.9600  -15.9440   44.5090 H         2 LYS4        0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+     33 HA         13.8120  -15.7800   41.6190 H         2 LYS4        0.0000 BACKBONE|DICT|DIRECT
+     34 HB2        15.0510  -13.8810   41.5920 H         2 LYS4        0.0000 DICT
+     35 HB3        15.5450  -14.0860   43.1350 H         2 LYS4        0.0000 DICT
+     36 HG2        13.3360  -13.5380   43.8610 H         2 LYS4        0.0000 DICT
+     37 HG3        12.9470  -13.2090   42.3090 H         2 LYS4        0.0000 DICT
+     38 HD2        14.9280  -11.6500   42.4360 H         2 LYS4        0.0000 DICT
+     39 HD3        14.6540  -11.7260   44.0440 H         2 LYS4        0.0000 DICT
+     40 HE2        13.5120   -9.9290   42.7050 H         2 LYS4        0.0000 DICT
+     41 HE3        12.6700  -10.6880   43.8810 H         2 LYS4        0.0000 DICT
+     42 HZ1        11.4380  -11.8140   42.4460 H         2 LYS4        0.0000 DICT|ESSENTIAL
+     43 HZ2        11.7240  -10.4820   41.5470 H         2 LYS4        0.0000 DICT|ESSENTIAL
+     44 HZ3        12.6100  -11.8330   41.3100 H         2 LYS4        0.0000 DICT|ESSENTIAL
+     45 N          16.0890  -16.6120   41.0680 N.am      3 ILE5        0.0000 BACKBONE|DICT|DIRECT
+     46 CA         17.2920  -17.3720   40.7580 C.3       3 ILE5        0.0000 BACKBONE|DICT|DIRECT
+     47 C          18.5220  -16.6230   41.2570 C.2       3 ILE5        0.0000 BACKBONE|DICT|DIRECT
+     48 O          18.5900  -15.3860   41.1960 O.2       3 ILE5        0.0000 BACKBONE|DICT|DIRECT
+     49 CB         17.3600  -17.6160   39.2410 C.3       3 ILE5        0.0000 DICT
+     50 CG1        16.0930  -18.3390   38.7720 C.3       3 ILE5        0.0000 DICT
+     51 CG2        18.6130  -18.4000   38.8580 C.3       3 ILE5        0.0000 DICT
+     52 CD1        15.9490  -18.4110   37.2700 C.3       3 ILE5        0.0000 DICT
+     53 H          15.5950  -16.1650   40.3220 H         3 ILE5        0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+     54 HA         17.2430  -18.2560   41.2240 H         3 ILE5        0.0000 BACKBONE|DICT|DIRECT
+     55 HB         17.3980  -16.7270   38.7840 H         3 ILE5        0.0000 DICT
+     56 HG12       15.3000  -17.8550   39.1410 H         3 ILE5        0.0000 DICT
+     57 HG13       16.1120  -19.2720   39.1310 H         3 ILE5        0.0000 DICT
+     58 HG21       18.6280  -18.5420   37.8680 H         3 ILE5        0.0000 DICT
+     59 HG22       19.4250  -17.8860   39.1330 H         3 ILE5        0.0000 DICT
+     60 HG23       18.6070  -19.2860   39.3220 H         3 ILE5        0.0000 DICT
+     61 HD11       15.1040  -18.8940   37.0390 H         3 ILE5        0.0000 DICT
+     62 HD12       15.9180  -17.4850   36.8930 H         3 ILE5        0.0000 DICT
+     63 HD13       16.7300  -18.9020   36.8830 H         3 ILE5        0.0000 DICT
+     64 N          19.4990  -17.3710   41.7660 N.am      4 SER6        0.0000 BACKBONE|DICT|DIRECT
+     65 CA         20.8160  -16.8290   42.1000 C.3       4 SER6        0.0000 BACKBONE|DICT|DIRECT
+     66 C          21.6870  -16.9290   40.8550 C.2       4 SER6        0.0000 BACKBONE|DICT|DIRECT
+     67 O          22.2060  -17.9980   40.5320 O.2       4 SER6        0.0000 BACKBONE|DICT|DIRECT
+     68 CB         21.4340  -17.5810   43.2750 C.3       4 SER6        0.0000 DICT
+     69 OG         20.5190  -17.6850   44.3530 O.3       4 SER6        0.0000 DICT
+     70 H          19.3250  -18.3430   41.9260 H         4 SER6        0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+     71 HA         20.7160  -15.8660   42.3490 H         4 SER6        0.0000 BACKBONE|DICT|DIRECT
+     72 HB2        22.2490  -17.0910   43.5840 H         4 SER6        0.0000 DICT
+     73 HB3        21.6920  -18.5000   42.9760 H         4 SER6        0.0000 DICT
+     74 HG         20.9480  -18.1810   45.1080 H         4 SER6        0.0000 DICT|ESSENTIAL
+     75 N          21.8500  -15.8060   40.1500 N.am      5 GLY7        0.0000 BACKBONE|DICT|DIRECT
+     76 CA         22.5440  -15.8270   38.8750 C.3       5 GLY7        0.0000 BACKBONE|DICT|DIRECT
+     77 C          24.0540  -15.7700   38.9630 C.2       5 GLY7        0.0000 BACKBONE|DICT|DIRECT
+     78 O          24.7300  -16.0430   37.9670 O.2       5 GLY7        0.0000 BACKBONE|DICT|DIRECT
+     79 H          21.4910  -14.9430   40.5040 H         5 GLY7        0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+     80 HA2        22.2350  -15.0400   38.3410 H         5 GLY7        0.0000 BACKBONE|DICT|DIRECT
+     81 HA3        22.2930  -16.6710   38.4000 H         5 GLY7        0.0000 DICT
+     82 N          24.6010  -15.4160   40.1190 N.am      6 GLY8        0.0000 BACKBONE|DICT|DIRECT
+     83 CA         26.0420  -15.3590   40.2610 C.3       6 GLY8        0.0000 BACKBONE|DICT|DIRECT
+     84 C          26.6580  -14.0280   39.8720 C.2       6 GLY8        0.0000 BACKBONE|DICT|DIRECT
+     85 O          26.0130  -12.9780   39.9670 O.2       6 GLY8        0.0000 BACKBONE|DICT|DIRECT
+     86 H          24.0150  -15.1870   40.8970 H         6 GLY8        0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+     87 HA2        26.4420  -16.0700   39.6820 H         6 GLY8        0.0000 BACKBONE|DICT|DIRECT
+     88 HA3        26.2690  -15.5410   41.2180 H         6 GLY8        0.0000 DICT
+     89 N          27.9090  -14.0720   39.4150 N.am      7 SER9        0.0000 BACKBONE|DICT|DIRECT
+     90 CA         28.7240  -12.8850   39.1900 C.3       7 SER9        0.0000 BACKBONE|DICT|DIRECT
+     91 C          28.6460  -12.4660   37.7260 C.2       7 SER9        0.0000 BACKBONE|DICT|DIRECT
+     92 O          29.0040  -13.2410   36.8330 O.2       7 SER9        0.0000 BACKBONE|DICT|DIRECT
+     93 CB         30.1740  -13.1500   39.5920 C.3       7 SER9        0.0000 DICT
+     94 OG         30.9920  -12.0260   39.3200 O.3       7 SER9        0.0000 DICT
+     95 H          28.3100  -14.9660   39.2160 H         7 SER9        0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+     96 HA         28.3670  -12.1410   39.7550 H         7 SER9        0.0000 BACKBONE|DICT|DIRECT
+     97 HB2        30.5170  -13.9360   39.0780 H         7 SER9        0.0000 DICT
+     98 HB3        30.2100  -13.3510   40.5710 H         7 SER9        0.0000 DICT
+     99 HG         30.6560  -11.2370   39.8350 H         7 SER9        0.0000 DICT|ESSENTIAL
+    100 N          28.2000  -11.2350   37.4870 N.am      8 VAL10       0.0000 BACKBONE|DICT|DIRECT
+    101 CA         28.0450  -10.6990   36.1390 C.3       8 VAL10       0.0000 BACKBONE|DICT|DIRECT
+    102 C          28.5660   -9.2690   36.1170 C.2       8 VAL10       0.0000 BACKBONE|DICT|DIRECT
+    103 O          28.1870   -8.4490   36.9610 O.2       8 VAL10       0.0000 BACKBONE|DICT|DIRECT
+    104 CB         26.5770  -10.7450   35.6710 C.3       8 VAL10       0.0000 DICT
+    105 CG1        26.3750   -9.8470   34.4550 C.3       8 VAL10       0.0000 DICT
+    106 CG2        26.1690  -12.1800   35.3530 C.3       8 VAL10       0.0000 DICT
+    107 H          27.9610  -10.6530   38.2640 H         8 VAL10       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    108 HA         28.5970  -11.2490   35.5120 H         8 VAL10       0.0000 BACKBONE|DICT|DIRECT
+    109 HB         25.9970  -10.4080   36.4130 H         8 VAL10       0.0000 DICT
+    110 HG11       25.4190   -9.8890   34.1650 H         8 VAL10       0.0000 DICT
+    111 HG12       26.6100   -8.9050   34.6940 H         8 VAL10       0.0000 DICT
+    112 HG13       26.9630  -10.1590   33.7090 H         8 VAL10       0.0000 DICT
+    113 HG21       25.2160  -12.1960   35.0510 H         8 VAL10       0.0000 DICT
+    114 HG22       26.7550  -12.5400   34.6270 H         8 VAL10       0.0000 DICT
+    115 HG23       26.2690  -12.7440   36.1730 H         8 VAL10       0.0000 DICT
+    116 N          29.4390   -8.9720   35.1600 N.am      9 VAL11       0.0000 BACKBONE|DICT|DIRECT
+    117 CA         29.9020   -7.6110   34.9240 C.3       9 VAL11       0.0000 BACKBONE|DICT|DIRECT
+    118 C          28.9190   -6.9260   33.9840 C.2       9 VAL11       0.0000 BACKBONE|DICT|DIRECT
+    119 O          28.6080   -7.4480   32.9060 O.2       9 VAL11       0.0000 BACKBONE|DICT|DIRECT
+    120 CB         31.3240   -7.6060   34.3410 C.3       9 VAL11       0.0000 DICT
+    121 CG1        31.7780   -6.1790   34.0550 C.3       9 VAL11       0.0000 DICT
+    122 CG2        32.2910   -8.3070   35.2930 C.3       9 VAL11       0.0000 DICT
+    123 H          29.7900   -9.7080   34.5820 H         9 VAL11       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    124 HA         29.9100   -7.1190   35.7950 H         9 VAL11       0.0000 BACKBONE|DICT|DIRECT
+    125 HB         31.3120   -8.1110   33.4780 H         9 VAL11       0.0000 DICT
+    126 HG11       32.7040   -6.1930   33.6770 H         9 VAL11       0.0000 DICT
+    127 HG12       31.1550   -5.7570   33.3960 H         9 VAL11       0.0000 DICT
+    128 HG13       31.7730   -5.6510   34.9040 H         9 VAL11       0.0000 DICT
+    129 HG21       33.2110   -8.2960   34.9010 H         9 VAL11       0.0000 DICT
+    130 HG22       32.2970   -7.8300   36.1720 H         9 VAL11       0.0000 DICT
+    131 HG23       31.9980   -9.2530   35.4290 H         9 VAL11       0.0000 DICT
+    132 N          28.4200   -5.7640   34.3940 N.am     10 GLU12       0.0000 BACKBONE|DICT|DIRECT
+    133 CA         27.4610   -4.9980   33.6120 C.3      10 GLU12       0.0000 BACKBONE|DICT|DIRECT
+    134 C          28.0210   -3.6140   33.3170 C.2      10 GLU12       0.0000 BACKBONE|DICT|DIRECT
+    135 O          28.6100   -2.9730   34.1940 O.2      10 GLU12       0.0000 BACKBONE|DICT|DIRECT
+    136 CB         26.1270   -4.8690   34.3440 C.3      10 GLU12       0.0000 DICT
+    137 CG         25.0800   -4.1140   33.5550 C.3      10 GLU12       0.0000 DICT
+    138 CD         24.3980   -3.0400   34.3710 C.2      10 GLU12       0.0000 DICT
+    139 OE1        24.7540   -2.8760   35.5560 O.co2    10 GLU12       0.0000 DICT
+    140 OE2        23.5040   -2.3590   33.8240 O.co2    10 GLU12       0.0000 DICT
+    141 H          28.7160   -5.4010   35.2770 H        10 GLU12       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    142 HA         27.3050   -5.4710   32.7450 H        10 GLU12       0.0000 BACKBONE|DICT|DIRECT
+    143 HB2        26.2840   -4.3870   35.2060 H        10 GLU12       0.0000 DICT
+    144 HB3        25.7800   -5.7870   34.5340 H        10 GLU12       0.0000 DICT
+    145 HG2        24.3880   -4.7630   33.2380 H        10 GLU12       0.0000 DICT
+    146 HG3        25.5210   -3.6850   32.7660 H        10 GLU12       0.0000 DICT
+    147 N          27.8290   -3.1550   32.0820 N.am     11 MET13       0.0000 BACKBONE|DICT|DIRECT
+    148 CA         28.3230   -1.8600   31.6320 C.3      11 MET13       0.0000 BACKBONE|DICT|DIRECT
+    149 C          27.1600   -1.0380   31.0880 C.2      11 MET13       0.0000 BACKBONE|DICT|DIRECT
+    150 O          26.5370   -1.4220   30.0930 O.2      11 MET13       0.0000 BACKBONE|DICT|DIRECT
+    151 CB         29.4110   -2.0330   30.5710 C.3      11 MET13       0.0000 DICT
+    152 CG         30.7530   -2.4730   31.1340 C.3      11 MET13       0.0000 DICT
+    153 SD         31.6350   -3.5830   30.0210 S.3      11 MET13       0.0000 DICT
+    154 CE         30.6490   -5.0760   30.2000 C.3      11 MET13       0.0000 DICT
+    155 H          27.3230   -3.7250   31.4340 H        11 MET13       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    156 HA         28.7150   -1.3780   32.4160 H        11 MET13       0.0000 BACKBONE|DICT|DIRECT
+    157 HB2        29.5370   -1.1580   30.1030 H        11 MET13       0.0000 DICT
+    158 HB3        29.1040   -2.7210   29.9140 H        11 MET13       0.0000 DICT
+    159 HG2        30.5980   -2.9450   32.0020 H        11 MET13       0.0000 DICT
+    160 HG3        31.3160   -1.6620   31.2920 H        11 MET13       0.0000 DICT
+    161 HE1        31.0310   -5.7990   29.6240 H        11 MET13       0.0000 DICT
+    162 HE2        30.6610   -5.3710   31.1560 H        11 MET13       0.0000 DICT
+    163 HE3        29.7070   -4.8890   29.9200 H        11 MET13       0.0000 DICT
+    164 N          26.8710    0.0850   31.7410 N.am     12 GLN14       0.0000 BACKBONE|DICT|DIRECT
+    165 CA         25.8260    0.9880   31.2820 C.3      12 GLN14       0.0000 BACKBONE|DICT|DIRECT
+    166 C          26.3530    1.8970   30.1780 C.2      12 GLN14       0.0000 BACKBONE|DICT|DIRECT
+    167 O          27.5410    2.2210   30.1240 O.2      12 GLN14       0.0000 BACKBONE|DICT|DIRECT
+    168 CB         25.2890    1.8240   32.4450 C.3      12 GLN14       0.0000 DICT
+    169 CG         24.4440    1.0170   33.4220 C.3      12 GLN14       0.0000 DICT
+    170 CD         24.5270    1.5320   34.8460 C.2      12 GLN14       0.0000 DICT
+    171 OE1        24.8800    2.6870   35.0850 O.2      12 GLN14       0.0000 DICT
+    172 NE2        24.2030    0.6690   35.8030 N.am     12 GLN14       0.0000 DICT
+    173 H          27.3850    0.3140   32.5680 H        12 GLN14       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    174 HA         25.0750    0.4410   30.9110 H        12 GLN14       0.0000 BACKBONE|DICT|DIRECT
+    175 HB2        24.7270    2.5630   32.0730 H        12 GLN14       0.0000 DICT
+    176 HB3        26.0650    2.2130   32.9420 H        12 GLN14       0.0000 DICT
+    177 HG2        24.7600    0.0680   33.4080 H        12 GLN14       0.0000 DICT
+    178 HG3        23.4900    1.0550   33.1250 H        12 GLN14       0.0000 DICT
+    179 HE21       23.9210   -0.2600   35.5640 H        12 GLN14       0.0000 DICT|ESSENTIAL
+    180 HE22       24.2410    0.9490   36.7620 H        12 GLN14       0.0000 DICT|ESSENTIAL
+    181 N          25.4490    2.3060   29.2910 N.am     13 GLY15       0.0000 BACKBONE|DICT|DIRECT
+    182 CA         25.8300    3.0520   28.1090 C.3      13 GLY15       0.0000 BACKBONE|DICT|DIRECT
+    183 C          25.1600    4.4030   27.9750 C.2      13 GLY15       0.0000 BACKBONE|DICT|DIRECT
+    184 O          24.8950    5.0710   28.9800 O.2      13 GLY15       0.0000 BACKBONE|DICT|DIRECT
+    185 H          24.4840    2.0930   29.4440 H        13 GLY15       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    186 HA2        25.5940    2.5060   27.3050 H        13 GLY15       0.0000 BACKBONE|DICT|DIRECT
+    187 HA3        26.8190    3.1950   28.1360 H        13 GLY15       0.0000 DICT
+    188 N          24.8680    4.8090   26.7380 N.am     14 ASP16       0.0000 BACKBONE|DICT|DIRECT
+    189 CA         24.4480    6.1670   26.4270 C.3      14 ASP16       0.0000 BACKBONE|DICT|DIRECT
+    190 C          23.1070    6.2010   25.7010 C.2      14 ASP16       0.0000 BACKBONE|DICT|DIRECT
+    191 O          22.7090    5.2370   25.0380 O.2      14 ASP16       0.0000 BACKBONE|DICT|DIRECT
+    192 CB         25.4880    6.8790   25.5500 C.3      14 ASP16       0.0000 DICT
+    193 CG         26.8110    7.0930   26.2580 C.2      14 ASP16       0.0000 DICT
+    194 OD1        26.8570    7.9140   27.1970 O.co2    14 ASP16       0.0000 DICT
+    195 OD2        27.8120    6.4550   25.8600 O.co2    14 ASP16       0.0000 DICT
+    196 H          24.9410    4.1490   25.9900 H        14 ASP16       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    197 HA         24.3570    6.6740   27.2840 H        14 ASP16       0.0000 BACKBONE|DICT|DIRECT
+    198 HB2        25.1220    7.7700   25.2810 H        14 ASP16       0.0000 DICT
+    199 HB3        25.6490    6.3250   24.7330 H        14 ASP16       0.0000 DICT
+    200 N          22.4250    7.3340   25.8390 N.am     15 GLU17       0.0000 BACKBONE|DICT|DIRECT
+    201 CA         21.3200    7.7790   24.9650 C.3      15 GLU17       0.0000 BACKBONE|DICT|DIRECT
+    202 C          20.1950    6.7370   24.9980 C.2      15 GLU17       0.0000 BACKBONE|DICT|DIRECT
+    203 O          19.8170    6.2680   26.0820 O.2      15 GLU17       0.0000 BACKBONE|DICT|DIRECT
+    204 CB         21.8810    8.0930   23.5870 C.3      15 GLU17       0.0000 DICT
+    205 CG         22.9200    9.2140   23.6200 C.3      15 GLU17       0.0000 DICT
+    206 CD         23.2850    9.7530   22.2480 C.2      15 GLU17       0.0000 DICT
+    207 OE1        23.3820    8.9580   21.2880 O.co2    15 GLU17       0.0000 DICT
+    208 OE2        23.4770   10.9830   22.1360 O.co2    15 GLU17       0.0000 DICT
+    209 H          22.6810    7.9340   26.5970 H        15 GLU17       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    210 HA         20.9570    8.6290   25.3450 H        15 GLU17       0.0000 BACKBONE|DICT|DIRECT
+    211 HB2        21.1280    8.3710   22.9900 H        15 GLU17       0.0000 DICT
+    212 HB3        22.3110    7.2680   23.2200 H        15 GLU17       0.0000 DICT
+    213 HG2        23.7500    8.8610   24.0510 H        15 GLU17       0.0000 DICT
+    214 HG3        22.5540    9.9670   24.1670 H        15 GLU17       0.0000 DICT
+    215 N          19.6260    6.3650   23.8490 N.am     16 MET18       0.0000 BACKBONE|DICT|DIRECT
+    216 CA         18.4110    5.5580   23.8710 C.3      16 MET18       0.0000 BACKBONE|DICT|DIRECT
+    217 C          18.6740    4.1630   24.4270 C.2      16 MET18       0.0000 BACKBONE|DICT|DIRECT
+    218 O          17.8420    3.6200   25.1630 O.2      16 MET18       0.0000 BACKBONE|DICT|DIRECT
+    219 CB         17.7990    5.4770   22.4730 C.3      16 MET18       0.0000 DICT
+    220 CG         16.3270    5.0780   22.4840 C.3      16 MET18       0.0000 DICT
+    221 SD         15.2740    6.3270   23.2580 S.3      16 MET18       0.0000 DICT
+    222 CE         13.9600    5.3020   23.9240 C.3      16 MET18       0.0000 DICT
+    223 H          20.0310    6.6390   22.9770 H        16 MET18       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    224 HA         17.7510    6.0100   24.4710 H        16 MET18       0.0000 BACKBONE|DICT|DIRECT
+    225 HB2        18.3080    4.8000   21.9420 H        16 MET18       0.0000 DICT
+    226 HB3        17.8820    6.3730   22.0370 H        16 MET18       0.0000 DICT
+    227 HG2        16.2310    4.2210   22.9900 H        16 MET18       0.0000 DICT
+    228 HG3        16.0240    4.9440   21.5400 H        16 MET18       0.0000 DICT
+    229 HE1        13.2910    5.8800   24.3910 H        16 MET18       0.0000 DICT
+    230 HE2        13.5120    4.8080   23.1790 H        16 MET18       0.0000 DICT
+    231 HE3        14.3450    4.6470   24.5740 H        16 MET18       0.0000 DICT
+    232 N          19.8270    3.5690   24.1070 N.am     17 THR19       0.0000 BACKBONE|DICT|DIRECT
+    233 CA         20.1170    2.2340   24.6240 C.3      17 THR19       0.0000 BACKBONE|DICT|DIRECT
+    234 C          20.2430    2.2320   26.1420 C.2      17 THR19       0.0000 BACKBONE|DICT|DIRECT
+    235 O          19.9090    1.2320   26.7870 O.2      17 THR19       0.0000 BACKBONE|DICT|DIRECT
+    236 CB         21.3840    1.6650   23.9810 C.3      17 THR19       0.0000 DICT
+    237 OG1        22.4180    2.6590   23.9650 O.3      17 THR19       0.0000 DICT
+    238 CG2        21.0930    1.2100   22.5590 C.3      17 THR19       0.0000 DICT
+    239 H          20.4870    4.0350   23.5180 H        17 THR19       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    240 HA         19.3530    1.6370   24.3780 H        17 THR19       0.0000 BACKBONE|DICT|DIRECT
+    241 HB         21.6960    0.8800   24.5160 H        17 THR19       0.0000 DICT
+    242 HG1        22.0760    3.5020   24.3790 H        17 THR19       0.0000 DICT|ESSENTIAL
+    243 HG21       21.9270    0.8410   22.1500 H        17 THR19       0.0000 DICT
+    244 HG22       20.3870    0.5020   22.5730 H        17 THR19       0.0000 DICT
+    245 HG23       20.7730    1.9880   22.0190 H        17 THR19       0.0000 DICT
+    246 N          20.7050    3.3380   26.7320 N.am     18 ARG20       0.0000 BACKBONE|DICT|DIRECT
+    247 CA         20.7540    3.4300   28.1890 C.3      18 ARG20       0.0000 BACKBONE|DICT|DIRECT
+    248 C          19.3590    3.3250   28.7950 C.2      18 ARG20       0.0000 BACKBONE|DICT|DIRECT
+    249 O          19.1720    2.6890   29.8380 O.2      18 ARG20       0.0000 BACKBONE|DICT|DIRECT
+    250 CB         21.4240    4.7380   28.6090 C.3      18 ARG20       0.0000 DICT
+    251 CG         21.7180    4.8380   30.0980 C.3      18 ARG20       0.0000 DICT
+    252 CD         22.3130    6.1960   30.4500 C.3      18 ARG20       0.0000 DICT
+    253 NE         22.6840    6.2880   31.8580 N.pl3    18 ARG20       0.0000 DICT
+    254 CZ         23.8910    5.9950   32.3370 C.cat    18 ARG20       0.0000 DICT
+    255 NH1        24.8540    5.5900   31.5170 N.pl3    18 ARG20       0.0000 DICT
+    256 NH2        24.1350    6.1070   33.6360 N.pl3    18 ARG20       0.0000 DICT
+    257 H          21.0190    4.1060   26.1740 H        18 ARG20       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    258 HA         21.3050    2.6700   28.5340 H        18 ARG20       0.0000 BACKBONE|DICT|DIRECT
+    259 HB2        20.8200    5.4940   28.3570 H        18 ARG20       0.0000 DICT
+    260 HB3        22.2880    4.8210   28.1120 H        18 ARG20       0.0000 DICT
+    261 HG2        22.3680    4.1210   30.3510 H        18 ARG20       0.0000 DICT
+    262 HG3        20.8670    4.7120   30.6080 H        18 ARG20       0.0000 DICT
+    263 HD2        21.6380    6.9050   30.2480 H        18 ARG20       0.0000 DICT
+    264 HD3        23.1290    6.3440   29.8920 H        18 ARG20       0.0000 DICT
+    265 HE         21.9850    6.5910   32.5060 H        18 ARG20       0.0000 DICT|ESSENTIAL
+    266 HH11       25.7600    5.3710   31.8790 H        18 ARG20       0.0000 DICT|ESSENTIAL
+    267 HH12       24.6730    5.5050   30.5370 H        18 ARG20       0.0000 DICT|ESSENTIAL
+    268 HH21       25.0420    5.8870   33.9950 H        18 ARG20       0.0000 DICT|ESSENTIAL
+    269 HH22       23.4120    6.4120   34.2560 H        18 ARG20       0.0000 DICT|ESSENTIAL
+    270 N          18.3670    3.9420   28.1500 N.am     19 ILE21       0.0000 BACKBONE|DICT|DIRECT
+    271 CA         16.9850    3.8330   28.6110 C.3      19 ILE21       0.0000 BACKBONE|DICT|DIRECT
+    272 C          16.4980    2.3930   28.4880 C.2      19 ILE21       0.0000 BACKBONE|DICT|DIRECT
+    273 O          15.9620    1.8150   29.4410 O.2      19 ILE21       0.0000 BACKBONE|DICT|DIRECT
+    274 CB         16.0850    4.8030   27.8240 C.3      19 ILE21       0.0000 DICT
+    275 CG1        16.4910    6.2520   28.1040 C.3      19 ILE21       0.0000 DICT
+    276 CG2        14.6130    4.5620   28.1470 C.3      19 ILE21       0.0000 DICT
+    277 CD1        15.8730    7.2530   27.1490 C.3      19 ILE21       0.0000 DICT
+    278 H          18.5730    4.4880   27.3380 H        19 ILE21       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    279 HA         16.9560    4.0920   29.5760 H        19 ILE21       0.0000 BACKBONE|DICT|DIRECT
+    280 HB         16.2200    4.6270   26.8490 H        19 ILE21       0.0000 DICT
+    281 HG12       17.4860    6.3200   28.0330 H        19 ILE21       0.0000 DICT
+    282 HG13       16.2070    6.4860   29.0340 H        19 ILE21       0.0000 DICT
+    283 HG21       14.0480    5.2020   27.6260 H        19 ILE21       0.0000 DICT
+    284 HG22       14.3670    3.6240   27.9020 H        19 ILE21       0.0000 DICT
+    285 HG23       14.4590    4.7020   29.1250 H        19 ILE21       0.0000 DICT
+    286 HD11       16.1790    8.1750   27.3880 H        19 ILE21       0.0000 DICT
+    287 HD12       16.1560    7.0400   26.2140 H        19 ILE21       0.0000 DICT
+    288 HD13       14.8760    7.2050   27.2150 H        19 ILE21       0.0000 DICT
+    289 N          16.6790    1.7940   27.3080 N.am     20 ILE22       0.0000 BACKBONE|DICT|DIRECT
+    290 CA         16.2390    0.4170   27.0920 C.3      20 ILE22       0.0000 BACKBONE|DICT|DIRECT
+    291 C          16.9240   -0.5180   28.0830 C.2      20 ILE22       0.0000 BACKBONE|DICT|DIRECT
+    292 O          16.3080   -1.4600   28.6000 O.2      20 ILE22       0.0000 BACKBONE|DICT|DIRECT
+    293 CB         16.4970   -0.0010   25.6290 C.3      20 ILE22       0.0000 DICT
+    294 CG1        15.2740    0.2720   24.7520 C.3      20 ILE22       0.0000 DICT
+    295 CG2        16.8740   -1.4660   25.5280 C.3      20 ILE22       0.0000 DICT
+    296 CD1        14.8190    1.6960   24.7560 C.3      20 ILE22       0.0000 DICT
+    297 H          17.1210    2.2940   26.5630 H        20 ILE22       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    298 HA         15.2540    0.3760   27.2570 H        20 ILE22       0.0000 BACKBONE|DICT|DIRECT
+    299 HB         17.2600    0.5430   25.2790 H        20 ILE22       0.0000 DICT
+    300 HG12       14.5210   -0.2980   25.0790 H        20 ILE22       0.0000 DICT
+    301 HG13       15.5000    0.0180   23.8120 H        20 ILE22       0.0000 DICT
+    302 HG21       17.0340   -1.7040   24.5700 H        20 ILE22       0.0000 DICT
+    303 HG22       17.7060   -1.6330   26.0560 H        20 ILE22       0.0000 DICT
+    304 HG23       16.1300   -2.0270   25.8910 H        20 ILE22       0.0000 DICT
+    305 HD11       14.0200    1.7920   24.1630 H        20 ILE22       0.0000 DICT
+    306 HD12       14.5770    1.9660   25.6880 H        20 ILE22       0.0000 DICT
+    307 HD13       15.5560    2.2820   24.4200 H        20 ILE22       0.0000 DICT
+    308 N          18.1990   -0.2520   28.3810 N.am     21 TRP23       0.0000 BACKBONE|DICT|DIRECT
+    309 CA         18.9710   -1.0990   29.2880 C.3      21 TRP23       0.0000 BACKBONE|DICT|DIRECT
+    310 C          18.3350   -1.1580   30.6720 C.2      21 TRP23       0.0000 BACKBONE|DICT|DIRECT
+    311 O          18.2220   -2.2370   31.2660 O.2      21 TRP23       0.0000 BACKBONE|DICT|DIRECT
+    312 CB         20.4050   -0.5680   29.3690 C.3      21 TRP23       0.0000 DICT
+    313 CG         21.4330   -1.5210   29.8890 C.2      21 TRP23       0.0000 DICT
+    314 CD1        21.9950   -1.5190   31.1320 C.2      21 TRP23       0.0000 DICT
+    315 CD2        22.0570   -2.5930   29.1690 C.ar     21 TRP23       0.0000 DICT
+    316 NE1        22.9220   -2.5290   31.2360 N.pl3    21 TRP23       0.0000 DICT
+    317 CE2        22.9780   -3.2040   30.0450 C.ar     21 TRP23       0.0000 DICT
+    318 CE3        21.9200   -3.1020   27.8720 C.ar     21 TRP23       0.0000 DICT
+    319 CZ2        23.7590   -4.3000   29.6660 C.ar     21 TRP23       0.0000 DICT
+    320 CZ3        22.7000   -4.1910   27.4950 C.ar     21 TRP23       0.0000 DICT
+    321 CH2        23.6060   -4.7770   28.3900 C.ar     21 TRP23       0.0000 DICT
+    322 H          18.6370    0.5490   27.9720 H        21 TRP23       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    323 HA         18.9970   -2.0250   28.9120 H        21 TRP23       0.0000 BACKBONE|DICT|DIRECT
+    324 HB2        20.4010    0.2330   29.9680 H        21 TRP23       0.0000 DICT
+    325 HB3        20.6810   -0.2940   28.4480 H        21 TRP23       0.0000 DICT
+    326 HD1        21.7660   -0.8760   31.8620 H        21 TRP23       0.0000 DICT
+    327 HE1        23.4670   -2.7370   32.0480 H        21 TRP23       0.0000 DICT|ESSENTIAL
+    328 HE3        21.2740   -2.6910   27.2290 H        21 TRP23       0.0000 DICT
+    329 HZ2        24.4060   -4.7210   30.3020 H        21 TRP23       0.0000 DICT
+    330 HZ3        22.6130   -4.5620   26.5700 H        21 TRP23       0.0000 DICT
+    331 HH2        24.1520   -5.5600   28.0910 H        21 TRP23       0.0000 DICT
+    332 N          17.9130   -0.0080   31.2040 N.am     22 GLU24       0.0000 BACKBONE|DICT|DIRECT
+    333 CA         17.2570    0.0100   32.5080 C.3      22 GLU24       0.0000 BACKBONE|DICT|DIRECT
+    334 C          15.8950   -0.6690   32.4530 C.2      22 GLU24       0.0000 BACKBONE|DICT|DIRECT
+    335 O          15.5220   -1.3950   33.3810 O.2      22 GLU24       0.0000 BACKBONE|DICT|DIRECT
+    336 CB         17.1130    1.4460   33.0120 C.3      22 GLU24       0.0000 DICT
+    337 CG         18.4280    2.0920   33.4090 C.3      22 GLU24       0.0000 DICT
+    338 CD         19.1880    1.2760   34.4370 C.2      22 GLU24       0.0000 DICT
+    339 OE1        20.3270    0.8610   34.1350 O.co2    22 GLU24       0.0000 DICT
+    340 OE2        18.6460    1.0460   35.5400 O.co2    22 GLU24       0.0000 DICT
+    341 H          18.0480    0.8480   30.7050 H        22 GLU24       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    342 HA         17.8310   -0.4920   33.1540 H        22 GLU24       0.0000 BACKBONE|DICT|DIRECT
+    343 HB2        16.5110    1.4410   33.8100 H        22 GLU24       0.0000 DICT
+    344 HB3        16.6990    1.9950   32.2860 H        22 GLU24       0.0000 DICT
+    345 HG2        18.2380    2.9960   33.7930 H        22 GLU24       0.0000 DICT
+    346 HG3        18.9970    2.1900   32.5920 H        22 GLU24       0.0000 DICT
+    347 N          15.1350   -0.4350   31.3790 N.am     23 LEU25       0.0000 BACKBONE|DICT|DIRECT
+    348 CA         13.8560   -1.1190   31.2190 C.3      23 LEU25       0.0000 BACKBONE|DICT|DIRECT
+    349 C          14.0380   -2.6320   31.2070 C.2      23 LEU25       0.0000 BACKBONE|DICT|DIRECT
+    350 O          13.2140   -3.3670   31.7640 O.2      23 LEU25       0.0000 BACKBONE|DICT|DIRECT
+    351 CB         13.1690   -0.6540   29.9380 C.3      23 LEU25       0.0000 DICT
+    352 CG         12.6960    0.7980   29.9120 C.3      23 LEU25       0.0000 DICT
+    353 CD1        12.0400    1.1090   28.5800 C.3      23 LEU25       0.0000 DICT
+    354 CD2        11.7360    1.0640   31.0570 C.3      23 LEU25       0.0000 DICT
+    355 H          15.4440    0.2120   30.6820 H        23 LEU25       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    356 HA         13.2720   -0.8790   31.9940 H        23 LEU25       0.0000 BACKBONE|DICT|DIRECT
+    357 HB2        12.3700   -1.2370   29.7920 H        23 LEU25       0.0000 DICT
+    358 HB3        13.8140   -0.7780   29.1840 H        23 LEU25       0.0000 DICT
+    359 HG         13.4920    1.3930   30.0200 H        23 LEU25       0.0000 DICT
+    360 HD11       11.7340    2.0610   28.5730 H        23 LEU25       0.0000 DICT
+    361 HD12       12.6990    0.9660   27.8420 H        23 LEU25       0.0000 DICT
+    362 HD13       11.2540    0.5050   28.4470 H        23 LEU25       0.0000 DICT
+    363 HD21       11.4360    2.0170   31.0260 H        23 LEU25       0.0000 DICT
+    364 HD22       10.9420    0.4620   30.9730 H        23 LEU25       0.0000 DICT
+    365 HD23       12.1970    0.8880   31.9270 H        23 LEU25       0.0000 DICT
+    366 N          15.1150   -3.1140   30.5840 N.am     24 ILE26       0.0000 BACKBONE|DICT|DIRECT
+    367 CA         15.3750   -4.5500   30.5490 C.3      24 ILE26       0.0000 BACKBONE|DICT|DIRECT
+    368 C          15.6870   -5.0720   31.9460 C.2      24 ILE26       0.0000 BACKBONE|DICT|DIRECT
+    369 O          15.1920   -6.1300   32.3550 O.2      24 ILE26       0.0000 BACKBONE|DICT|DIRECT
+    370 CB         16.5120   -4.8560   29.5590 C.3      24 ILE26       0.0000 DICT
+    371 CG1        16.0440   -4.6110   28.1240 C.3      24 ILE26       0.0000 DICT
+    372 CG2        17.0160   -6.2790   29.7390 C.3      24 ILE26       0.0000 DICT
+    373 CD1        17.1610   -4.6640   27.1190 C.3      24 ILE26       0.0000 DICT
+    374 H          15.7510   -2.4850   30.1360 H        24 ILE26       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    375 HA         14.5480   -5.0080   30.2240 H        24 ILE26       0.0000 BACKBONE|DICT|DIRECT
+    376 HB         17.2690   -4.2310   29.7510 H        24 ILE26       0.0000 DICT
+    377 HG12       15.6180   -3.7070   28.0790 H        24 ILE26       0.0000 DICT
+    378 HG13       15.3690   -5.3100   27.8860 H        24 ILE26       0.0000 DICT
+    379 HG21       17.7530   -6.4560   29.0870 H        24 ILE26       0.0000 DICT
+    380 HG22       17.3600   -6.3950   30.6710 H        24 ILE26       0.0000 DICT
+    381 HG23       16.2660   -6.9210   29.5780 H        24 ILE26       0.0000 DICT
+    382 HD11       16.7940   -4.4970   26.2040 H        24 ILE26       0.0000 DICT
+    383 HD12       17.8400   -3.9640   27.3390 H        24 ILE26       0.0000 DICT
+    384 HD13       17.5910   -5.5660   27.1460 H        24 ILE26       0.0000 DICT
+    385 N          16.5080   -4.3420   32.7030 N.am     25 LYS27       0.0000 BACKBONE|DICT|DIRECT
+    386 CA         16.8350   -4.7890   34.0510 C.3      25 LYS27       0.0000 BACKBONE|DICT|DIRECT
+    387 C          15.6220   -4.7060   34.9680 C.2      25 LYS27       0.0000 BACKBONE|DICT|DIRECT
+    388 O          15.3710   -5.6220   35.7590 O.2      25 LYS27       0.0000 BACKBONE|DICT|DIRECT
+    389 CB         18.0010   -3.9720   34.6080 C.3      25 LYS27       0.0000 DICT
+    390 CG         19.3010   -4.1760   33.8450 C.3      25 LYS27       0.0000 DICT
+    391 CD         20.4970   -3.6620   34.6270 C.3      25 LYS27       0.0000 DICT
+    392 CE         20.4010   -2.1710   34.8410 C.3      25 LYS27       0.0000 DICT
+    393 NZ         21.5670   -1.6360   35.5890 N.4      25 LYS27       0.0000 DICT
+    394 H          16.8970   -3.4920   32.3470 H        25 LYS27       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    395 HA         17.1220   -5.7460   34.0000 H        25 LYS27       0.0000 BACKBONE|DICT|DIRECT
+    396 HB2        18.1480   -4.2380   35.5610 H        25 LYS27       0.0000 DICT
+    397 HB3        17.7580   -3.0030   34.5660 H        25 LYS27       0.0000 DICT
+    398 HG2        19.2470   -3.6850   32.9750 H        25 LYS27       0.0000 DICT
+    399 HG3        19.4240   -5.1530   33.6690 H        25 LYS27       0.0000 DICT
+    400 HD2        21.3330   -3.8660   34.1180 H        25 LYS27       0.0000 DICT
+    401 HD3        20.5280   -4.1190   35.5160 H        25 LYS27       0.0000 DICT
+    402 HE2        19.5680   -1.9730   35.3580 H        25 LYS27       0.0000 DICT
+    403 HE3        20.3560   -1.7200   33.9500 H        25 LYS27       0.0000 DICT
+    404 HZ1        21.4620   -0.6490   35.7080 H        25 LYS27       0.0000 DICT|ESSENTIAL
+    405 HZ2        21.6180   -2.0760   36.4860 H        25 LYS27       0.0000 DICT|ESSENTIAL
+    406 HZ3        22.4060   -1.8230   35.0770 H        25 LYS27       0.0000 DICT|ESSENTIAL
+    407 N          14.8440   -3.6280   34.8600 N.am     26 GLU28       0.0000 BACKBONE|DICT|DIRECT
+    408 CA         13.6910   -3.4520   35.7380 C.3      26 GLU28       0.0000 BACKBONE|DICT|DIRECT
+    409 C          12.5930   -4.4690   35.4420 C.2      26 GLU28       0.0000 BACKBONE|DICT|DIRECT
+    410 O          12.0110   -5.0430   36.3670 O.2      26 GLU28       0.0000 BACKBONE|DICT|DIRECT
+    411 CB         13.1480   -2.0290   35.6060 C.3      26 GLU28       0.0000 DICT
+    412 CG         11.7470   -1.8410   36.1680 C.3      26 GLU28       0.0000 DICT
+    413 CD         11.0580   -0.5940   35.6330 C.2      26 GLU28       0.0000 DICT
+    414 OE1        11.7610    0.3240   35.1570 O.co2    26 GLU28       0.0000 DICT
+    415 OE2         9.8100   -0.5370   35.6830 O.co2    26 GLU28       0.0000 DICT
+    416 H          15.0520   -2.9340   34.1710 H        26 GLU28       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    417 HA         13.9940   -3.5850   36.6820 H        26 GLU28       0.0000 BACKBONE|DICT|DIRECT
+    418 HB2        13.1310   -1.7890   34.6350 H        26 GLU28       0.0000 DICT
+    419 HB3        13.7660   -1.4110   36.0920 H        26 GLU28       0.0000 DICT
+    420 HG2        11.8090   -1.7690   37.1630 H        26 GLU28       0.0000 DICT
+    421 HG3        11.1960   -2.6390   35.9250 H        26 GLU28       0.0000 DICT
+    422 N          12.2970   -4.7100   34.1650 N.am     27 LYS29       0.0000 BACKBONE|DICT|DIRECT
+    423 CA         11.1190   -5.4850   33.7960 C.3      27 LYS29       0.0000 BACKBONE|DICT|DIRECT
+    424 C          11.4080   -6.9390   33.4470 C.2      27 LYS29       0.0000 BACKBONE|DICT|DIRECT
+    425 O          10.4990   -7.7680   33.5500 O.2      27 LYS29       0.0000 BACKBONE|DICT|DIRECT
+    426 CB         10.4050   -4.8270   32.6080 C.3      27 LYS29       0.0000 DICT
+    427 CG          9.9110   -3.4160   32.8920 C.3      27 LYS29       0.0000 DICT
+    428 CD          9.0770   -2.8770   31.7430 C.3      27 LYS29       0.0000 DICT
+    429 CE          8.6210   -1.4550   32.0140 C.3      27 LYS29       0.0000 DICT
+    430 NZ          7.8770   -1.3490   33.3020 N.4      27 LYS29       0.0000 DICT
+    431 H          12.8940   -4.3530   33.4470 H        27 LYS29       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    432 HA         10.4910   -5.4760   34.5740 H        27 LYS29       0.0000 BACKBONE|DICT|DIRECT
+    433 HB2         9.6180   -5.3930   32.3610 H        27 LYS29       0.0000 DICT
+    434 HB3        11.0430   -4.7890   31.8390 H        27 LYS29       0.0000 DICT
+    435 HG2        10.7000   -2.8170   33.0300 H        27 LYS29       0.0000 DICT
+    436 HG3         9.3520   -3.4280   33.7210 H        27 LYS29       0.0000 DICT
+    437 HD2         8.2730   -3.4600   31.6220 H        27 LYS29       0.0000 DICT
+    438 HD3         9.6260   -2.8900   30.9080 H        27 LYS29       0.0000 DICT
+    439 HE2         8.0230   -1.1590   31.2690 H        27 LYS29       0.0000 DICT
+    440 HE3         9.4230   -0.8600   32.0540 H        27 LYS29       0.0000 DICT
+    441 HZ1         7.5930   -0.4010   33.4460 H        27 LYS29       0.0000 DICT|ESSENTIAL
+    442 HZ2         7.0690   -1.9370   33.2700 H        27 LYS29       0.0000 DICT|ESSENTIAL
+    443 HZ3         8.4700   -1.6380   34.0540 H        27 LYS29       0.0000 DICT|ESSENTIAL
+    444 N          12.6320   -7.2750   33.0420 N.am     28 LEU30       0.0000 BACKBONE|DICT|DIRECT
+    445 CA         12.9170   -8.6120   32.5360 C.3      28 LEU30       0.0000 BACKBONE|DICT|DIRECT
+    446 C          13.9480   -9.3890   33.3420 C.2      28 LEU30       0.0000 BACKBONE|DICT|DIRECT
+    447 O          13.8410  -10.6150   33.4190 O.2      28 LEU30       0.0000 BACKBONE|DICT|DIRECT
+    448 CB         13.3890   -8.5410   31.0750 C.3      28 LEU30       0.0000 DICT
+    449 CG         12.4610   -7.8420   30.0790 C.3      28 LEU30       0.0000 DICT
+    450 CD1        13.0170   -7.9410   28.6610 C.3      28 LEU30       0.0000 DICT
+    451 CD2        11.0530   -8.4140   30.1480 C.3      28 LEU30       0.0000 DICT
+    452 H          13.3670   -6.5990   33.0860 H        28 LEU30       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    453 HA         12.0630   -9.1320   32.5540 H        28 LEU30       0.0000 BACKBONE|DICT|DIRECT
+    454 HB2        13.5230   -9.4790   30.7550 H        28 LEU30       0.0000 DICT
+    455 HB3        14.2640   -8.0570   31.0640 H        28 LEU30       0.0000 DICT
+    456 HG         12.4140   -6.8740   30.3260 H        28 LEU30       0.0000 DICT
+    457 HD11       12.3970   -7.4790   28.0270 H        28 LEU30       0.0000 DICT
+    458 HD12       13.9160   -7.5060   28.6240 H        28 LEU30       0.0000 DICT
+    459 HD13       13.1020   -8.9030   28.4030 H        28 LEU30       0.0000 DICT
+    460 HD21       10.4680   -7.9410   29.4890 H        28 LEU30       0.0000 DICT
+    461 HD22       11.0790   -9.3900   29.9310 H        28 LEU30       0.0000 DICT
+    462 HD23       10.6870   -8.2870   31.0700 H        28 LEU30       0.0000 DICT
+    463 N          14.9360   -8.7270   33.9440 N.am     29 ILE31       0.0000 BACKBONE|DICT|DIRECT
+    464 CA         16.0190   -9.4330   34.6220 C.3      29 ILE31       0.0000 BACKBONE|DICT|DIRECT
+    465 C          15.8040   -9.4510   36.1310 C.2      29 ILE31       0.0000 BACKBONE|DICT|DIRECT
+    466 O          15.6570  -10.5200   36.7350 O.2      29 ILE31       0.0000 BACKBONE|DICT|DIRECT
+    467 CB         17.3840   -8.8080   34.2830 C.3      29 ILE31       0.0000 DICT
+    468 CG1        17.5650   -8.7090   32.7670 C.3      29 ILE31       0.0000 DICT
+    469 CG2        18.5100   -9.6230   34.9120 C.3      29 ILE31       0.0000 DICT
+    470 CD1        17.5380  -10.0440   32.0560 C.3      29 ILE31       0.0000 DICT
+    471 H          14.9350   -7.7270   33.9310 H        29 ILE31       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    472 HA         16.0220  -10.3790   34.2980 H        29 ILE31       0.0000 BACKBONE|DICT|DIRECT
+    473 HB         17.4120   -7.8840   34.6650 H        29 ILE31       0.0000 DICT
+    474 HG12       18.4460   -8.2730   32.5830 H        29 ILE31       0.0000 DICT
+    475 HG13       16.8290   -8.1420   32.3990 H        29 ILE31       0.0000 DICT
+    476 HG21       19.3900   -9.2070   34.6840 H        29 ILE31       0.0000 DICT
+    477 HG22       18.3960   -9.6380   35.9050 H        29 ILE31       0.0000 DICT
+    478 HG23       18.4820  -10.5580   34.5590 H        29 ILE31       0.0000 DICT
+    479 HD11       17.6620   -9.9010   31.0740 H        29 ILE31       0.0000 DICT
+    480 HD12       18.2760  -10.6220   32.4040 H        29 ILE31       0.0000 DICT
+    481 HD13       16.6590  -10.4910   32.2200 H        29 ILE31       0.0000 DICT
+    482 N          15.8010   -8.2700   36.7490 N.am     30 PHE32       0.0000 BACKBONE|DICT|DIRECT
+    483 CA         15.7450   -8.1920   38.2080 C.3      30 PHE32       0.0000 BACKBONE|DICT|DIRECT
+    484 C          14.5200   -8.8560   38.8350 C.2      30 PHE32       0.0000 BACKBONE|DICT|DIRECT
+    485 O          14.6710   -9.4470   39.9190 O.2      30 PHE32       0.0000 BACKBONE|DICT|DIRECT
+    486 CB         15.8380   -6.7270   38.6530 C.3      30 PHE32       0.0000 DICT
+    487 CG         17.1940   -6.1080   38.4380 C.ar     30 PHE32       0.0000 DICT
+    488 CD1        18.2940   -6.8960   38.1300 C.ar     30 PHE32       0.0000 DICT
+    489 CD2        17.3680   -4.7380   38.5470 C.ar     30 PHE32       0.0000 DICT
+    490 CE1        19.5420   -6.3290   37.9350 C.ar     30 PHE32       0.0000 DICT
+    491 CE2        18.6140   -4.1640   38.3550 C.ar     30 PHE32       0.0000 DICT
+    492 CZ         19.7020   -4.9630   38.0490 C.ar     30 PHE32       0.0000 DICT
+    493 H          15.8370   -7.4290   36.2090 H        30 PHE32       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    494 HA         16.5530   -8.6630   38.5630 H        30 PHE32       0.0000 BACKBONE|DICT|DIRECT
+    495 HB2        15.6220   -6.6800   39.6280 H        30 PHE32       0.0000 DICT
+    496 HB3        15.1650   -6.1980   38.1360 H        30 PHE32       0.0000 DICT
+    497 HD1        18.1840   -7.8870   38.0480 H        30 PHE32       0.0000 DICT
+    498 HD2        16.5850   -4.1560   38.7670 H        30 PHE32       0.0000 DICT
+    499 HE1        20.3260   -6.9080   37.7120 H        30 PHE32       0.0000 DICT
+    500 HE2        18.7270   -3.1740   38.4370 H        30 PHE32       0.0000 DICT
+    501 HZ         20.6030   -4.5510   37.9110 H        30 PHE32       0.0000 DICT
+    502 N          13.3130   -8.8030   38.2560 N.am     31 PRO33       0.0000 BACKBONE|DICT|DIRECT
+    503 CA         12.1790   -9.4920   38.8990 C.3      31 PRO33       0.0000 BACKBONE|DICT|DIRECT
+    504 C          12.3560  -10.9920   39.0290 C.2      31 PRO33       0.0000 BACKBONE|DICT|DIRECT
+    505 O          11.5680  -11.6260   39.7400 O.2      31 PRO33       0.0000 BACKBONE|DICT|DIRECT
+    506 CB         10.9940   -9.1630   37.9800 C.3      31 PRO33       0.0000 DICT
+    507 CG         11.3750   -7.9190   37.3090 C.3      31 PRO33       0.0000 DICT
+    508 CD         12.8600   -7.9970   37.1080 C.3      31 PRO33       0.0000 DICT
+    509 HA         12.0190   -9.0960   39.8030 H        31 PRO33       0.0000 BACKBONE|DICT|DIRECT
+    510 HB2        10.8520   -9.8940   37.3130 H        31 PRO33       0.0000 DICT
+    511 HB3        10.1590   -9.0330   38.5150 H        31 PRO33       0.0000 DICT
+    512 HG2        10.9080   -7.8420   36.4280 H        31 PRO33       0.0000 DICT
+    513 HG3        11.1420   -7.1310   37.8790 H        31 PRO33       0.0000 DICT
+    514 HD2        13.0820   -8.4480   36.2430 H        31 PRO33       0.0000 DICT
+    515 HD3        13.2720   -7.0860   37.1240 H        31 PRO33       0.0000 DICT
+    516 N          13.3530  -11.5860   38.3780 N.am     32 TYR34       0.0000 BACKBONE|DICT|DIRECT
+    517 CA         13.5040  -13.0340   38.3910 C.3      32 TYR34       0.0000 BACKBONE|DICT|DIRECT
+    518 C          14.8950  -13.5230   38.7520 C.2      32 TYR34       0.0000 BACKBONE|DICT|DIRECT
+    519 O          15.0320  -14.7010   39.1080 O.2      32 TYR34       0.0000 BACKBONE|DICT|DIRECT
+    520 CB         13.1150  -13.6190   37.0260 C.3      32 TYR34       0.0000 DICT
+    521 CG         11.7360  -13.1930   36.5870 C.ar     32 TYR34       0.0000 DICT
+    522 CD1        10.6000  -13.8020   37.1090 C.ar     32 TYR34       0.0000 DICT
+    523 CD2        11.5670  -12.1690   35.6660 C.ar     32 TYR34       0.0000 DICT
+    524 CE1         9.3320  -13.4100   36.7170 C.ar     32 TYR34       0.0000 DICT
+    525 CE2        10.3060  -11.7690   35.2680 C.ar     32 TYR34       0.0000 DICT
+    526 CZ          9.1920  -12.3940   35.7960 C.ar     32 TYR34       0.0000 DICT
+    527 OH          7.9340  -11.9990   35.4060 O.3      32 TYR34       0.0000 DICT
+    528 H          14.0100  -11.0280   37.8710 H        32 TYR34       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    529 HA         12.8680  -13.4000   39.0700 H        32 TYR34       0.0000 BACKBONE|DICT|DIRECT
+    530 HB2        13.1380  -14.6170   37.0860 H        32 TYR34       0.0000 DICT
+    531 HB3        13.7780  -13.3110   36.3440 H        32 TYR34       0.0000 DICT
+    532 HD1        10.7010  -14.5370   37.7800 H        32 TYR34       0.0000 DICT
+    533 HD2        12.3710  -11.7130   35.2840 H        32 TYR34       0.0000 DICT
+    534 HE1         8.5240  -13.8600   37.0990 H        32 TYR34       0.0000 DICT
+    535 HE2        10.2000  -11.0310   34.6010 H        32 TYR34       0.0000 DICT
+    536 HH          7.8260  -11.2630   34.7380 H        32 TYR34       0.0000 DICT|ESSENTIAL
+    537 N          15.9220  -12.6800   38.6830 N.am     33 VAL35       0.0000 BACKBONE|DICT|DIRECT
+    538 CA         17.2990  -13.1020   38.9010 C.3      33 VAL35       0.0000 BACKBONE|DICT|DIRECT
+    539 C          17.9650  -12.1280   39.8630 C.2      33 VAL35       0.0000 BACKBONE|DICT|DIRECT
+    540 O          17.9060  -10.9100   39.6620 O.2      33 VAL35       0.0000 BACKBONE|DICT|DIRECT
+    541 CB         18.0880  -13.1800   37.5780 C.3      33 VAL35       0.0000 DICT
+    542 CG1        19.5290  -13.5780   37.8400 C.3      33 VAL35       0.0000 DICT
+    543 CG2        17.4350  -14.1630   36.6180 C.3      33 VAL35       0.0000 DICT
+    544 H          15.7420  -11.7190   38.4730 H        33 VAL35       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    545 HA         17.2910  -14.0090   39.3210 H        33 VAL35       0.0000 BACKBONE|DICT|DIRECT
+    546 HB         18.0830  -12.2740   37.1540 H        33 VAL35       0.0000 DICT
+    547 HG11       20.0250  -13.6240   36.9730 H        33 VAL35       0.0000 DICT
+    548 HG12       19.9590  -12.8990   38.4350 H        33 VAL35       0.0000 DICT
+    549 HG13       19.5520  -14.4730   38.2850 H        33 VAL35       0.0000 DICT
+    550 HG21       17.9610  -14.1980   35.7680 H        33 VAL35       0.0000 DICT
+    551 HG22       17.4130  -15.0720   37.0350 H        33 VAL35       0.0000 DICT
+    552 HG23       16.5010  -13.8650   36.4200 H        33 VAL35       0.0000 DICT
+    553 N          18.5820  -12.6620   40.9100 N.am     34 GLU36       0.0000 BACKBONE|DICT|DIRECT
+    554 CA         19.4720  -11.8910   41.7630 C.3      34 GLU36       0.0000 BACKBONE|DICT|DIRECT
+    555 C          20.9040  -12.1500   41.3230 C.2      34 GLU36       0.0000 BACKBONE|DICT|DIRECT
+    556 O          21.2780  -13.2910   41.0310 O.2      34 GLU36       0.0000 BACKBONE|DICT|DIRECT
+    557 CB         19.2960  -12.2530   43.2400 C.3      34 GLU36       0.0000 DICT
+    558 CG         17.9130  -11.9450   43.8100 C.3      34 GLU36       0.0000 DICT
+    559 CD         17.6660  -10.4590   44.0410 C.2      34 GLU36       0.0000 DICT
+    560 OE1        18.4620   -9.6210   43.5660 O.co2    34 GLU36       0.0000 DICT
+    561 OE2        16.6630  -10.1260   44.7070 O.co2    34 GLU36       0.0000 DICT
+    562 H          18.4290  -13.6280   41.1190 H        34 GLU36       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    563 HA         19.2700  -10.9190   41.6440 H        34 GLU36       0.0000 BACKBONE|DICT|DIRECT
+    564 HB2        19.9730  -11.7410   43.7690 H        34 GLU36       0.0000 DICT
+    565 HB3        19.4650  -13.2330   43.3430 H        34 GLU36       0.0000 DICT
+    566 HG2        17.8180  -12.4210   44.6840 H        34 GLU36       0.0000 DICT
+    567 HG3        17.2240  -12.2840   43.1690 H        34 GLU36       0.0000 DICT
+    568 N          21.6990  -11.0850   41.2630 N.am     35 LEU37       0.0000 BACKBONE|DICT|DIRECT
+    569 CA         23.0420  -11.1540   40.7100 C.3      35 LEU37       0.0000 BACKBONE|DICT|DIRECT
+    570 C          24.0370  -10.5160   41.6630 C.2      35 LEU37       0.0000 BACKBONE|DICT|DIRECT
+    571 O          23.7410   -9.5010   42.2990 O.2      35 LEU37       0.0000 BACKBONE|DICT|DIRECT
+    572 CB         23.1210  -10.4470   39.3480 C.3      35 LEU37       0.0000 DICT
+    573 CG         22.3700  -11.0700   38.1740 C.3      35 LEU37       0.0000 DICT
+    574 CD1        22.3310  -10.1050   36.9970 C.3      35 LEU37       0.0000 DICT
+    575 CD2        23.0250  -12.3800   37.7700 C.3      35 LEU37       0.0000 DICT
+    576 H          21.3620  -10.2090   41.6090 H        35 LEU37       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    577 HA         23.2880  -12.1150   40.5860 H        35 LEU37       0.0000 BACKBONE|DICT|DIRECT
+    578 HB2        24.0870  -10.4000   39.0920 H        35 LEU37       0.0000 DICT
+    579 HB3        22.7640   -9.5210   39.4720 H        35 LEU37       0.0000 DICT
+    580 HG         21.4310  -11.2590   38.4610 H        35 LEU37       0.0000 DICT
+    581 HD11       21.8370  -10.5260   36.2370 H        35 LEU37       0.0000 DICT
+    582 HD12       21.8660   -9.2630   37.2710 H        35 LEU37       0.0000 DICT
+    583 HD13       23.2650   -9.8920   36.7100 H        35 LEU37       0.0000 DICT
+    584 HD21       22.5260  -12.7790   37.0010 H        35 LEU37       0.0000 DICT
+    585 HD22       23.9730  -12.2090   37.5000 H        35 LEU37       0.0000 DICT
+    586 HD23       23.0080  -13.0140   38.5430 H        35 LEU37       0.0000 DICT
+    587 N          25.2160  -11.1230   41.7640 N.am     36 ASP38       0.0000 BACKBONE|DICT|DIRECT
+    588 CA         26.3830  -10.4300   42.2990 C.3      36 ASP38       0.0000 BACKBONE|DICT|DIRECT
+    589 C          26.8680   -9.5300   41.1720 C.2      36 ASP38       0.0000 BACKBONE|DICT|DIRECT
+    590 O          27.6940   -9.9160   40.3440 O.2      36 ASP38       0.0000 BACKBONE|DICT|DIRECT
+    591 CB         27.4450  -11.4160   42.7620 C.3      36 ASP38       0.0000 DICT
+    592 CG         26.9570  -12.3020   43.8930 C.2      36 ASP38       0.0000 DICT
+    593 OD1        26.1580  -11.8180   44.7210 O.co2    36 ASP38       0.0000 DICT
+    594 OD2        27.3650  -13.4800   43.9520 O.co2    36 ASP38       0.0000 DICT
+    595 H          25.3040  -12.0740   41.4670 H        36 ASP38       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    596 HA         26.1020   -9.8630   43.0730 H        36 ASP38       0.0000 BACKBONE|DICT|DIRECT
+    597 HB2        28.2440  -10.9030   43.0770 H        36 ASP38       0.0000 DICT
+    598 HB3        27.7040  -11.9950   41.9890 H        36 ASP38       0.0000 DICT
+    599 N          26.3160   -8.3220   41.1280 N.am     37 LEU39       0.0000 BACKBONE|DICT|DIRECT
+    600 CA         26.4140   -7.4610   39.9580 C.3      37 LEU39       0.0000 BACKBONE|DICT|DIRECT
+    601 C          27.5870   -6.5020   40.1090 C.2      37 LEU39       0.0000 BACKBONE|DICT|DIRECT
+    602 O          27.6560   -5.7430   41.0830 O.2      37 LEU39       0.0000 BACKBONE|DICT|DIRECT
+    603 CB         25.1100   -6.6920   39.7570 C.3      37 LEU39       0.0000 DICT
+    604 CG         24.9060   -6.0700   38.3760 C.3      37 LEU39       0.0000 DICT
+    605 CD1        24.8860   -7.1490   37.2960 C.3      37 LEU39       0.0000 DICT
+    606 CD2        23.6280   -5.2500   38.3510 C.3      37 LEU39       0.0000 DICT
+    607 H          25.8150   -7.9920   41.9280 H        37 LEU39       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    608 HA         26.5730   -8.0340   39.1540 H        37 LEU39       0.0000 BACKBONE|DICT|DIRECT
+    609 HB2        25.0820   -5.9550   40.4320 H        37 LEU39       0.0000 DICT
+    610 HB3        24.3530   -7.3240   39.9230 H        37 LEU39       0.0000 DICT
+    611 HG         25.6750   -5.4570   38.1920 H        37 LEU39       0.0000 DICT
+    612 HD11       24.7520   -6.7230   36.4010 H        37 LEU39       0.0000 DICT
+    613 HD12       25.7550   -7.6430   37.3030 H        37 LEU39       0.0000 DICT
+    614 HD13       24.1380   -7.7880   37.4770 H        37 LEU39       0.0000 DICT
+    615 HD21       23.5070   -4.8490   37.4430 H        37 LEU39       0.0000 DICT
+    616 HD22       22.8490   -5.8410   38.5610 H        37 LEU39       0.0000 DICT
+    617 HD23       23.6870   -4.5200   39.0320 H        37 LEU39       0.0000 DICT
+    618 N          28.5030   -6.5410   39.1450 N.am     38 HIS40       0.0000 BACKBONE|DICT|DIRECT
+    619 CA         29.6250   -5.6080   39.0660 C.3      38 HIS40       0.0000 BACKBONE|DICT|DIRECT
+    620 C          29.2730   -4.6070   37.9710 C.2      38 HIS40       0.0000 BACKBONE|DICT|DIRECT
+    621 O          29.5140   -4.8440   36.7880 O.2      38 HIS40       0.0000 BACKBONE|DICT|DIRECT
+    622 CB         30.9270   -6.3440   38.7710 C.3      38 HIS40       0.0000 DICT
+    623 CG         31.1570   -7.5410   39.6410 C.2      38 HIS40       0.0000 DICT
+    624 ND1        32.0020   -7.5200   40.7300 N.pl3    38 HIS40       0.0000 DICT
+    625 CD2        30.6530   -8.7970   39.5820 C.2      38 HIS40       0.0000 DICT
+    626 CE1        32.0080   -8.7100   41.3040 C.2      38 HIS40       0.0000 DICT
+    627 NE2        31.1970   -9.5030   40.6270 N.2      38 HIS40       0.0000 DICT
+    628 H          28.4200   -7.2440   38.4390 H        38 HIS40       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    629 HA         29.7120   -5.1240   39.9370 H        38 HIS40       0.0000 BACKBONE|DICT|DIRECT
+    630 HB2        31.6860   -5.7070   38.9050 H        38 HIS40       0.0000 DICT
+    631 HB3        30.9090   -6.6460   37.8180 H        38 HIS40       0.0000 DICT
+    632 HD1        32.5280   -6.7270   41.0380 H        38 HIS40       0.0000 DICT|ESSENTIAL
+    633 HD2        30.0060   -9.1450   38.9040 H        38 HIS40       0.0000 DICT
+    634 HE1        32.5370   -8.9670   42.1130 H        38 HIS40       0.0000 DICT
+    635 N          28.6830   -3.4830   38.3700 N.am     39 SER41       0.0000 BACKBONE|DICT|DIRECT
+    636 CA         28.1460   -2.5070   37.4310 C.3      39 SER41       0.0000 BACKBONE|DICT|DIRECT
+    637 C          29.1550   -1.3940   37.2020 C.2      39 SER41       0.0000 BACKBONE|DICT|DIRECT
+    638 O          29.7350   -0.8630   38.1560 O.2      39 SER41       0.0000 BACKBONE|DICT|DIRECT
+    639 CB         26.8300   -1.9170   37.9360 C.3      39 SER41       0.0000 DICT
+    640 OG         25.8390   -2.9180   38.0410 O.3      39 SER41       0.0000 DICT
+    641 H          28.6050   -3.3020   39.3500 H        39 SER41       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    642 HA         27.9750   -2.9650   36.5590 H        39 SER41       0.0000 BACKBONE|DICT|DIRECT
+    643 HB2        26.5190   -1.2140   37.2970 H        39 SER41       0.0000 DICT
+    644 HB3        26.9780   -1.5070   38.8360 H        39 SER41       0.0000 DICT
+    645 HG         25.3400   -2.9850   37.1770 H        39 SER41       0.0000 DICT|ESSENTIAL
+    646 N          29.3550   -1.0430   35.9390 N.am     40 TYR42       0.0000 BACKBONE|DICT|DIRECT
+    647 CA         30.2580    0.0300   35.5580 C.3      40 TYR42       0.0000 BACKBONE|DICT|DIRECT
+    648 C          29.5020    0.9860   34.6520 C.2      40 TYR42       0.0000 BACKBONE|DICT|DIRECT
+    649 O          28.8110    0.5510   33.7250 O.2      40 TYR42       0.0000 BACKBONE|DICT|DIRECT
+    650 CB         31.5090   -0.5250   34.8660 C.3      40 TYR42       0.0000 DICT
+    651 CG         32.3670   -1.3390   35.8050 C.ar     40 TYR42       0.0000 DICT
+    652 CD1        32.1200   -2.6950   36.0050 C.ar     40 TYR42       0.0000 DICT
+    653 CD2        33.4050   -0.7480   36.5160 C.ar     40 TYR42       0.0000 DICT
+    654 CE1        32.8910   -3.4420   36.8760 C.ar     40 TYR42       0.0000 DICT
+    655 CE2        34.1860   -1.4880   37.3900 C.ar     40 TYR42       0.0000 DICT
+    656 CZ         33.9240   -2.8350   37.5660 C.ar     40 TYR42       0.0000 DICT
+    657 OH         34.6960   -3.5780   38.4300 O.3      40 TYR42       0.0000 DICT
+    658 H          28.8650   -1.5360   35.2200 H        40 TYR42       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    659 HA         30.5380    0.5220   36.3820 H        40 TYR42       0.0000 BACKBONE|DICT|DIRECT
+    660 HB2        32.0500    0.2400   34.5170 H        40 TYR42       0.0000 DICT
+    661 HB3        31.2240   -1.1070   34.1040 H        40 TYR42       0.0000 DICT
+    662 HD1        31.3720   -3.1360   35.5100 H        40 TYR42       0.0000 DICT
+    663 HD2        33.5910    0.2270   36.3950 H        40 TYR42       0.0000 DICT
+    664 HE1        32.7030   -4.4150   37.0060 H        40 TYR42       0.0000 DICT
+    665 HE2        34.9340   -1.0510   37.8900 H        40 TYR42       0.0000 DICT
+    666 HH         34.5090   -4.5520   38.5560 H        40 TYR42       0.0000 DICT|ESSENTIAL
+    667 N          29.6110    2.2800   34.9370 N.am     41 ASP43       0.0000 BACKBONE|DICT|DIRECT
+    668 CA         28.8940    3.3010   34.1780 C.3      41 ASP43       0.0000 BACKBONE|DICT|DIRECT
+    669 C          29.8110    3.8000   33.0690 C.2      41 ASP43       0.0000 BACKBONE|DICT|DIRECT
+    670 O          30.6540    4.6740   33.2870 O.2      41 ASP43       0.0000 BACKBONE|DICT|DIRECT
+    671 CB         28.4450    4.4400   35.0880 C.3      41 ASP43       0.0000 DICT
+    672 CG         27.3920    5.3190   34.4430 C.2      41 ASP43       0.0000 DICT
+    673 OD1        27.1980    5.2220   33.2130 O.co2    41 ASP43       0.0000 DICT
+    674 OD2        26.7530    6.1100   35.1660 O.co2    41 ASP43       0.0000 DICT
+    675 H          30.2010    2.5620   35.6930 H        41 ASP43       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    676 HA         28.0860    2.8840   33.7630 H        41 ASP43       0.0000 BACKBONE|DICT|DIRECT
+    677 HB2        29.2400    5.0040   35.3120 H        41 ASP43       0.0000 DICT
+    678 HB3        28.0660    4.0500   35.9270 H        41 ASP43       0.0000 DICT
+    679 N          29.6430    3.2460   31.8680 N.am     42 LEU44       0.0000 BACKBONE|DICT|DIRECT
+    680 CA         30.3820    3.7020   30.7020 C.3      42 LEU44       0.0000 BACKBONE|DICT|DIRECT
+    681 C          29.6570    4.8120   29.9500 C.2      42 LEU44       0.0000 BACKBONE|DICT|DIRECT
+    682 O          29.9620    5.0540   28.7760 O.2      42 LEU44       0.0000 BACKBONE|DICT|DIRECT
+    683 CB         30.6780    2.5280   29.7670 C.3      42 LEU44       0.0000 DICT
+    684 CG         31.4930    1.3880   30.3860 C.3      42 LEU44       0.0000 DICT
+    685 CD1        32.0500    0.4670   29.3050 C.3      42 LEU44       0.0000 DICT
+    686 CD2        32.6060    1.9270   31.2750 C.3      42 LEU44       0.0000 DICT
+    687 H          28.9900    2.4950   31.7660 H        42 LEU44       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    688 HA         31.2570    4.0680   31.0190 H        42 LEU44       0.0000 BACKBONE|DICT|DIRECT
+    689 HB2        31.1860    2.8800   28.9810 H        42 LEU44       0.0000 DICT
+    690 HB3        29.8050    2.1510   29.4580 H        42 LEU44       0.0000 DICT
+    691 HG         30.8770    0.8480   30.9600 H        42 LEU44       0.0000 DICT
+    692 HD11       32.5770   -0.2680   29.7320 H        42 LEU44       0.0000 DICT
+    693 HD12       31.2950    0.0740   28.7800 H        42 LEU44       0.0000 DICT
+    694 HD13       32.6430    0.9910   28.6940 H        42 LEU44       0.0000 DICT
+    695 HD21       33.1210    1.1630   31.6650 H        42 LEU44       0.0000 DICT
+    696 HD22       33.2200    2.4990   30.7310 H        42 LEU44       0.0000 DICT
+    697 HD23       32.2090    2.4720   32.0130 H        42 LEU44       0.0000 DICT
+    698 N          28.7000    5.4800   30.5930 N.am     43 GLY45       0.0000 BACKBONE|DICT|DIRECT
+    699 CA         28.1330    6.6800   30.0070 C.3      43 GLY45       0.0000 BACKBONE|DICT|DIRECT
+    700 C          29.2090    7.7040   29.7040 C.2      43 GLY45       0.0000 BACKBONE|DICT|DIRECT
+    701 O          30.2440    7.7670   30.3720 O.2      43 GLY45       0.0000 BACKBONE|DICT|DIRECT
+    702 H          28.3720    5.1540   31.4800 H        43 GLY45       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    703 HA2        27.4760    7.0770   30.6480 H        43 GLY45       0.0000 BACKBONE|DICT|DIRECT
+    704 HA3        27.6650    6.4380   29.1570 H        43 GLY45       0.0000 DICT
+    705 N          28.9610    8.5130   28.6710 N.am     44 ILE46       0.0000 BACKBONE|DICT|DIRECT
+    706 CA         30.0010    9.4090   28.1690 C.3      44 ILE46       0.0000 BACKBONE|DICT|DIRECT
+    707 C          30.4350   10.3960   29.2480 C.2      44 ILE46       0.0000 BACKBONE|DICT|DIRECT
+    708 O          31.6230   10.7190   29.3700 O.2      44 ILE46       0.0000 BACKBONE|DICT|DIRECT
+    709 CB         29.5260   10.1230   26.8890 C.3      44 ILE46       0.0000 DICT
+    710 CG1        30.6640   10.9610   26.2980 C.3      44 ILE46       0.0000 DICT
+    711 CG2        28.2880   10.9810   27.1570 C.3      44 ILE46       0.0000 DICT
+    712 CD1        31.9130   10.1610   25.9990 C.3      44 ILE46       0.0000 DICT
+    713 H          28.0590    8.5060   28.2390 H        44 ILE46       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    714 HA         30.7950    8.8500   27.9300 H        44 ILE46       0.0000 BACKBONE|DICT|DIRECT
+    715 HB         29.2780    9.4230   26.2190 H        44 ILE46       0.0000 DICT
+    716 HG12       30.8990   11.6810   26.9510 H        44 ILE46       0.0000 DICT
+    717 HG13       30.3420   11.3750   25.4460 H        44 ILE46       0.0000 DICT
+    718 HG21       28.0040   11.4300   26.3100 H        44 ILE46       0.0000 DICT
+    719 HG22       27.5460   10.4000   27.4910 H        44 ILE46       0.0000 DICT
+    720 HG23       28.5050   11.6730   27.8450 H        44 ILE46       0.0000 DICT
+    721 HD11       32.6130   10.7650   25.6180 H        44 ILE46       0.0000 DICT
+    722 HD12       32.2540    9.7470   26.8430 H        44 ILE46       0.0000 DICT
+    723 HD13       31.6980    9.4420   25.3390 H        44 ILE46       0.0000 DICT
+    724 N          29.4910   10.8640   30.0720 N.am     45 GLU47       0.0000 BACKBONE|DICT|DIRECT
+    725 CA         29.8350   11.8470   31.0940 C.3      45 GLU47       0.0000 BACKBONE|DICT|DIRECT
+    726 C          30.7030   11.2330   32.1840 C.2      45 GLU47       0.0000 BACKBONE|DICT|DIRECT
+    727 O          31.6170   11.8880   32.6990 O.2      45 GLU47       0.0000 BACKBONE|DICT|DIRECT
+    728 CB         28.5710   12.4560   31.7030 C.3      45 GLU47       0.0000 DICT
+    729 CG         27.6120   13.0760   30.6970 C.3      45 GLU47       0.0000 DICT
+    730 CD         26.5780   12.0830   30.1810 C.2      45 GLU47       0.0000 DICT
+    731 OE1        26.7830   10.8550   30.3390 O.co2    45 GLU47       0.0000 DICT
+    732 OE2        25.5550   12.5350   29.6210 O.co2    45 GLU47       0.0000 DICT
+    733 H          28.5490   10.5400   29.9880 H        45 GLU47       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    734 HA         30.3550   12.5810   30.6580 H        45 GLU47       0.0000 BACKBONE|DICT|DIRECT
+    735 HB2        28.8490   13.1680   32.3480 H        45 GLU47       0.0000 DICT
+    736 HB3        28.0830   11.7340   32.1940 H        45 GLU47       0.0000 DICT
+    737 HG2        28.1410   13.4200   29.9210 H        45 GLU47       0.0000 DICT
+    738 HG3        27.1340   13.8360   31.1370 H        45 GLU47       0.0000 DICT
+    739 N          30.4350    9.9760   32.5500 N.am     46 ASN48       0.0000 BACKBONE|DICT|DIRECT
+    740 CA         31.2410    9.3310   33.5800 C.3      46 ASN48       0.0000 BACKBONE|DICT|DIRECT
+    741 C          32.6140    8.9340   33.0460 C.2      46 ASN48       0.0000 BACKBONE|DICT|DIRECT
+    742 O          33.6080    8.9970   33.7790 O.2      46 ASN48       0.0000 BACKBONE|DICT|DIRECT
+    743 CB         30.5160    8.1090   34.1450 C.3      46 ASN48       0.0000 DICT
+    744 CG         31.2240    7.5280   35.3550 C.2      46 ASN48       0.0000 DICT
+    745 OD1        31.5800    8.2540   36.2810 O.2      46 ASN48       0.0000 DICT
+    746 ND2        31.4550    6.2190   35.3410 N.am     46 ASN48       0.0000 DICT
+    747 H          29.6830    9.4780   32.1180 H        46 ASN48       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    748 HA         31.3750    9.9850   34.3250 H        46 ASN48       0.0000 BACKBONE|DICT|DIRECT
+    749 HB2        30.4660    7.4080   33.4340 H        46 ASN48       0.0000 DICT
+    750 HB3        29.5910    8.3790   34.4130 H        46 ASN48       0.0000 DICT
+    751 HD21       31.1480    5.6650   34.5670 H        46 ASN48       0.0000 DICT|ESSENTIAL
+    752 HD22       31.9360    5.7880   36.1040 H        46 ASN48       0.0000 DICT|ESSENTIAL
+    753 N          32.6890    8.5060   31.7810 N.am     47 ARG49       0.0000 BACKBONE|DICT|DIRECT
+    754 CA         33.9910    8.2200   31.1820 C.3      47 ARG49       0.0000 BACKBONE|DICT|DIRECT
+    755 C          34.8730    9.4630   31.1770 C.2      47 ARG49       0.0000 BACKBONE|DICT|DIRECT
+    756 O          36.0700    9.3890   31.4790 O.2      47 ARG49       0.0000 BACKBONE|DICT|DIRECT
+    757 CB         33.8180    7.6730   29.7620 C.3      47 ARG49       0.0000 DICT
+    758 CG         33.5360    6.1740   29.7010 C.3      47 ARG49       0.0000 DICT
+    759 CD         33.4180    5.6470   28.2720 C.3      47 ARG49       0.0000 DICT
+    760 NE         32.1090    5.9050   27.6750 N.pl3    47 ARG49       0.0000 DICT
+    761 CZ         31.9180    6.4450   26.4740 C.cat    47 ARG49       0.0000 DICT
+    762 NH1        32.9550    6.7850   25.7240 N.pl3    47 ARG49       0.0000 DICT
+    763 NH2        30.6860    6.6370   26.0200 N.pl3    47 ARG49       0.0000 DICT
+    764 H          31.8540    8.3820   31.2450 H        47 ARG49       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    765 HA         34.4420    7.5190   31.7340 H        47 ARG49       0.0000 BACKBONE|DICT|DIRECT
+    766 HB2        34.6580    7.8560   29.2510 H        47 ARG49       0.0000 DICT
+    767 HB3        33.0540    8.1540   29.3310 H        47 ARG49       0.0000 DICT
+    768 HG2        32.6770    5.9910   30.1800 H        47 ARG49       0.0000 DICT
+    769 HG3        34.2820    5.6900   30.1580 H        47 ARG49       0.0000 DICT
+    770 HD2        33.5740    4.6590   28.2830 H        47 ARG49       0.0000 DICT
+    771 HD3        34.1170    6.0890   27.7100 H        47 ARG49       0.0000 DICT
+    772 HE         31.2990    5.6580   28.2070 H        47 ARG49       0.0000 DICT|ESSENTIAL
+    773 HH11       32.8080    7.1910   24.8220 H        47 ARG49       0.0000 DICT|ESSENTIAL
+    774 HH12       33.8850    6.6360   26.0600 H        47 ARG49       0.0000 DICT|ESSENTIAL
+    775 HH21       30.5430    7.0430   25.1170 H        47 ARG49       0.0000 DICT|ESSENTIAL
+    776 HH22       29.9000    6.3760   26.5810 H        47 ARG49       0.0000 DICT|ESSENTIAL
+    777 N          34.2890   10.6200   30.8590 N.am     48 ASP50       0.0000 BACKBONE|DICT|DIRECT
+    778 CA         35.0440   11.8690   30.8660 C.3      48 ASP50       0.0000 BACKBONE|DICT|DIRECT
+    779 C          35.4740   12.2510   32.2790 C.2      48 ASP50       0.0000 BACKBONE|DICT|DIRECT
+    780 O          36.6150   12.6730   32.4940 O.2      48 ASP50       0.0000 BACKBONE|DICT|DIRECT
+    781 CB         34.2040   12.9800   30.2320 C.3      48 ASP50       0.0000 DICT
+    782 CG         34.9710   14.2800   30.0740 C.2      48 ASP50       0.0000 DICT
+    783 OD1        35.7890   14.3870   29.1360 O.co2    48 ASP50       0.0000 DICT
+    784 OD2        34.7450   15.2020   30.8830 O.co2    48 ASP50       0.0000 DICT
+    785 H          33.3200   10.6310   30.6120 H        48 ASP50       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    786 HA         35.8660   11.7420   30.3110 H        48 ASP50       0.0000 BACKBONE|DICT|DIRECT
+    787 HB2        33.4070   13.1480   30.8120 H        48 ASP50       0.0000 DICT
+    788 HB3        33.9010   12.6760   29.3290 H        48 ASP50       0.0000 DICT
+    789 N          34.5790   12.0960   33.2590 N.am     49 ALA51       0.0000 BACKBONE|DICT|DIRECT
+    790 CA         34.8970   12.5130   34.6210 C.3      49 ALA51       0.0000 BACKBONE|DICT|DIRECT
+    791 C          36.0000   11.6620   35.2390 C.2      49 ALA51       0.0000 BACKBONE|DICT|DIRECT
+    792 O          36.7810   12.1640   36.0530 O.2      49 ALA51       0.0000 BACKBONE|DICT|DIRECT
+    793 CB         33.6430   12.4660   35.4910 C.3      49 ALA51       0.0000 DICT
+    794 H          33.6870   11.6920   33.0580 H        49 ALA51       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    795 HA         35.2170   13.4600   34.5890 H        49 ALA51       0.0000 BACKBONE|DICT|DIRECT
+    796 HB1        33.8720   12.7530   36.4210 H        49 ALA51       0.0000 DICT
+    797 HB2        32.9520   13.0810   35.1130 H        49 ALA51       0.0000 DICT
+    798 HB3        33.2850   11.5330   35.5090 H        49 ALA51       0.0000 DICT
+    799 N          36.0830   10.3840   34.8780 N.am     50 THR52       0.0000 BACKBONE|DICT|DIRECT
+    800 CA         37.0990    9.4930   35.4180 C.3      50 THR52       0.0000 BACKBONE|DICT|DIRECT
+    801 C          38.3060    9.3600   34.5000 C.2      50 THR52       0.0000 BACKBONE|DICT|DIRECT
+    802 O          39.1760    8.5250   34.7600 O.2      50 THR52       0.0000 BACKBONE|DICT|DIRECT
+    803 CB         36.5050    8.1070   35.6900 C.3      50 THR52       0.0000 DICT
+    804 OG1        36.1560    7.4830   34.4480 O.3      50 THR52       0.0000 DICT
+    805 CG2        35.2590    8.2180   36.5630 C.3      50 THR52       0.0000 DICT
+    806 H          35.4270   10.0240   34.2150 H        50 THR52       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    807 HA         37.4120    9.8720   36.2890 H        50 THR52       0.0000 BACKBONE|DICT|DIRECT
+    808 HB         37.1860    7.5450   36.1600 H        50 THR52       0.0000 DICT
+    809 HG1        35.2130    7.7170   34.2110 H        50 THR52       0.0000 DICT|ESSENTIAL
+    810 HG21       34.8860    7.3050   36.7290 H        50 THR52       0.0000 DICT
+    811 HG22       35.5000    8.6440   37.4350 H        50 THR52       0.0000 DICT
+    812 HG23       34.5740    8.7780   36.0970 H        50 THR52       0.0000 DICT
+    813 N          38.3730   10.1600   33.4340 N.am     51 ASN53       0.0000 BACKBONE|DICT|DIRECT
+    814 CA         39.4420   10.0700   32.4380 C.3      51 ASN53       0.0000 BACKBONE|DICT|DIRECT
+    815 C          39.5410    8.6570   31.8700 C.2      51 ASN53       0.0000 BACKBONE|DICT|DIRECT
+    816 O          40.6240    8.0790   31.7490 O.2      51 ASN53       0.0000 BACKBONE|DICT|DIRECT
+    817 CB         40.7790   10.5300   33.0210 C.3      51 ASN53       0.0000 DICT
+    818 CG         40.7690   11.9970   33.3890 C.2      51 ASN53       0.0000 DICT
+    819 OD1        40.3930   12.8450   32.5800 O.2      51 ASN53       0.0000 DICT
+    820 ND2        41.1580   12.3030   34.6200 N.am     51 ASN53       0.0000 DICT
+    821 H          37.6610   10.8520   33.3100 H        51 ASN53       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    822 HA         39.2100   10.6860   31.6850 H        51 ASN53       0.0000 BACKBONE|DICT|DIRECT
+    823 HB2        41.4970   10.3730   32.3430 H        51 ASN53       0.0000 DICT
+    824 HB3        40.9740    9.9940   33.8420 H        51 ASN53       0.0000 DICT
+    825 HD21       41.4560   11.5810   35.2440 H        51 ASN53       0.0000 DICT|ESSENTIAL
+    826 HD22       41.1530   13.2560   34.9240 H        51 ASN53       0.0000 DICT|ESSENTIAL
+    827 N          38.3790    8.0980   31.5350 N.am     52 ASP54       0.0000 BACKBONE|DICT|DIRECT
+    828 CA         38.2150    6.7810   30.9240 C.3      52 ASP54       0.0000 BACKBONE|DICT|DIRECT
+    829 C          38.6960    5.6420   31.8180 C.2      52 ASP54       0.0000 BACKBONE|DICT|DIRECT
+    830 O          38.8120    4.5020   31.3490 O.2      52 ASP54       0.0000 BACKBONE|DICT|DIRECT
+    831 CB         38.9150    6.7030   29.5580 C.3      52 ASP54       0.0000 DICT
+    832 CG         38.2100    5.7660   28.5950 C.2      52 ASP54       0.0000 DICT
+    833 OD1        36.9710    5.6210   28.7010 O.co2    52 ASP54       0.0000 DICT
+    834 OD2        38.8930    5.1750   27.7310 O.co2    52 ASP54       0.0000 DICT
+    835 H          37.5490    8.6240   31.7170 H        52 ASP54       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    836 HA         37.2370    6.6440   30.7670 H        52 ASP54       0.0000 BACKBONE|DICT|DIRECT
+    837 HB2        39.8500    6.3770   29.6950 H        52 ASP54       0.0000 DICT
+    838 HB3        38.9370    7.6190   29.1560 H        52 ASP54       0.0000 DICT
+    839 N          38.9770    5.9140   33.0960 N.am     53 GLN55       0.0000 BACKBONE|DICT|DIRECT
+    840 CA         39.4240    4.8520   33.9910 C.3      53 GLN55       0.0000 BACKBONE|DICT|DIRECT
+    841 C          38.3360    3.8070   34.2140 C.2      53 GLN55       0.0000 BACKBONE|DICT|DIRECT
+    842 O          38.6460    2.6270   34.4130 O.2      53 GLN55       0.0000 BACKBONE|DICT|DIRECT
+    843 CB         39.8760    5.4430   35.3260 C.3      53 GLN55       0.0000 DICT
+    844 CG         40.5080    4.4300   36.2620 C.3      53 GLN55       0.0000 DICT
+    845 CD         41.7330    3.7760   35.6530 C.2      53 GLN55       0.0000 DICT
+    846 OE1        42.6100    4.4560   35.1190 O.2      53 GLN55       0.0000 DICT
+    847 NE2        41.7930    2.4510   35.7170 N.am     53 GLN55       0.0000 DICT
+    848 H          38.8810    6.8480   33.4400 H        53 GLN55       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    849 HA         40.2090    4.3990   33.5690 H        53 GLN55       0.0000 BACKBONE|DICT|DIRECT
+    850 HB2        39.0790    5.8390   35.7820 H        53 GLN55       0.0000 DICT
+    851 HB3        40.5460    6.1620   35.1420 H        53 GLN55       0.0000 DICT
+    852 HG2        39.8350    3.7210   36.4720 H        53 GLN55       0.0000 DICT
+    853 HG3        40.7770    4.8950   37.1060 H        53 GLN55       0.0000 DICT
+    854 HE21       41.0580    1.9380   36.1600 H        53 GLN55       0.0000 DICT|ESSENTIAL
+    855 HE22       42.5730    1.9660   35.3220 H        53 GLN55       0.0000 DICT|ESSENTIAL
+    856 N          37.0620    4.2160   34.1730 N.am     54 VAL56       0.0000 BACKBONE|DICT|DIRECT
+    857 CA         35.9660    3.2680   34.3610 C.3      54 VAL56       0.0000 BACKBONE|DICT|DIRECT
+    858 C          35.9490    2.2230   33.2500 C.2      54 VAL56       0.0000 BACKBONE|DICT|DIRECT
+    859 O          35.5430    1.0750   33.4710 O.2      54 VAL56       0.0000 BACKBONE|DICT|DIRECT
+    860 CB         34.6230    4.0230   34.4550 C.3      54 VAL56       0.0000 DICT
+    861 CG1        34.3290    4.7750   33.1580 C.3      54 VAL56       0.0000 DICT
+    862 CG2        33.4820    3.0660   34.7990 C.3      54 VAL56       0.0000 DICT
+    863 H          36.8580    5.1820   34.0120 H        54 VAL56       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    864 HA         36.1140    2.7930   35.2290 H        54 VAL56       0.0000 BACKBONE|DICT|DIRECT
+    865 HB         34.6970    4.6950   35.1920 H        54 VAL56       0.0000 DICT
+    866 HG11       33.4560    5.2560   33.2420 H        54 VAL56       0.0000 DICT
+    867 HG12       35.0580    5.4370   32.9840 H        54 VAL56       0.0000 DICT
+    868 HG13       34.2800    4.1250   32.4000 H        54 VAL56       0.0000 DICT
+    869 HG21       32.6240    3.5770   34.8540 H        54 VAL56       0.0000 DICT
+    870 HG22       33.4080    2.3660   34.0880 H        54 VAL56       0.0000 DICT
+    871 HG23       33.6670    2.6290   35.6790 H        54 VAL56       0.0000 DICT
+    872 N          36.3980    2.5930   32.0460 N.am     55 THR57       0.0000 BACKBONE|DICT|DIRECT
+    873 CA         36.4130    1.6480   30.9340 C.3      55 THR57       0.0000 BACKBONE|DICT|DIRECT
+    874 C          37.4660    0.5680   31.1430 C.2      55 THR57       0.0000 BACKBONE|DICT|DIRECT
+    875 O          37.2100   -0.6150   30.8880 O.2      55 THR57       0.0000 BACKBONE|DICT|DIRECT
+    876 CB         36.6550    2.3920   29.6180 C.3      55 THR57       0.0000 DICT
+    877 OG1        35.6280    3.3700   29.4260 O.3      55 THR57       0.0000 DICT
+    878 CG2        36.6470    1.4290   28.4390 C.3      55 THR57       0.0000 DICT
+    879 H          36.7270    3.5270   31.9060 H        55 THR57       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    880 HA         35.5170    1.2070   30.8850 H        55 THR57       0.0000 BACKBONE|DICT|DIRECT
+    881 HB         37.5420    2.8520   29.6600 H        55 THR57       0.0000 DICT
+    882 HG1        35.9950    4.1400   28.9040 H        55 THR57       0.0000 DICT|ESSENTIAL
+    883 HG21       36.8070    1.9370   27.5930 H        55 THR57       0.0000 DICT
+    884 HG22       37.3690    0.7480   28.5600 H        55 THR57       0.0000 DICT
+    885 HG23       35.7600    0.9700   28.3900 H        55 THR57       0.0000 DICT
+    886 N          38.6540    0.9520   31.6140 N.am     56 LYS58       0.0000 BACKBONE|DICT|DIRECT
+    887 CA         39.6950   -0.0360   31.8830 C.3      56 LYS58       0.0000 BACKBONE|DICT|DIRECT
+    888 C          39.3260   -0.9250   33.0630 C.2      56 LYS58       0.0000 BACKBONE|DICT|DIRECT
+    889 O          39.5950   -2.1320   33.0440 O.2      56 LYS58       0.0000 BACKBONE|DICT|DIRECT
+    890 CB         41.0270    0.6600   32.1420 C.3      56 LYS58       0.0000 DICT
+    891 CG         41.5400    1.4630   30.9730 C.3      56 LYS58       0.0000 DICT
+    892 CD         42.2470    2.7130   31.4640 C.3      56 LYS58       0.0000 DICT
+    893 CE         43.2800    3.1890   30.4670 C.3      56 LYS58       0.0000 DICT
+    894 NZ         43.5470    4.6450   30.6260 N.4      56 LYS58       0.0000 DICT
+    895 H          38.8320    1.9210   31.7840 H        56 LYS58       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    896 HA         39.7950   -0.6150   31.0740 H        56 LYS58       0.0000 BACKBONE|DICT|DIRECT
+    897 HB2        41.7070   -0.0380   32.3660 H        56 LYS58       0.0000 DICT
+    898 HB3        40.9130    1.2770   32.9210 H        56 LYS58       0.0000 DICT
+    899 HG2        40.7710    1.7260   30.3900 H        56 LYS58       0.0000 DICT
+    900 HG3        42.1820    0.9060   30.4460 H        56 LYS58       0.0000 DICT
+    901 HD2        42.7010    2.5110   32.3320 H        56 LYS58       0.0000 DICT
+    902 HD3        41.5710    3.4360   31.6020 H        56 LYS58       0.0000 DICT
+    903 HE2        42.9430    3.0180   29.5410 H        56 LYS58       0.0000 DICT
+    904 HE3        44.1310    2.6830   30.6110 H        56 LYS58       0.0000 DICT
+    905 HZ1        44.2320    4.9330   29.9570 H        56 LYS58       0.0000 DICT|ESSENTIAL
+    906 HZ2        42.7010    5.1570   30.4790 H        56 LYS58       0.0000 DICT|ESSENTIAL
+    907 HZ3        43.8880    4.8230   31.5490 H        56 LYS58       0.0000 DICT|ESSENTIAL
+    908 N          38.7150   -0.3470   34.1020 N.am     57 ASP59       0.0000 BACKBONE|DICT|DIRECT
+    909 CA         38.2920   -1.1440   35.2490 C.3      57 ASP59       0.0000 BACKBONE|DICT|DIRECT
+    910 C          37.2500   -2.1800   34.8480 C.2      57 ASP59       0.0000 BACKBONE|DICT|DIRECT
+    911 O          37.2720   -3.3160   35.3390 O.2      57 ASP59       0.0000 BACKBONE|DICT|DIRECT
+    912 CB         37.7490   -0.2320   36.3500 C.3      57 ASP59       0.0000 DICT
+    913 CG         38.8470    0.5060   37.0940 C.2      57 ASP59       0.0000 DICT
+    914 OD1        40.0230    0.4130   36.6800 O.co2    57 ASP59       0.0000 DICT
+    915 OD2        38.5320    1.1890   38.0930 O.co2    57 ASP59       0.0000 DICT
+    916 H          38.5470    0.6390   34.0930 H        57 ASP59       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    917 HA         39.0910   -1.6260   35.6070 H        57 ASP59       0.0000 BACKBONE|DICT|DIRECT
+    918 HB2        37.2380   -0.7900   37.0040 H        57 ASP59       0.0000 DICT
+    919 HB3        37.1360    0.4400   35.9350 H        57 ASP59       0.0000 DICT
+    920 N          36.3280   -1.8100   33.9560 N.am     58 ALA60       0.0000 BACKBONE|DICT|DIRECT
+    921 CA         35.3130   -2.7600   33.5090 C.3      58 ALA60       0.0000 BACKBONE|DICT|DIRECT
+    922 C          35.9300   -3.8880   32.6920 C.2      58 ALA60       0.0000 BACKBONE|DICT|DIRECT
+    923 O          35.5010   -5.0410   32.7980 O.2      58 ALA60       0.0000 BACKBONE|DICT|DIRECT
+    924 CB         34.2320   -2.0420   32.7000 C.3      58 ALA60       0.0000 DICT
+    925 H          36.3330   -0.8780   33.5920 H        58 ALA60       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    926 HA         34.8830   -3.1600   34.3180 H        58 ALA60       0.0000 BACKBONE|DICT|DIRECT
+    927 HB1        33.5450   -2.7040   32.4010 H        58 ALA60       0.0000 DICT
+    928 HB2        33.7970   -1.3450   33.2700 H        58 ALA60       0.0000 DICT
+    929 HB3        34.6470   -1.6080   31.9000 H        58 ALA60       0.0000 DICT
+    930 N          36.9370   -3.5760   31.8690 N.am     59 ALA61       0.0000 BACKBONE|DICT|DIRECT
+    931 CA         37.5990   -4.6170   31.0880 C.3      59 ALA61       0.0000 BACKBONE|DICT|DIRECT
+    932 C          38.2880   -5.6260   31.9970 C.2      59 ALA61       0.0000 BACKBONE|DICT|DIRECT
+    933 O          38.1880   -6.8410   31.7800 O.2      59 ALA61       0.0000 BACKBONE|DICT|DIRECT
+    934 CB         38.6010   -3.9910   30.1190 C.3      59 ALA61       0.0000 DICT
+    935 H          37.2380   -2.6260   31.7880 H        59 ALA61       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    936 HA         36.9040   -5.0990   30.5540 H        59 ALA61       0.0000 BACKBONE|DICT|DIRECT
+    937 HB1        39.0480   -4.7120   29.5900 H        59 ALA61       0.0000 DICT
+    938 HB2        38.1220   -3.3710   29.4980 H        59 ALA61       0.0000 DICT
+    939 HB3        39.2890   -3.4810   30.6350 H        59 ALA61       0.0000 DICT
+    940 N          38.9860   -5.1410   33.0270 N.am     60 GLU62       0.0000 BACKBONE|DICT|DIRECT
+    941 CA         39.6290   -6.0400   33.9780 C.3      60 GLU62       0.0000 BACKBONE|DICT|DIRECT
+    942 C          38.6040   -6.8430   34.7690 C.2      60 GLU62       0.0000 BACKBONE|DICT|DIRECT
+    943 O          38.8680   -7.9950   35.1320 O.2      60 GLU62       0.0000 BACKBONE|DICT|DIRECT
+    944 CB         40.5350   -5.2470   34.9260 C.3      60 GLU62       0.0000 DICT
+    945 CG         41.6480   -4.4850   34.2240 C.3      60 GLU62       0.0000 DICT
+    946 CD         42.7760   -5.3980   33.7600 C.2      60 GLU62       0.0000 DICT
+    947 OE1        43.0320   -6.4390   34.4100 O.co2    60 GLU62       0.0000 DICT
+    948 OE2        43.4020   -5.0900   32.7220 O.co2    60 GLU62       0.0000 DICT
+    949 H          39.0680   -4.1520   33.1470 H        60 GLU62       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    950 HA         40.1990   -6.6810   33.4650 H        60 GLU62       0.0000 BACKBONE|DICT|DIRECT
+    951 HB2        40.9510   -5.8870   35.5720 H        60 GLU62       0.0000 DICT
+    952 HB3        39.9700   -4.5900   35.4250 H        60 GLU62       0.0000 DICT
+    953 HG2        42.0230   -3.8080   34.8580 H        60 GLU62       0.0000 DICT
+    954 HG3        41.2640   -4.0190   33.4270 H        60 GLU62       0.0000 DICT
+    955 N          37.4310   -6.2610   35.0360 N.am     61 ALA63       0.0000 BACKBONE|DICT|DIRECT
+    956 CA         36.3850   -6.9990   35.7360 C.3      61 ALA63       0.0000 BACKBONE|DICT|DIRECT
+    957 C          35.8810   -8.1680   34.8970 C.2      61 ALA63       0.0000 BACKBONE|DICT|DIRECT
+    958 O          35.5720   -9.2390   35.4350 O.2      61 ALA63       0.0000 BACKBONE|DICT|DIRECT
+    959 CB         35.2370   -6.0580   36.1000 C.3      61 ALA63       0.0000 DICT
+    960 H          37.2690   -5.3150   34.7550 H        61 ALA63       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    961 HA         36.7720   -7.3640   36.5830 H        61 ALA63       0.0000 BACKBONE|DICT|DIRECT
+    962 HB1        34.5250   -6.5710   36.5790 H        61 ALA63       0.0000 DICT
+    963 HB2        35.5790   -5.3290   36.6930 H        61 ALA63       0.0000 DICT
+    964 HB3        34.8560   -5.6580   35.2660 H        61 ALA63       0.0000 DICT
+    965 N          35.7890   -7.9800   33.5790 N.am     62 ILE64       0.0000 BACKBONE|DICT|DIRECT
+    966 CA         35.3700   -9.0680   32.7020 C.3      62 ILE64       0.0000 BACKBONE|DICT|DIRECT
+    967 C          36.3980  -10.1930   32.7180 C.2      62 ILE64       0.0000 BACKBONE|DICT|DIRECT
+    968 O          36.0380  -11.3760   32.6870 O.2      62 ILE64       0.0000 BACKBONE|DICT|DIRECT
+    969 CB         35.1220   -8.5440   31.2770 C.3      62 ILE64       0.0000 DICT
+    970 CG1        34.1190   -7.3900   31.3020 C.3      62 ILE64       0.0000 DICT
+    971 CG2        34.6100   -9.6640   30.3780 C.3      62 ILE64       0.0000 DICT
+    972 CD1        33.9790   -6.6720   29.9720 C.3      62 ILE64       0.0000 DICT
+    973 H          36.0090   -7.0860   33.1890 H        62 ILE64       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    974 HA         34.5070   -9.4330   33.0520 H        62 ILE64       0.0000 BACKBONE|DICT|DIRECT
+    975 HB         35.9870   -8.2070   30.9060 H        62 ILE64       0.0000 DICT
+    976 HG12       34.4180   -6.7270   31.9880 H        62 ILE64       0.0000 DICT
+    977 HG13       33.2240   -7.7550   31.5590 H        62 ILE64       0.0000 DICT
+    978 HG21       34.4540   -9.3070   29.4570 H        62 ILE64       0.0000 DICT
+    979 HG22       35.2880  -10.3980   30.3410 H        62 ILE64       0.0000 DICT
+    980 HG23       33.7520  -10.0210   30.7470 H        62 ILE64       0.0000 DICT
+    981 HD11       33.3110   -5.9330   30.0610 H        62 ILE64       0.0000 DICT
+    982 HD12       34.8640   -6.2910   29.7040 H        62 ILE64       0.0000 DICT
+    983 HD13       33.6700   -7.3190   29.2750 H        62 ILE64       0.0000 DICT
+    984 N          37.6900   -9.8490   32.7680 N.am     63 LYS65       0.0000 BACKBONE|DICT|DIRECT
+    985 CA         38.7230  -10.8750   32.9030 C.3      63 LYS65       0.0000 BACKBONE|DICT|DIRECT
+    986 C          38.5420  -11.6660   34.1900 C.2      63 LYS65       0.0000 BACKBONE|DICT|DIRECT
+    987 O          38.6360  -12.8990   34.1920 O.2      63 LYS65       0.0000 BACKBONE|DICT|DIRECT
+    988 CB         40.1160  -10.2410   32.8680 C.3      63 LYS65       0.0000 DICT
+    989 CG         40.6010   -9.8620   31.4810 C.3      63 LYS65       0.0000 DICT
+    990 CD         41.9090   -9.0780   31.5200 C.3      63 LYS65       0.0000 DICT
+    991 CE         43.1090   -9.9770   31.7550 C.3      63 LYS65       0.0000 DICT
+    992 NZ         44.3920   -9.2410   31.5520 N.4      63 LYS65       0.0000 DICT
+    993 H          37.9510   -8.8850   32.7130 H        63 LYS65       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+    994 HA         38.6440  -11.5060   32.1310 H        63 LYS65       0.0000 BACKBONE|DICT|DIRECT
+    995 HB2        40.7660  -10.8930   33.2590 H        63 LYS65       0.0000 DICT
+    996 HB3        40.0970   -9.4130   33.4290 H        63 LYS65       0.0000 DICT
+    997 HG2        39.9020   -9.3000   31.0380 H        63 LYS65       0.0000 DICT
+    998 HG3        40.7420  -10.6980   30.9500 H        63 LYS65       0.0000 DICT
+    999 HD2        41.8600   -8.4060   32.2590 H        63 LYS65       0.0000 DICT
+   1000 HD3        42.0270   -8.6050   30.6470 H        63 LYS65       0.0000 DICT
+   1001 HE2        43.0700  -10.7450   31.1150 H        63 LYS65       0.0000 DICT
+   1002 HE3        43.0770  -10.3230   32.6930 H        63 LYS65       0.0000 DICT
+   1003 HZ1        45.1610   -9.8600   31.7140 H        63 LYS65       0.0000 DICT|ESSENTIAL
+   1004 HZ2        44.4340   -8.8960   30.6140 H        63 LYS65       0.0000 DICT|ESSENTIAL
+   1005 HZ3        44.4410   -8.4740   32.1920 H        63 LYS65       0.0000 DICT|ESSENTIAL
+   1006 N          38.2600  -10.9690   35.2920 N.am     64 LYS66       0.0000 BACKBONE|DICT|DIRECT
+   1007 CA         38.1670  -11.6190   36.5930 C.3      64 LYS66       0.0000 BACKBONE|DICT|DIRECT
+   1008 C          36.9380  -12.5150   36.6870 C.2      64 LYS66       0.0000 BACKBONE|DICT|DIRECT
+   1009 O          37.0270  -13.6440   37.1850 O.2      64 LYS66       0.0000 BACKBONE|DICT|DIRECT
+   1010 CB         38.1460  -10.5550   37.6910 C.3      64 LYS66       0.0000 DICT
+   1011 CG         38.3330  -11.0740   39.1060 C.3      64 LYS66       0.0000 DICT
+   1012 CD         38.1480   -9.9400   40.1070 C.3      64 LYS66       0.0000 DICT
+   1013 CE         39.0650  -10.0860   41.3090 C.3      64 LYS66       0.0000 DICT
+   1014 NZ         38.7440  -11.2910   42.1150 N.4      64 LYS66       0.0000 DICT
+   1015 H          38.1100   -9.9830   35.2240 H        64 LYS66       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1016 HA         38.9810  -12.1860   36.7200 H        64 LYS66       0.0000 BACKBONE|DICT|DIRECT
+   1017 HB2        37.2640  -10.0860   37.6490 H        64 LYS66       0.0000 DICT
+   1018 HB3        38.8800   -9.9030   37.5020 H        64 LYS66       0.0000 DICT
+   1019 HG2        39.2540  -11.4520   39.2010 H        64 LYS66       0.0000 DICT
+   1020 HG3        37.6580  -11.7890   39.2880 H        64 LYS66       0.0000 DICT
+   1021 HD2        37.1990   -9.9400   40.4230 H        64 LYS66       0.0000 DICT
+   1022 HD3        38.3480   -9.0720   39.6520 H        64 LYS66       0.0000 DICT
+   1023 HE2        38.9690   -9.2760   41.8880 H        64 LYS66       0.0000 DICT
+   1024 HE3        40.0090  -10.1560   40.9870 H        64 LYS66       0.0000 DICT
+   1025 HZ1        39.3690  -11.3480   42.8930 H        64 LYS66       0.0000 DICT|ESSENTIAL
+   1026 HZ2        37.8030  -11.2290   42.4480 H        64 LYS66       0.0000 DICT|ESSENTIAL
+   1027 HZ3        38.8430  -12.1080   41.5470 H        64 LYS66       0.0000 DICT|ESSENTIAL
+   1028 N          35.7860  -12.0430   36.2070 N.am     65 HIS67       0.0000 BACKBONE|DICT|DIRECT
+   1029 CA         34.5160  -12.7150   36.4570 C.3      65 HIS67       0.0000 BACKBONE|DICT|DIRECT
+   1030 C          33.9510  -13.4440   35.2450 C.2      65 HIS67       0.0000 BACKBONE|DICT|DIRECT
+   1031 O          32.9190  -14.1130   35.3720 O.2      65 HIS67       0.0000 BACKBONE|DICT|DIRECT
+   1032 CB         33.4940  -11.7050   36.9920 C.3      65 HIS67       0.0000 DICT
+   1033 CG         33.9280  -11.0340   38.2580 C.2      65 HIS67       0.0000 DICT
+   1034 ND1        33.9300  -11.6780   39.4770 N.2      65 HIS67       0.0000 DICT
+   1035 CD2        34.3960   -9.7850   38.4910 C.2      65 HIS67       0.0000 DICT
+   1036 CE1        34.3720  -10.8510   40.4080 C.2      65 HIS67       0.0000 DICT
+   1037 NE2        34.6620   -9.6970   39.8360 N.pl3    65 HIS67       0.0000 DICT
+   1038 H          35.7940  -11.2050   35.6610 H        65 HIS67       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1039 HA         34.6710  -13.3960   37.1730 H        65 HIS67       0.0000 BACKBONE|DICT|DIRECT
+   1040 HB2        32.6350  -12.1860   37.1670 H        65 HIS67       0.0000 DICT
+   1041 HB3        33.3480  -11.0030   36.2950 H        65 HIS67       0.0000 DICT
+   1042 HD2        34.5240   -9.0620   37.8120 H        65 HIS67       0.0000 DICT
+   1043 HE1        34.4700  -11.0630   41.3800 H        65 HIS67       0.0000 DICT
+   1044 HE2        35.0180   -8.8890   40.3060 H        65 HIS67       0.0000 DICT|ESSENTIAL
+   1045 N          34.5830  -13.3270   34.0780 N.am     66 ASN68       0.0000 BACKBONE|DICT|DIRECT
+   1046 CA         34.3800  -14.1350   32.8800 C.3      66 ASN68       0.0000 BACKBONE|DICT|DIRECT
+   1047 C          33.1020  -13.7980   32.1100 C.2      66 ASN68       0.0000 BACKBONE|DICT|DIRECT
+   1048 O          32.9080  -14.3430   31.0200 O.2      66 ASN68       0.0000 BACKBONE|DICT|DIRECT
+   1049 CB         34.3830  -15.6510   33.1690 C.3      66 ASN68       0.0000 DICT
+   1050 CG         35.6200  -16.0970   33.9220 C.2      66 ASN68       0.0000 DICT
+   1051 OD1        35.5500  -16.4530   35.0990 O.2      66 ASN68       0.0000 DICT
+   1052 ND2        36.7650  -16.0740   33.2460 N.am     66 ASN68       0.0000 DICT
+   1053 H          35.2730  -12.6060   34.0160 H        66 ASN68       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1054 HA         35.1490  -13.9510   32.2680 H        66 ASN68       0.0000 BACKBONE|DICT|DIRECT
+   1055 HB2        34.3420  -16.1430   32.2990 H        66 ASN68       0.0000 DICT
+   1056 HB3        33.5770  -15.8740   33.7160 H        66 ASN68       0.0000 DICT
+   1057 HD21       36.7760  -15.7780   32.2910 H        66 ASN68       0.0000 DICT|ESSENTIAL
+   1058 HD22       37.6150  -16.3530   33.6930 H        66 ASN68       0.0000 DICT|ESSENTIAL
+   1059 N          32.2170  -12.9410   32.6210 N.am     67 VAL69       0.0000 BACKBONE|DICT|DIRECT
+   1060 CA         30.9480  -12.6640   31.9510 C.3      67 VAL69       0.0000 BACKBONE|DICT|DIRECT
+   1061 C          30.6910  -11.1630   31.9770 C.2      67 VAL69       0.0000 BACKBONE|DICT|DIRECT
+   1062 O          30.5840  -10.5650   33.0540 O.2      67 VAL69       0.0000 BACKBONE|DICT|DIRECT
+   1063 CB         29.7650  -13.4150   32.5920 C.3      67 VAL69       0.0000 DICT
+   1064 CG1        28.4750  -13.0780   31.8610 C.3      67 VAL69       0.0000 DICT
+   1065 CG2        30.0040  -14.9180   32.5680 C.3      67 VAL69       0.0000 DICT
+   1066 H          32.4260  -12.4780   33.4820 H        67 VAL69       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1067 HA         31.0260  -12.9540   30.9970 H        67 VAL69       0.0000 BACKBONE|DICT|DIRECT
+   1068 HB         29.6780  -13.1210   33.5440 H        67 VAL69       0.0000 DICT
+   1069 HG11       27.7140  -13.5700   32.2840 H        67 VAL69       0.0000 DICT
+   1070 HG12       28.3080  -12.0940   31.9160 H        67 VAL69       0.0000 DICT
+   1071 HG13       28.5550  -13.3490   30.9020 H        67 VAL69       0.0000 DICT
+   1072 HG21       29.2260  -15.3860   32.9880 H        67 VAL69       0.0000 DICT
+   1073 HG22       30.1060  -15.2240   31.6220 H        67 VAL69       0.0000 DICT
+   1074 HG23       30.8370  -15.1310   33.0790 H        67 VAL69       0.0000 DICT
+   1075 N          30.5770  -10.5630   30.8050 N.am     68 GLY70       0.0000 BACKBONE|DICT|DIRECT
+   1076 CA         30.2790   -9.1440   30.7000 C.3      68 GLY70       0.0000 BACKBONE|DICT|DIRECT
+   1077 C          29.1580   -8.8860   29.7180 C.2      68 GLY70       0.0000 BACKBONE|DICT|DIRECT
+   1078 O          29.1120   -9.4780   28.6430 O.2      68 GLY70       0.0000 BACKBONE|DICT|DIRECT
+   1079 H          30.6990  -11.0990   29.9690 H        68 GLY70       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1080 HA2        31.0990   -8.6610   30.3920 H        68 GLY70       0.0000 BACKBONE|DICT|DIRECT
+   1081 HA3        30.0090   -8.8010   31.6000 H        68 GLY70       0.0000 DICT
+   1082 N          28.2450   -8.0010   30.1070 N.am     69 VAL71       0.0000 BACKBONE|DICT|DIRECT
+   1083 CA         27.1500   -7.5590   29.2500 C.3      69 VAL71       0.0000 BACKBONE|DICT|DIRECT
+   1084 C          27.2260   -6.0430   29.1470 C.2      69 VAL71       0.0000 BACKBONE|DICT|DIRECT
+   1085 O          27.2590   -5.3470   30.1690 O.2      69 VAL71       0.0000 BACKBONE|DICT|DIRECT
+   1086 CB         25.7800   -8.0250   29.7830 C.3      69 VAL71       0.0000 DICT
+   1087 CG1        25.6300   -9.5260   29.5870 C.3      69 VAL71       0.0000 DICT
+   1088 CG2        25.6180   -7.6800   31.2560 C.3      69 VAL71       0.0000 DICT
+   1089 H          28.3120   -7.6210   31.0290 H        69 VAL71       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1090 HA         27.2840   -7.9460   28.3380 H        69 VAL71       0.0000 BACKBONE|DICT|DIRECT
+   1091 HB         25.0610   -7.5620   29.2650 H        69 VAL71       0.0000 DICT
+   1092 HG11       24.7400   -9.8200   29.9350 H        69 VAL71       0.0000 DICT
+   1093 HG12       25.6960   -9.7430   28.6130 H        69 VAL71       0.0000 DICT
+   1094 HG13       26.3560  -10.0010   30.0840 H        69 VAL71       0.0000 DICT
+   1095 HG21       24.7230   -7.9930   31.5750 H        69 VAL71       0.0000 DICT
+   1096 HG22       26.3370   -8.1310   31.7850 H        69 VAL71       0.0000 DICT
+   1097 HG23       25.6870   -6.6900   31.3760 H        69 VAL71       0.0000 DICT
+   1098 N          27.2860   -5.5330   27.9200 N.am     70 LYS72       0.0000 BACKBONE|DICT|DIRECT
+   1099 CA         27.5870   -4.1270   27.6900 C.3      70 LYS72       0.0000 BACKBONE|DICT|DIRECT
+   1100 C          26.4910   -3.4610   26.8730 C.2      70 LYS72       0.0000 BACKBONE|DICT|DIRECT
+   1101 O          26.0600   -3.9930   25.8440 O.2      70 LYS72       0.0000 BACKBONE|DICT|DIRECT
+   1102 CB         28.9330   -3.9540   26.9820 C.3      70 LYS72       0.0000 DICT
+   1103 CG         29.2200   -2.5060   26.6250 C.3      70 LYS72       0.0000 DICT
+   1104 CD         30.5750   -2.3200   25.9870 C.3      70 LYS72       0.0000 DICT
+   1105 CE         30.7420   -0.8870   25.5170 C.3      70 LYS72       0.0000 DICT
+   1106 NZ         29.7190   -0.5300   24.5000 N.4      70 LYS72       0.0000 DICT
+   1107 H          27.1200   -6.1300   27.1350 H        70 LYS72       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1108 HA         27.6390   -3.6690   28.5770 H        70 LYS72       0.0000 BACKBONE|DICT|DIRECT
+   1109 HB2        28.9250   -4.4960   26.1420 H        70 LYS72       0.0000 DICT
+   1110 HB3        29.6580   -4.2850   27.5860 H        70 LYS72       0.0000 DICT
+   1111 HG2        29.1820   -1.9570   27.4600 H        70 LYS72       0.0000 DICT
+   1112 HG3        28.5190   -2.1890   25.9860 H        70 LYS72       0.0000 DICT
+   1113 HD2        30.6580   -2.9360   25.2040 H        70 LYS72       0.0000 DICT
+   1114 HD3        31.2870   -2.5330   26.6560 H        70 LYS72       0.0000 DICT
+   1115 HE2        31.6520   -0.7800   25.1160 H        70 LYS72       0.0000 DICT
+   1116 HE3        30.6490   -0.2740   26.3020 H        70 LYS72       0.0000 DICT
+   1117 HZ1        29.8540    0.4170   24.2100 H        70 LYS72       0.0000 DICT|ESSENTIAL
+   1118 HZ2        29.8090   -1.1360   23.7100 H        70 LYS72       0.0000 DICT|ESSENTIAL
+   1119 HZ3        28.8060   -0.6310   24.8960 H        70 LYS72       0.0000 DICT|ESSENTIAL
+   1120 N          26.0550   -2.2950   27.3410 N.am     71 CYS73       0.0000 BACKBONE|DICT|DIRECT
+   1121 CA         25.1540   -1.4260   26.6030 C.3      71 CYS73       0.0000 BACKBONE|DICT|DIRECT
+   1122 C          25.9510   -0.5830   25.6070 C.2      71 CYS73       0.0000 BACKBONE|DICT|DIRECT
+   1123 O          27.1410   -0.3230   25.8000 O.2      71 CYS73       0.0000 BACKBONE|DICT|DIRECT
+   1124 CB         24.3920   -0.5380   27.5900 C.3      71 CYS73       0.0000 DICT
+   1125 SG         23.2530    0.6640   26.8890 S.3      71 CYS73       0.0000 DICT
+   1126 H          26.3630   -2.0020   28.2460 H        71 CYS73       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1127 HA         24.4990   -1.9890   26.1000 H        71 CYS73       0.0000 BACKBONE|DICT|DIRECT
+   1128 HB2        25.0680   -0.0350   28.1290 H        71 CYS73       0.0000 DICT
+   1129 HB3        23.8650   -1.1380   28.1920 H        71 CYS73       0.0000 DICT
+   1130 HG         23.7550    1.2910   26.2940 H        71 CYS73       0.0000 DICT|ESSENTIAL
+   1131 N          25.2900   -0.1580   24.5310 N.am     72 ALA74       0.0000 BACKBONE|DICT|DIRECT
+   1132 CA         25.9740    0.6420   23.5180 C.3      72 ALA74       0.0000 BACKBONE|DICT|DIRECT
+   1133 C          26.4450    1.9730   24.1030 C.2      72 ALA74       0.0000 BACKBONE|DICT|DIRECT
+   1134 O          25.7980    2.5570   24.9750 O.2      72 ALA74       0.0000 BACKBONE|DICT|DIRECT
+   1135 CB         25.0550    0.8910   22.3220 C.3      72 ALA74       0.0000 DICT
+   1136 H          24.3230   -0.3870   24.4170 H        72 ALA74       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1137 HA         26.7750    0.1340   23.2010 H        72 ALA74       0.0000 BACKBONE|DICT|DIRECT
+   1138 HB1        25.5380    1.4390   21.6390 H        72 ALA74       0.0000 DICT
+   1139 HB2        24.7880    0.0160   21.9190 H        72 ALA74       0.0000 DICT
+   1140 HB3        24.2380    1.3810   22.6260 H        72 ALA74       0.0000 DICT
+   1141 N          27.5850    2.4570   23.6090 N.am     73 THR75       0.0000 BACKBONE|DICT|DIRECT
+   1142 CA         28.2190    3.6560   24.1410 C.3      73 THR75       0.0000 BACKBONE|DICT|DIRECT
+   1143 C          28.5650    4.6290   23.0220 C.2      73 THR75       0.0000 BACKBONE|DICT|DIRECT
+   1144 O          28.7510    4.2390   21.8680 O.2      73 THR75       0.0000 BACKBONE|DICT|DIRECT
+   1145 CB         29.4950    3.3170   24.9270 C.3      73 THR75       0.0000 DICT
+   1146 OG1        30.2760    2.3690   24.1880 O.3      73 THR75       0.0000 DICT
+   1147 CG2        29.1530    2.7430   26.2960 C.3      73 THR75       0.0000 DICT
+   1148 H          28.0210    1.9800   22.8460 H        73 THR75       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1149 HA         27.5760    4.1040   24.7620 H        73 THR75       0.0000 BACKBONE|DICT|DIRECT
+   1150 HB         30.0310    4.1520   25.0510 H        73 THR75       0.0000 DICT
+   1151 HG1        30.5250    2.7610   23.3020 H        73 THR75       0.0000 DICT|ESSENTIAL
+   1152 HG21       29.9970    2.5300   26.7890 H        73 THR75       0.0000 DICT
+   1153 HG22       28.6240    3.4140   26.8160 H        73 THR75       0.0000 DICT
+   1154 HG23       28.6140    1.9080   26.1820 H        73 THR75       0.0000 DICT
+   1155 N          28.6550    5.9100   23.3820 N.am     74 ILE76       0.0000 BACKBONE|DICT|DIRECT
+   1156 CA         29.0630    6.9350   22.4290 C.3      74 ILE76       0.0000 BACKBONE|DICT|DIRECT
+   1157 C          30.5630    6.8410   22.1930 C.2      74 ILE76       0.0000 BACKBONE|DICT|DIRECT
+   1158 O          31.3600    6.8870   23.1400 O.2      74 ILE76       0.0000 BACKBONE|DICT|DIRECT
+   1159 CB         28.6800    8.3340   22.9380 C.3      74 ILE76       0.0000 DICT
+   1160 CG1        27.1630    8.5190   22.9400 C.3      74 ILE76       0.0000 DICT
+   1161 CG2        29.3540    9.4140   22.0920 C.3      74 ILE76       0.0000 DICT
+   1162 CD1        26.7100    9.7770   23.6470 C.3      74 ILE76       0.0000 DICT
+   1163 H          28.4390    6.1720   24.3220 H        74 ILE76       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1164 HA         28.5920    6.7710   21.5620 H        74 ILE76       0.0000 BACKBONE|DICT|DIRECT
+   1165 HB         29.0070    8.4250   23.8790 H        74 ILE76       0.0000 DICT
+   1166 HG12       26.7490    7.7320   23.3970 H        74 ILE76       0.0000 DICT
+   1167 HG13       26.8480    8.5580   21.9920 H        74 ILE76       0.0000 DICT
+   1168 HG21       29.0950   10.3170   22.4360 H        74 ILE76       0.0000 DICT
+   1169 HG22       30.3470    9.3090   22.1470 H        74 ILE76       0.0000 DICT
+   1170 HG23       29.0610    9.3230   21.1400 H        74 ILE76       0.0000 DICT
+   1171 HD11       25.7120    9.8380   23.6130 H        74 ILE76       0.0000 DICT
+   1172 HD12       27.0100    9.7500   24.6010 H        74 ILE76       0.0000 DICT
+   1173 HD13       27.1080   10.5750   23.1950 H        74 ILE76       0.0000 DICT
+   1174 N          30.9600    6.7100   20.9280 N.am     75 THR77       0.0000 BACKBONE|DICT|DIRECT
+   1175 CA         32.3610    6.8550   20.5630 C.3      75 THR77       0.0000 BACKBONE|DICT|DIRECT
+   1176 C          32.5940    8.2950   20.1360 C.2      75 THR77       0.0000 BACKBONE|DICT|DIRECT
+   1177 O          32.0340    8.7240   19.1160 O.2      75 THR77       0.0000 BACKBONE|DICT|DIRECT
+   1178 CB         32.7460    5.8950   19.4400 C.3      75 THR77       0.0000 DICT
+   1179 OG1        32.6790    4.5470   19.9210 O.3      75 THR77       0.0000 DICT
+   1180 CG2        34.1630    6.1830   18.9690 C.3      75 THR77       0.0000 DICT
+   1181 H          30.2850    6.5090   20.2180 H        75 THR77       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1182 HA         32.9260    6.6590   21.3640 H        75 THR77       0.0000 BACKBONE|DICT|DIRECT
+   1183 HB         32.1120    6.0070   18.6750 H        75 THR77       0.0000 DICT
+   1184 HG1        31.9800    4.4820   20.6330 H        75 THR77       0.0000 DICT|ESSENTIAL
+   1185 HG21       34.4050    5.5490   18.2340 H        75 THR77       0.0000 DICT
+   1186 HG22       34.2170    7.1220   18.6310 H        75 THR77       0.0000 DICT
+   1187 HG23       34.7980    6.0660   19.7320 H        75 THR77       0.0000 DICT
+   1188 N          33.3950    9.0700   20.8640 N.am     76 PRO78       0.0000 BACKBONE|DICT|DIRECT
+   1189 CA         33.4470   10.5180   20.6190 C.3      76 PRO78       0.0000 BACKBONE|DICT|DIRECT
+   1190 C          34.0690   10.8700   19.2750 C.2      76 PRO78       0.0000 BACKBONE|DICT|DIRECT
+   1191 O          34.9970   10.2090   18.8010 O.2      76 PRO78       0.0000 BACKBONE|DICT|DIRECT
+   1192 CB         34.3060   11.0430   21.7780 C.3      76 PRO78       0.0000 DICT
+   1193 CG         34.3030    9.9490   22.8040 C.3      76 PRO78       0.0000 DICT
+   1194 CD         34.1920    8.6740   22.0350 C.3      76 PRO78       0.0000 DICT
+   1195 HA         32.5270   10.9050   20.6780 H        76 PRO78       0.0000 BACKBONE|DICT|DIRECT
+   1196 HB2        35.2380   11.2280   21.4670 H        76 PRO78       0.0000 DICT
+   1197 HB3        33.9090   11.8790   22.1570 H        76 PRO78       0.0000 DICT
+   1198 HG2        35.1520    9.9650   23.3330 H        76 PRO78       0.0000 DICT
+   1199 HG3        33.5230   10.0530   23.4220 H        76 PRO78       0.0000 DICT
+   1200 HD2        35.0930    8.3390   21.7610 H        76 PRO78       0.0000 DICT
+   1201 HD3        33.7230    7.9710   22.5690 H        76 PRO78       0.0000 DICT
+   1202 N          33.5320   11.9180   18.6590 N.am     77 ASP79       0.0000 BACKBONE|DICT|DIRECT
+   1203 CA         34.1620   12.5730   17.5180 C.3      77 ASP79       0.0000 BACKBONE|DICT|DIRECT
+   1204 C          34.2460   14.0560   17.8760 C.2      77 ASP79       0.0000 BACKBONE|DICT|DIRECT
+   1205 O          34.0530   14.4520   19.0310 O.2      77 ASP79       0.0000 BACKBONE|DICT|DIRECT
+   1206 CB         33.4010   12.2970   16.2130 C.3      77 ASP79       0.0000 DICT
+   1207 CG         31.9370   12.7080   16.2780 C.2      77 ASP79       0.0000 DICT
+   1208 OD1        31.5480   13.4730   17.1860 O.co2    77 ASP79       0.0000 DICT
+   1209 OD2        31.1660   12.2680   15.4030 O.co2    77 ASP79       0.0000 DICT
+   1210 H          32.6580   12.2730   18.9920 H        77 ASP79       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1211 HA         35.0920   12.2170   17.4230 H        77 ASP79       0.0000 BACKBONE|DICT|DIRECT
+   1212 HB2        33.4480   11.3170   16.0180 H        77 ASP79       0.0000 DICT
+   1213 HB3        33.8420   12.8060   15.4740 H        77 ASP79       0.0000 DICT
+   1214 N          34.5110   14.9040   16.8800 N.am     78 GLU80       0.0000 BACKBONE|DICT|DIRECT
+   1215 CA         34.7080   16.3240   17.1600 C.3      78 GLU80       0.0000 BACKBONE|DICT|DIRECT
+   1216 C          33.4400   16.9650   17.7110 C.2      78 GLU80       0.0000 BACKBONE|DICT|DIRECT
+   1217 O          33.4900   17.7260   18.6870 O.2      78 GLU80       0.0000 BACKBONE|DICT|DIRECT
+   1218 CB         35.1730   17.0540   15.9010 C.3      78 GLU80       0.0000 DICT
+   1219 CG         35.6170   18.4850   16.1640 C.3      78 GLU80       0.0000 DICT
+   1220 CD         36.4100   18.6240   17.4580 C.2      78 GLU80       0.0000 DICT
+   1221 OE1        36.0270   19.4580   18.3080 O.co2    78 GLU80       0.0000 DICT
+   1222 OE2        37.4140   17.8970   17.6300 O.co2    78 GLU80       0.0000 DICT
+   1223 H          34.5750   14.5670   15.9410 H        78 GLU80       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1224 HA         35.4250   16.4080   17.8520 H        78 GLU80       0.0000 BACKBONE|DICT|DIRECT
+   1225 HB2        34.4170   17.0720   15.2470 H        78 GLU80       0.0000 DICT
+   1226 HB3        35.9420   16.5500   15.5080 H        78 GLU80       0.0000 DICT
+   1227 HG2        34.8060   19.0670   16.2220 H        78 GLU80       0.0000 DICT
+   1228 HG3        36.1910   18.7870   15.4030 H        78 GLU80       0.0000 DICT
+   1229 N          32.2910   16.6620   17.1010 N.am     79 LYS81       0.0000 BACKBONE|DICT|DIRECT
+   1230 CA         31.0340   17.2560   17.5450 C.3      79 LYS81       0.0000 BACKBONE|DICT|DIRECT
+   1231 C          30.6440   16.7360   18.9270 C.2      79 LYS81       0.0000 BACKBONE|DICT|DIRECT
+   1232 O          30.1050   17.4860   19.7510 O.2      79 LYS81       0.0000 BACKBONE|DICT|DIRECT
+   1233 CB         29.9380   16.9860   16.5060 C.3      79 LYS81       0.0000 DICT
+   1234 CG         28.5060   17.3150   16.9410 C.3      79 LYS81       0.0000 DICT
+   1235 CD         27.8230   16.1370   17.6180 C.3      79 LYS81       0.0000 DICT
+   1236 CE         26.4080   16.4590   18.0470 C.3      79 LYS81       0.0000 DICT
+   1237 NZ         26.0830   15.5400   19.1600 N.4      79 LYS81       0.0000 DICT
+   1238 H          32.2920   16.0220   16.3330 H        79 LYS81       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1239 HA         31.1640   18.2450   17.6100 H        79 LYS81       0.0000 BACKBONE|DICT|DIRECT
+   1240 HB2        29.9710   16.0140   16.2710 H        79 LYS81       0.0000 DICT
+   1241 HB3        30.1440   17.5320   15.6940 H        79 LYS81       0.0000 DICT
+   1242 HG2        27.9760   17.5730   16.1330 H        79 LYS81       0.0000 DICT
+   1243 HG3        28.5330   18.0830   17.5810 H        79 LYS81       0.0000 DICT
+   1244 HD2        28.3530   15.8800   18.4260 H        79 LYS81       0.0000 DICT
+   1245 HD3        27.7980   15.3690   16.9780 H        79 LYS81       0.0000 DICT
+   1246 HE2        25.7760   16.3160   17.2860 H        79 LYS81       0.0000 DICT
+   1247 HE3        26.3490   17.4080   18.3550 H        79 LYS81       0.0000 DICT
+   1248 HZ1        25.1520   15.7170   19.4780 H        79 LYS81       0.0000 DICT|ESSENTIAL
+   1249 HZ2        26.1520   14.5940   18.8420 H        79 LYS81       0.0000 DICT|ESSENTIAL
+   1250 HZ3        26.7250   15.6870   19.9120 H        79 LYS81       0.0000 DICT|ESSENTIAL
+   1251 N          30.9110   15.4520   19.2020 N.am     80 ARG82       0.0000 BACKBONE|DICT|DIRECT
+   1252 CA         30.6870   14.9150   20.5420 C.3      80 ARG82       0.0000 BACKBONE|DICT|DIRECT
+   1253 C          31.5490   15.6340   21.5710 C.2      80 ARG82       0.0000 BACKBONE|DICT|DIRECT
+   1254 O          31.0920   15.9150   22.6850 O.2      80 ARG82       0.0000 BACKBONE|DICT|DIRECT
+   1255 CB         30.9730   13.4130   20.5650 C.3      80 ARG82       0.0000 DICT
+   1256 CG         29.9820   12.5510   19.7890 C.3      80 ARG82       0.0000 DICT
+   1257 CD         28.5730   12.6510   20.3640 C.3      80 ARG82       0.0000 DICT
+   1258 NE         27.6830   11.6270   19.8180 N.pl3    80 ARG82       0.0000 DICT
+   1259 CZ         26.4120   11.4680   20.1780 C.cat    80 ARG82       0.0000 DICT
+   1260 NH1        25.8680   12.2680   21.0850 N.pl3    80 ARG82       0.0000 DICT
+   1261 NH2        25.6820   10.5060   19.6310 N.pl3    80 ARG82       0.0000 DICT
+   1262 H          31.2670   14.8550   18.4830 H        80 ARG82       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1263 HA         29.7260   15.0560   20.7820 H        80 ARG82       0.0000 BACKBONE|DICT|DIRECT
+   1264 HB2        30.9650   13.1110   21.5180 H        80 ARG82       0.0000 DICT
+   1265 HB3        31.8820   13.2650   20.1760 H        80 ARG82       0.0000 DICT
+   1266 HG2        30.2810   11.5980   19.8290 H        80 ARG82       0.0000 DICT
+   1267 HG3        29.9650   12.8550   18.8360 H        80 ARG82       0.0000 DICT
+   1268 HD2        28.1990   13.5530   20.1470 H        80 ARG82       0.0000 DICT
+   1269 HD3        28.6210   12.5410   21.3570 H        80 ARG82       0.0000 DICT
+   1270 HE         28.0540   11.0050   19.1280 H        80 ARG82       0.0000 DICT|ESSENTIAL
+   1271 HH11       24.9120   12.1440   21.3520 H        80 ARG82       0.0000 DICT|ESSENTIAL
+   1272 HH12       26.4130   12.9950   21.5020 H        80 ARG82       0.0000 DICT|ESSENTIAL
+   1273 HH21       24.7270   10.3870   19.9020 H        80 ARG82       0.0000 DICT|ESSENTIAL
+   1274 HH22       26.0870    9.8990   18.9470 H        80 ARG82       0.0000 DICT|ESSENTIAL
+   1275 N          32.8050   15.9270   21.2160 N.am     81 VAL83       0.0000 BACKBONE|DICT|DIRECT
+   1276 CA         33.6880   16.6610   22.1170 C.3      81 VAL83       0.0000 BACKBONE|DICT|DIRECT
+   1277 C          33.0910   18.0200   22.4530 C.2      81 VAL83       0.0000 BACKBONE|DICT|DIRECT
+   1278 O          33.2020   18.4970   23.5870 O.2      81 VAL83       0.0000 BACKBONE|DICT|DIRECT
+   1279 CB         35.0950   16.7900   21.5000 C.3      81 VAL83       0.0000 DICT
+   1280 CG1        35.9360   17.7730   22.2900 C.3      81 VAL83       0.0000 DICT
+   1281 CG2        35.7790   15.4400   21.4670 C.3      81 VAL83       0.0000 DICT
+   1282 H          33.1440   15.6390   20.3200 H        81 VAL83       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1283 HA         33.7680   16.1390   22.9660 H        81 VAL83       0.0000 BACKBONE|DICT|DIRECT
+   1284 HB         35.0040   17.1260   20.5630 H        81 VAL83       0.0000 DICT
+   1285 HG11       36.8430   17.8440   21.8760 H        81 VAL83       0.0000 DICT
+   1286 HG12       35.4950   18.6710   22.2820 H        81 VAL83       0.0000 DICT
+   1287 HG13       36.0240   17.4530   23.2330 H        81 VAL83       0.0000 DICT
+   1288 HG21       36.6890   15.5370   21.0650 H        81 VAL83       0.0000 DICT
+   1289 HG22       35.8620   15.0850   22.3980 H        81 VAL83       0.0000 DICT
+   1290 HG23       35.2370   14.8050   20.9160 H        81 VAL83       0.0000 DICT
+   1291 N          32.4260   18.6520   21.4850 N.am     82 GLU84       0.0000 BACKBONE|DICT|DIRECT
+   1292 CA         31.7880   19.9380   21.7500 C.3      82 GLU84       0.0000 BACKBONE|DICT|DIRECT
+   1293 C          30.4500   19.7720   22.4640 C.2      82 GLU84       0.0000 BACKBONE|DICT|DIRECT
+   1294 O          30.0990   20.5910   23.3220 O.2      82 GLU84       0.0000 BACKBONE|DICT|DIRECT
+   1295 CB         31.6020   20.7120   20.4430 C.3      82 GLU84       0.0000 DICT
+   1296 CG         30.4840   21.7370   20.4860 C.3      82 GLU84       0.0000 DICT
+   1297 CD         30.3420   22.5000   19.1880 C.2      82 GLU84       0.0000 DICT
+   1298 OE1        31.3280   22.5570   18.4230 O.co2    82 GLU84       0.0000 DICT
+   1299 OE2        29.2420   23.0350   18.9300 O.co2    82 GLU84       0.0000 DICT
+   1300 H          32.3640   18.2430   20.5740 H        82 GLU84       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1301 HA         32.3930   20.4690   22.3430 H        82 GLU84       0.0000 BACKBONE|DICT|DIRECT
+   1302 HB2        31.4000   20.0560   19.7150 H        82 GLU84       0.0000 DICT
+   1303 HB3        32.4570   21.1880   20.2350 H        82 GLU84       0.0000 DICT
+   1304 HG2        30.6750   22.3880   21.2210 H        82 GLU84       0.0000 DICT
+   1305 HG3        29.6230   21.2640   20.6750 H        82 GLU84       0.0000 DICT
+   1306 N          29.6930   18.7220   22.1280 N.am     83 GLU85       0.0000 BACKBONE|DICT|DIRECT
+   1307 CA         28.3790   18.5240   22.7380 C.3      83 GLU85       0.0000 BACKBONE|DICT|DIRECT
+   1308 C          28.4920   18.3540   24.2470 C.2      83 GLU85       0.0000 BACKBONE|DICT|DIRECT
+   1309 O          27.7250   18.9490   25.0110 O.2      83 GLU85       0.0000 BACKBONE|DICT|DIRECT
+   1310 CB         27.6860   17.3090   22.1230 C.3      83 GLU85       0.0000 DICT
+   1311 CG         26.4060   16.8930   22.8440 C.3      83 GLU85       0.0000 DICT
+   1312 CD         25.7440   15.6820   22.2100 C.2      83 GLU85       0.0000 DICT
+   1313 OE1        26.3510   15.0860   21.2960 O.co2    83 GLU85       0.0000 DICT
+   1314 OE2        24.6140   15.3350   22.6140 O.co2    83 GLU85       0.0000 DICT
+   1315 H          30.0290   18.0660   21.4530 H        83 GLU85       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1316 HA         27.8210   19.3330   22.5530 H        83 GLU85       0.0000 BACKBONE|DICT|DIRECT
+   1317 HB2        28.3240   16.5390   22.1450 H        83 GLU85       0.0000 DICT
+   1318 HB3        27.4560   17.5250   21.1740 H        83 GLU85       0.0000 DICT
+   1319 HG2        25.7630   17.6580   22.8210 H        83 GLU85       0.0000 DICT
+   1320 HG3        26.6300   16.6750   23.7940 H        83 GLU85       0.0000 DICT
+   1321 N          29.4400   17.5360   24.6950 N.am     84 PHE86       0.0000 BACKBONE|DICT|DIRECT
+   1322 CA         29.6210   17.2650   26.1120 C.3      84 PHE86       0.0000 BACKBONE|DICT|DIRECT
+   1323 C          30.7950   18.0210   26.7150 C.2      84 PHE86       0.0000 BACKBONE|DICT|DIRECT
+   1324 O          31.0730   17.8500   27.9070 O.2      84 PHE86       0.0000 BACKBONE|DICT|DIRECT
+   1325 CB         29.8030   15.7590   26.3430 C.3      84 PHE86       0.0000 DICT
+   1326 CG         28.6340   14.9300   25.8880 C.ar     84 PHE86       0.0000 DICT
+   1327 CD1        27.5460   14.7250   26.7230 C.ar     84 PHE86       0.0000 DICT
+   1328 CD2        28.6230   14.3580   24.6260 C.ar     84 PHE86       0.0000 DICT
+   1329 CE1        26.4680   13.9650   26.3080 C.ar     84 PHE86       0.0000 DICT
+   1330 CE2        27.5500   13.5950   24.2050 C.ar     84 PHE86       0.0000 DICT
+   1331 CZ         26.4700   13.3970   25.0470 C.ar     84 PHE86       0.0000 DICT
+   1332 H          30.0480   17.0930   24.0360 H        84 PHE86       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1333 HA         28.7910   17.5520   26.5900 H        84 PHE86       0.0000 BACKBONE|DICT|DIRECT
+   1334 HB2        29.9380   15.6040   27.3220 H        84 PHE86       0.0000 DICT
+   1335 HB3        30.6160   15.4590   25.8430 H        84 PHE86       0.0000 DICT
+   1336 HD1        27.5410   15.1320   27.6360 H        84 PHE86       0.0000 DICT
+   1337 HD2        29.4000   14.4990   24.0130 H        84 PHE86       0.0000 DICT
+   1338 HE1        25.6880   13.8260   26.9190 H        84 PHE86       0.0000 DICT
+   1339 HE2        27.5540   13.1860   23.2920 H        84 PHE86       0.0000 DICT
+   1340 HZ         25.6930   12.8450   24.7450 H        84 PHE86       0.0000 DICT
+   1341 N          31.4770   18.8560   25.9310 N.am     85 LYS87       0.0000 BACKBONE|DICT|DIRECT
+   1342 CA         32.6890   19.5540   26.3620 C.3      85 LYS87       0.0000 BACKBONE|DICT|DIRECT
+   1343 C          33.6870   18.5720   26.9780 C.2      85 LYS87       0.0000 BACKBONE|DICT|DIRECT
+   1344 O          34.1050   18.6930   28.1300 O.2      85 LYS87       0.0000 BACKBONE|DICT|DIRECT
+   1345 CB         32.3520   20.6990   27.3200 C.3      85 LYS87       0.0000 DICT
+   1346 CG         31.8520   21.9550   26.6110 C.3      85 LYS87       0.0000 DICT
+   1347 CD         32.9530   22.5910   25.7610 C.3      85 LYS87       0.0000 DICT
+   1348 CE         32.6250   22.5450   24.2740 C.3      85 LYS87       0.0000 DICT
+   1349 NZ         33.8580   22.6220   23.4360 N.4      85 LYS87       0.0000 DICT
+   1350 H          31.1440   19.0130   25.0010 H        85 LYS87       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1351 HA         33.1160   19.9520   25.5500 H        85 LYS87       0.0000 BACKBONE|DICT|DIRECT
+   1352 HB2        33.1760   20.9330   27.8360 H        85 LYS87       0.0000 DICT
+   1353 HB3        31.6410   20.3860   27.9500 H        85 LYS87       0.0000 DICT
+   1354 HG2        31.5470   22.6160   27.2970 H        85 LYS87       0.0000 DICT
+   1355 HG3        31.0840   21.7110   26.0190 H        85 LYS87       0.0000 DICT
+   1356 HD2        33.8080   22.0970   25.9180 H        85 LYS87       0.0000 DICT
+   1357 HD3        33.0640   23.5460   26.0380 H        85 LYS87       0.0000 DICT
+   1358 HE2        32.0310   23.3170   24.0490 H        85 LYS87       0.0000 DICT
+   1359 HE3        32.1490   21.6890   24.0730 H        85 LYS87       0.0000 DICT
+   1360 HZ1        33.6060   22.5890   22.4690 H        85 LYS87       0.0000 DICT|ESSENTIAL
+   1361 HZ2        34.3380   23.4780   23.6270 H        85 LYS87       0.0000 DICT|ESSENTIAL
+   1362 HZ3        34.4560   21.8500   23.6510 H        85 LYS87       0.0000 DICT|ESSENTIAL
+   1363 N          34.0560   17.5780   26.1740 N.am     86 LEU88       0.0000 BACKBONE|DICT|DIRECT
+   1364 CA         34.9380   16.5170   26.6320 C.3      86 LEU88       0.0000 BACKBONE|DICT|DIRECT
+   1365 C          36.3690   17.0210   26.7780 C.2      86 LEU88       0.0000 BACKBONE|DICT|DIRECT
+   1366 O          36.8280   17.8830   26.0240 O.2      86 LEU88       0.0000 BACKBONE|DICT|DIRECT
+   1367 CB         34.9040   15.3380   25.6580 C.3      86 LEU88       0.0000 DICT
+   1368 CG         33.5580   14.6420   25.4520 C.3      86 LEU88       0.0000 DICT
+   1369 CD1        33.6680   13.6080   24.3470 C.3      86 LEU88       0.0000 DICT
+   1370 CD2        33.0830   14.0010   26.7450 C.3      86 LEU88       0.0000 DICT
+   1371 H          33.7190   17.5600   25.2330 H        86 LEU88       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1372 HA         34.6190   16.2010   27.5260 H        86 LEU88       0.0000 BACKBONE|DICT|DIRECT
+   1373 HB2        35.5500   14.6520   25.9930 H        86 LEU88       0.0000 DICT
+   1374 HB3        35.2080   15.6750   24.7670 H        86 LEU88       0.0000 DICT
+   1375 HG         32.8860   15.3290   25.1750 H        86 LEU88       0.0000 DICT
+   1376 HD11       32.7830   13.1600   24.2210 H        86 LEU88       0.0000 DICT
+   1377 HD12       33.9380   14.0570   23.4960 H        86 LEU88       0.0000 DICT
+   1378 HD13       34.3550   12.9260   24.5960 H        86 LEU88       0.0000 DICT
+   1379 HD21       32.2030   13.5520   26.5910 H        86 LEU88       0.0000 DICT
+   1380 HD22       33.7540   13.3240   27.0480 H        86 LEU88       0.0000 DICT
+   1381 HD23       32.9790   14.7050   27.4480 H        86 LEU88       0.0000 DICT
+   1382 N          37.0760   16.4640   27.7660 N.am     87 LYS89       0.0000 BACKBONE|DICT|DIRECT
+   1383 CA         38.4870   16.7910   27.9530 C.3      87 LYS89       0.0000 BACKBONE|DICT|DIRECT
+   1384 C          39.3060   16.4130   26.7260 C.2      87 LYS89       0.0000 BACKBONE|DICT|DIRECT
+   1385 O          40.2330   17.1360   26.3420 O.2      87 LYS89       0.0000 BACKBONE|DICT|DIRECT
+   1386 CB         39.0320   16.0780   29.1920 C.3      87 LYS89       0.0000 DICT
+   1387 CG         38.3150   16.4200   30.4810 C.3      87 LYS89       0.0000 DICT
+   1388 CD         38.7310   15.4790   31.5980 C.3      87 LYS89       0.0000 DICT
+   1389 CE         37.9880   15.7870   32.8820 C.3      87 LYS89       0.0000 DICT
+   1390 NZ         38.3330   14.8230   33.9600 N.4      87 LYS89       0.0000 DICT
+   1391 H          36.6330   15.8150   28.3850 H        87 LYS89       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1392 HA         38.5670   17.7780   28.0950 H        87 LYS89       0.0000 BACKBONE|DICT|DIRECT
+   1393 HB2        39.9950   16.3250   29.2960 H        87 LYS89       0.0000 DICT
+   1394 HB3        38.9550   15.0920   29.0440 H        87 LYS89       0.0000 DICT
+   1395 HG2        37.3280   16.3420   30.3380 H        87 LYS89       0.0000 DICT
+   1396 HG3        38.5410   17.3580   30.7420 H        87 LYS89       0.0000 DICT
+   1397 HD2        39.7130   15.5780   31.7580 H        87 LYS89       0.0000 DICT
+   1398 HD3        38.5310   14.5390   31.3230 H        87 LYS89       0.0000 DICT
+   1399 HE2        37.0050   15.7400   32.7070 H        87 LYS89       0.0000 DICT
+   1400 HE3        38.2290   16.7100   33.1830 H        87 LYS89       0.0000 DICT
+   1401 HZ1        37.8260   15.0560   34.7900 H        87 LYS89       0.0000 DICT|ESSENTIAL
+   1402 HZ2        38.0900   13.8970   33.6700 H        87 LYS89       0.0000 DICT|ESSENTIAL
+   1403 HZ3        39.3150   14.8680   34.1450 H        87 LYS89       0.0000 DICT|ESSENTIAL
+   1404 N          38.9870   15.2810   26.1050 N.am     88 GLN90       0.0000 BACKBONE|DICT|DIRECT
+   1405 CA         39.6550   14.8660   24.8810 C.3      88 GLN90       0.0000 BACKBONE|DICT|DIRECT
+   1406 C          38.7600   13.8760   24.1540 C.2      88 GLN90       0.0000 BACKBONE|DICT|DIRECT
+   1407 O          37.7060   13.4750   24.6550 O.2      88 GLN90       0.0000 BACKBONE|DICT|DIRECT
+   1408 CB         41.0330   14.2640   25.1670 C.3      88 GLN90       0.0000 DICT
+   1409 CG         41.0380   13.1770   26.2190 C.3      88 GLN90       0.0000 DICT
+   1410 CD         42.4460   12.7460   26.5900 C.2      88 GLN90       0.0000 DICT
+   1411 OE1        42.8960   12.9540   27.7200 O.2      88 GLN90       0.0000 DICT
+   1412 NE2        43.1540   12.1500   25.6330 N.am     88 GLN90       0.0000 DICT
+   1413 H          38.2690   14.7000   26.4890 H        88 GLN90       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1414 HA         39.7760   15.6700   24.2990 H        88 GLN90       0.0000 BACKBONE|DICT|DIRECT
+   1415 HB2        41.6370   14.9990   25.4750 H        88 GLN90       0.0000 DICT
+   1416 HB3        41.3870   13.8760   24.3160 H        88 GLN90       0.0000 DICT
+   1417 HG2        40.5410   12.3840   25.8660 H        88 GLN90       0.0000 DICT
+   1418 HG3        40.5790   13.5200   27.0390 H        88 GLN90       0.0000 DICT
+   1419 HE21       42.7500   12.0020   24.7310 H        88 GLN90       0.0000 DICT|ESSENTIAL
+   1420 HE22       44.0910   11.8510   25.8170 H        88 GLN90       0.0000 DICT|ESSENTIAL
+   1421 N          39.1920   13.4920   22.9550 N.am     89 MET91       0.0000 BACKBONE|DICT|DIRECT
+   1422 CA         38.4400   12.5570   22.1200 C.3      89 MET91       0.0000 BACKBONE|DICT|DIRECT
+   1423 C          38.7850   11.1410   22.5640 C.2      89 MET91       0.0000 BACKBONE|DICT|DIRECT
+   1424 O          39.7010   10.5050   22.0400 O.2      89 MET91       0.0000 BACKBONE|DICT|DIRECT
+   1425 CB         38.7520   12.7820   20.6460 C.3      89 MET91       0.0000 DICT
+   1426 CG         37.5310   12.7030   19.7500 C.3      89 MET91       0.0000 DICT
+   1427 SD         37.9330   12.8360   18.0000 S.3      89 MET91       0.0000 DICT
+   1428 CE         38.5580   14.5100   17.9120 C.3      89 MET91       0.0000 DICT
+   1429 H          40.0590   13.8550   22.6140 H        89 MET91       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1430 HA         37.4630   12.7100   22.2680 H        89 MET91       0.0000 BACKBONE|DICT|DIRECT
+   1431 HB2        39.4060   12.0860   20.3510 H        89 MET91       0.0000 DICT
+   1432 HB3        39.1610   13.6890   20.5440 H        89 MET91       0.0000 DICT
+   1433 HG2        36.9100   13.4480   19.9920 H        89 MET91       0.0000 DICT
+   1434 HG3        37.0770   11.8260   19.9070 H        89 MET91       0.0000 DICT
+   1435 HE1        38.8240   14.7180   16.9710 H        89 MET91       0.0000 DICT
+   1436 HE2        37.8460   15.1480   18.2060 H        89 MET91       0.0000 DICT
+   1437 HE3        39.3540   14.6010   18.5110 H        89 MET91       0.0000 DICT
+   1438 N          38.0350   10.6440   23.5460 N.am     90 TRP92       0.0000 BACKBONE|DICT|DIRECT
+   1439 CA         38.3210    9.3370   24.1230 C.3      90 TRP92       0.0000 BACKBONE|DICT|DIRECT
+   1440 C          38.1520    8.2370   23.0830 C.2      90 TRP92       0.0000 BACKBONE|DICT|DIRECT
+   1441 O          37.2550    8.2880   22.2390 O.2      90 TRP92       0.0000 BACKBONE|DICT|DIRECT
+   1442 CB         37.4020    9.0700   25.3160 C.3      90 TRP92       0.0000 DICT
+   1443 CG         37.4470   10.1430   26.3540 C.2      90 TRP92       0.0000 DICT
+   1444 CD1        36.4790   11.0700   26.6210 C.2      90 TRP92       0.0000 DICT
+   1445 CD2        38.5230   10.4130   27.2610 C.ar     90 TRP92       0.0000 DICT
+   1446 NE1        36.8830   11.8950   27.6430 N.pl3    90 TRP92       0.0000 DICT
+   1447 CE2        38.1340   11.5120   28.0530 C.ar     90 TRP92       0.0000 DICT
+   1448 CE3        39.7740    9.8270   27.4840 C.ar     90 TRP92       0.0000 DICT
+   1449 CZ2        38.9530   12.0390   29.0500 C.ar     90 TRP92       0.0000 DICT
+   1450 CZ3        40.5860   10.3520   28.4750 C.ar     90 TRP92       0.0000 DICT
+   1451 CH2        40.1730   11.4470   29.2440 C.ar     90 TRP92       0.0000 DICT
+   1452 H          37.2630   11.1770   23.8930 H        90 TRP92       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1453 HA         39.2680    9.3300   24.4430 H        90 TRP92       0.0000 BACKBONE|DICT|DIRECT
+   1454 HB2        37.6770    8.2070   25.7400 H        90 TRP92       0.0000 DICT
+   1455 HB3        36.4630    8.9930   24.9810 H        90 TRP92       0.0000 DICT
+   1456 HD1        35.6040   11.1380   26.1420 H        90 TRP92       0.0000 DICT
+   1457 HE1        36.3520   12.6510   28.0250 H        90 TRP92       0.0000 DICT|ESSENTIAL
+   1458 HE3        40.0750    9.0450   26.9390 H        90 TRP92       0.0000 DICT
+   1459 HZ2        38.6610   12.8200   29.6030 H        90 TRP92       0.0000 DICT
+   1460 HZ3        41.4820    9.9420   28.6440 H        90 TRP92       0.0000 DICT
+   1461 HH2        40.7830   11.8050   29.9510 H        90 TRP92       0.0000 DICT
+   1462 N          39.0300    7.2420   23.1460 N.am     91 LYS93       0.0000 BACKBONE|DICT|DIRECT
+   1463 CA         38.9260    6.0920   22.2620 C.3      91 LYS93       0.0000 BACKBONE|DICT|DIRECT
+   1464 C          37.6470    5.3140   22.5570 C.2      91 LYS93       0.0000 BACKBONE|DICT|DIRECT
+   1465 O          37.1450    5.3090   23.6840 O.2      91 LYS93       0.0000 BACKBONE|DICT|DIRECT
+   1466 CB         40.1490    5.1880   22.4240 C.3      91 LYS93       0.0000 DICT
+   1467 CG         40.0990    3.8890   21.6260 C.3      91 LYS93       0.0000 DICT
+   1468 CD         40.7200    2.7340   22.3970 C.3      91 LYS93       0.0000 DICT
+   1469 CE         42.0140    2.2710   21.7520 C.3      91 LYS93       0.0000 DICT
+   1470 NZ         42.6250    1.1490   22.5150 N.4      91 LYS93       0.0000 DICT
+   1471 H          39.7750    7.2850   23.8120 H        91 LYS93       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1472 HA         38.8920    6.4170   21.3170 H        91 LYS93       0.0000 BACKBONE|DICT|DIRECT
+   1473 HB2        40.2360    4.9540   23.3920 H        91 LYS93       0.0000 DICT
+   1474 HB3        40.9560    5.7010   22.1310 H        91 LYS93       0.0000 DICT
+   1475 HG2        40.6000    4.0150   20.7700 H        91 LYS93       0.0000 DICT
+   1476 HG3        39.1450    3.6690   21.4240 H        91 LYS93       0.0000 DICT
+   1477 HD2        40.0740    1.9710   22.4160 H        91 LYS93       0.0000 DICT
+   1478 HD3        40.9110    3.0320   23.3320 H        91 LYS93       0.0000 DICT
+   1479 HE2        42.6570    3.0360   21.7260 H        91 LYS93       0.0000 DICT
+   1480 HE3        41.8220    1.9650   20.8200 H        91 LYS93       0.0000 DICT
+   1481 HZ1        43.4740    0.8650   22.0680 H        91 LYS93       0.0000 DICT|ESSENTIAL
+   1482 HZ2        42.8240    1.4490   23.4480 H        91 LYS93       0.0000 DICT|ESSENTIAL
+   1483 HZ3        41.9880    0.3780   22.5410 H        91 LYS93       0.0000 DICT|ESSENTIAL
+   1484 N          37.1140    4.6710   21.5230 N.am     92 SER94       0.0000 BACKBONE|DICT|DIRECT
+   1485 CA         35.9110    3.8670   21.6600 C.3      92 SER94       0.0000 BACKBONE|DICT|DIRECT
+   1486 C          36.0660    2.8710   22.8080 C.2      92 SER94       0.0000 BACKBONE|DICT|DIRECT
+   1487 O          37.0750    2.1530   22.8660 O.2      92 SER94       0.0000 BACKBONE|DICT|DIRECT
+   1488 CB         35.6250    3.1200   20.3580 C.3      92 SER94       0.0000 DICT
+   1489 OG         34.7660    2.0160   20.5880 O.3      92 SER94       0.0000 DICT
+   1490 H          37.5520    4.7420   20.6270 H        92 SER94       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1491 HA         35.1400    4.4720   21.8600 H        92 SER94       0.0000 BACKBONE|DICT|DIRECT
+   1492 HB2        36.4870    2.7900   19.9740 H        92 SER94       0.0000 DICT
+   1493 HB3        35.1890    3.7450   19.7110 H        92 SER94       0.0000 DICT
+   1494 HG         34.5930    1.5430   19.7240 H        92 SER94       0.0000 DICT|ESSENTIAL
+   1495 N          35.1070    2.8040   23.7360 N.am     93 PRO95       0.0000 BACKBONE|DICT|DIRECT
+   1496 CA         35.2110    1.8090   24.8140 C.3      93 PRO95       0.0000 BACKBONE|DICT|DIRECT
+   1497 C          35.2680    0.3830   24.3030 C.2      93 PRO95       0.0000 BACKBONE|DICT|DIRECT
+   1498 O          35.8920   -0.4710   24.9460 O.2      93 PRO95       0.0000 BACKBONE|DICT|DIRECT
+   1499 CB         33.9450    2.0600   25.6480 C.3      93 PRO95       0.0000 DICT
+   1500 CG         33.5250    3.4530   25.3090 C.3      93 PRO95       0.0000 DICT
+   1501 CD         33.9080    3.6490   23.8730 C.3      93 PRO95       0.0000 DICT
+   1502 HA         36.0210    1.9990   25.3690 H        93 PRO95       0.0000 BACKBONE|DICT|DIRECT
+   1503 HB2        33.2280    1.4080   25.4030 H        93 PRO95       0.0000 DICT
+   1504 HB3        34.1470    1.9820   26.6240 H        93 PRO95       0.0000 DICT
+   1505 HG2        32.5370    3.5580   25.4250 H        93 PRO95       0.0000 DICT
+   1506 HG3        34.0010    4.1130   25.8910 H        93 PRO95       0.0000 DICT
+   1507 HD2        33.1790    3.3420   23.2610 H        93 PRO95       0.0000 DICT
+   1508 HD3        34.1200    4.6080   23.6840 H        93 PRO95       0.0000 DICT
+   1509 N          34.6420    0.0980   23.1580 N.am     94 ASN96       0.0000 BACKBONE|DICT|DIRECT
+   1510 CA         34.6840   -1.2550   22.6100 C.3      94 ASN96       0.0000 BACKBONE|DICT|DIRECT
+   1511 C          36.0910   -1.6310   22.1620 C.2      94 ASN96       0.0000 BACKBONE|DICT|DIRECT
+   1512 O          36.5170   -2.7780   22.3400 O.2      94 ASN96       0.0000 BACKBONE|DICT|DIRECT
+   1513 CB         33.6980   -1.3820   21.4510 C.3      94 ASN96       0.0000 DICT
+   1514 CG         32.2590   -1.2760   21.9020 C.2      94 ASN96       0.0000 DICT
+   1515 OD1        31.7670   -2.1240   22.6450 O.2      94 ASN96       0.0000 DICT
+   1516 ND2        31.5750   -0.2290   21.4590 N.am     94 ASN96       0.0000 DICT
+   1517 H          34.1420    0.8150   22.6730 H        94 ASN96       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1518 HA         34.4050   -1.8920   23.3290 H        94 ASN96       0.0000 BACKBONE|DICT|DIRECT
+   1519 HB2        33.8320   -2.2700   21.0120 H        94 ASN96       0.0000 DICT
+   1520 HB3        33.8820   -0.6530   20.7920 H        94 ASN96       0.0000 DICT
+   1521 HD21       32.0150    0.4370   20.8560 H        94 ASN96       0.0000 DICT|ESSENTIAL
+   1522 HD22       30.6200   -0.1060   21.7280 H        94 ASN96       0.0000 DICT|ESSENTIAL
+   1523 N          36.8260   -0.6840   21.5760 N.am     95 GLY97       0.0000 BACKBONE|DICT|DIRECT
+   1524 CA         38.2060   -0.9580   21.2130 C.3      95 GLY97       0.0000 BACKBONE|DICT|DIRECT
+   1525 C          39.0920   -1.1650   22.4270 C.2      95 GLY97       0.0000 BACKBONE|DICT|DIRECT
+   1526 O          39.9650   -2.0390   22.4310 O.2      95 GLY97       0.0000 BACKBONE|DICT|DIRECT
+   1527 H          36.4270    0.2130   21.3870 H        95 GLY97       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1528 HA2        38.5590   -0.1850   20.6860 H        95 GLY97       0.0000 BACKBONE|DICT|DIRECT
+   1529 HA3        38.2320   -1.7850   20.6510 H        95 GLY97       0.0000 DICT
+   1530 N          38.8810   -0.3650   23.4750 N.am     96 THR98       0.0000 BACKBONE|DICT|DIRECT
+   1531 CA         39.6080   -0.5700   24.7220 C.3      96 THR98       0.0000 BACKBONE|DICT|DIRECT
+   1532 C          39.3470   -1.9620   25.2800 C.2      96 THR98       0.0000 BACKBONE|DICT|DIRECT
+   1533 O          40.2840   -2.7080   25.5820 O.2      96 THR98       0.0000 BACKBONE|DICT|DIRECT
+   1534 CB         39.2090    0.4940   25.7420 C.3      96 THR98       0.0000 DICT
+   1535 OG1        39.5960    1.7860   25.2620 O.3      96 THR98       0.0000 DICT
+   1536 CG2        39.8790    0.2230   27.0820 C.3      96 THR98       0.0000 DICT
+   1537 H          38.2190    0.3810   23.4040 H        96 THR98       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1538 HA         40.5870   -0.4810   24.5370 H        96 THR98       0.0000 BACKBONE|DICT|DIRECT
+   1539 HB         38.2170    0.4740   25.8630 H        96 THR98       0.0000 DICT
+   1540 HG1        39.1370    1.9700   24.3930 H        96 THR98       0.0000 DICT|ESSENTIAL
+   1541 HG21       39.6080    0.9270   27.7380 H        96 THR98       0.0000 DICT
+   1542 HG22       39.5960   -0.6750   27.4200 H        96 THR98       0.0000 DICT
+   1543 HG23       40.8720    0.2380   26.9670 H        96 THR98       0.0000 DICT
+   1544 N          38.0720   -2.3360   25.4030 N.am     97 ILE99       0.0000 BACKBONE|DICT|DIRECT
+   1545 CA         37.7230   -3.6460   25.9470 C.3      97 ILE99       0.0000 BACKBONE|DICT|DIRECT
+   1546 C          38.2930   -4.7600   25.0740 C.2      97 ILE99       0.0000 BACKBONE|DICT|DIRECT
+   1547 O          38.8790   -5.7280   25.5770 O.2      97 ILE99       0.0000 BACKBONE|DICT|DIRECT
+   1548 CB         36.1970   -3.7660   26.1010 C.3      97 ILE99       0.0000 DICT
+   1549 CG1        35.6950   -2.7760   27.1580 C.3      97 ILE99       0.0000 DICT
+   1550 CG2        35.8050   -5.1870   26.4620 C.3      97 ILE99       0.0000 DICT
+   1551 CD1        34.1880   -2.6710   27.2410 C.3      97 ILE99       0.0000 DICT
+   1552 H          37.3450   -1.7110   25.1190 H        97 ILE99       0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1553 HA         38.1330   -3.7240   26.8560 H        97 ILE99       0.0000 BACKBONE|DICT|DIRECT
+   1554 HB         35.7730   -3.5350   25.2260 H        97 ILE99       0.0000 DICT
+   1555 HG12       36.0610   -1.8710   26.9400 H        97 ILE99       0.0000 DICT
+   1556 HG13       36.0390   -3.0680   28.0500 H        97 ILE99       0.0000 DICT
+   1557 HG21       34.8110   -5.2450   26.5580 H        97 ILE99       0.0000 DICT
+   1558 HG22       36.1070   -5.8100   25.7400 H        97 ILE99       0.0000 DICT
+   1559 HG23       36.2380   -5.4430   27.3260 H        97 ILE99       0.0000 DICT
+   1560 HD11       33.9380   -2.0100   27.9490 H        97 ILE99       0.0000 DICT
+   1561 HD12       33.8260   -2.3680   26.3590 H        97 ILE99       0.0000 DICT
+   1562 HD13       33.8040   -3.5650   27.4700 H        97 ILE99       0.0000 DICT
+   1563 N          38.1410   -4.6380   23.7520 N.am     98 ARG100      0.0000 BACKBONE|DICT|DIRECT
+   1564 CA         38.6540   -5.6730   22.8580 C.3      98 ARG100      0.0000 BACKBONE|DICT|DIRECT
+   1565 C          40.1660   -5.8160   22.9660 C.2      98 ARG100      0.0000 BACKBONE|DICT|DIRECT
+   1566 O          40.6940   -6.9200   22.8020 O.2      98 ARG100      0.0000 BACKBONE|DICT|DIRECT
+   1567 CB         38.2530   -5.3810   21.4110 C.3      98 ARG100      0.0000 DICT
+   1568 CG         36.9890   -6.1040   20.9740 C.3      98 ARG100      0.0000 DICT
+   1569 CD         36.7620   -6.0130   19.4700 C.3      98 ARG100      0.0000 DICT
+   1570 NE         36.1320   -4.7560   19.0770 N.pl3    98 ARG100      0.0000 DICT
+   1571 CZ         36.7820   -3.7330   18.5340 C.cat    98 ARG100      0.0000 DICT
+   1572 NH1        38.0870   -3.8160   18.3120 N.pl3    98 ARG100      0.0000 DICT
+   1573 NH2        36.1260   -2.6270   18.2070 N.pl3    98 ARG100      0.0000 DICT
+   1574 H          37.6760   -3.8370   23.3740 H        98 ARG100      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1575 HA         38.2410   -6.5440   23.1240 H        98 ARG100      0.0000 BACKBONE|DICT|DIRECT
+   1576 HB2        39.0020   -5.6630   20.8120 H        98 ARG100      0.0000 DICT
+   1577 HB3        38.1030   -4.3970   21.3170 H        98 ARG100      0.0000 DICT
+   1578 HG2        36.2060   -5.6950   21.4430 H        98 ARG100      0.0000 DICT
+   1579 HG3        37.0650   -7.0680   21.2300 H        98 ARG100      0.0000 DICT
+   1580 HD2        36.1720   -6.7700   19.1880 H        98 ARG100      0.0000 DICT
+   1581 HD3        37.6450   -6.0880   19.0070 H        98 ARG100      0.0000 DICT
+   1582 HE         35.1480   -4.6590   19.2260 H        98 ARG100      0.0000 DICT|ESSENTIAL
+   1583 HH11       38.5750   -3.0450   17.9030 H        98 ARG100      0.0000 DICT|ESSENTIAL
+   1584 HH12       38.5830   -4.6500   18.5540 H        98 ARG100      0.0000 DICT|ESSENTIAL
+   1585 HH21       36.6160   -1.8570   17.7980 H        98 ARG100      0.0000 DICT|ESSENTIAL
+   1586 HH22       35.1410   -2.5630   18.3690 H        98 ARG100      0.0000 DICT|ESSENTIAL
+   1587 N          40.8770   -4.7240   23.2550 N.am     99 ASN101      0.0000 BACKBONE|DICT|DIRECT
+   1588 CA         42.3310   -4.8010   23.3460 C.3      99 ASN101      0.0000 BACKBONE|DICT|DIRECT
+   1589 C          42.7760   -5.4780   24.6370 C.2      99 ASN101      0.0000 BACKBONE|DICT|DIRECT
+   1590 O          43.7820   -6.1950   24.6500 O.2      99 ASN101      0.0000 BACKBONE|DICT|DIRECT
+   1591 CB         42.9410   -3.4060   23.2310 C.3      99 ASN101      0.0000 DICT
+   1592 CG         43.4820   -3.1230   21.8440 C.2      99 ASN101      0.0000 DICT
+   1593 OD1        44.6960   -3.1150   21.6320 O.2      99 ASN101      0.0000 DICT
+   1594 ND2        42.5850   -2.9020   20.8880 N.am     99 ASN101      0.0000 DICT
+   1595 H          40.4120   -3.8520   23.4090 H        99 ASN101      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1596 HA         42.6620   -5.3490   22.5780 H        99 ASN101      0.0000 BACKBONE|DICT|DIRECT
+   1597 HB2        43.6890   -3.3280   23.8900 H        99 ASN101      0.0000 DICT
+   1598 HB3        42.2370   -2.7290   23.4450 H        99 ASN101      0.0000 DICT
+   1599 HD21       41.6090   -2.9180   21.1050 H        99 ASN101      0.0000 DICT|ESSENTIAL
+   1600 HD22       42.8860   -2.7200   19.9520 H        99 ASN101      0.0000 DICT|ESSENTIAL
+   1601 N          42.0480   -5.2620   25.7340 N.am    100 ILE102      0.0000 BACKBONE|DICT|DIRECT
+   1602 CA         42.4190   -5.9200   26.9830 C.3     100 ILE102      0.0000 BACKBONE|DICT|DIRECT
+   1603 C          42.0450   -7.4000   26.9400 C.2     100 ILE102      0.0000 BACKBONE|DICT|DIRECT
+   1604 O          42.7600   -8.2440   27.4960 O.2     100 ILE102      0.0000 BACKBONE|DICT|DIRECT
+   1605 CB         41.7830   -5.1970   28.1930 C.3     100 ILE102      0.0000 DICT
+   1606 CG1        42.5690   -3.9410   28.5870 C.3     100 ILE102      0.0000 DICT
+   1607 CG2        41.7080   -6.1130   29.4040 C.3     100 ILE102      0.0000 DICT
+   1608 CD1        42.5180   -2.7990   27.6120 C.3     100 ILE102      0.0000 DICT
+   1609 H          41.2550   -4.6540   25.7010 H       100 ILE102      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1610 HA         43.4130   -5.8580   27.0780 H       100 ILE102      0.0000 BACKBONE|DICT|DIRECT
+   1611 HB         40.8540   -4.9240   27.9450 H       100 ILE102      0.0000 DICT
+   1612 HG12       43.5270   -4.2030   28.7010 H       100 ILE102      0.0000 DICT
+   1613 HG13       42.2060   -3.6140   29.4600 H       100 ILE102      0.0000 DICT
+   1614 HG21       41.2940   -5.6200   30.1690 H       100 ILE102      0.0000 DICT
+   1615 HG22       41.1510   -6.9140   29.1820 H       100 ILE102      0.0000 DICT
+   1616 HG23       42.6300   -6.4070   29.6570 H       100 ILE102      0.0000 DICT
+   1617 HD11       43.0600   -2.0360   27.9640 H       100 ILE102      0.0000 DICT
+   1618 HD12       42.8900   -3.0950   26.7320 H       100 ILE102      0.0000 DICT
+   1619 HD13       41.5700   -2.5060   27.4910 H       100 ILE102      0.0000 DICT
+   1620 N          40.9530   -7.7480   26.2560 N.am    101 LEU103      0.0000 BACKBONE|DICT|DIRECT
+   1621 CA         40.4400   -9.1150   26.2640 C.3     101 LEU103      0.0000 BACKBONE|DICT|DIRECT
+   1622 C          40.9430   -9.9570   25.0950 C.2     101 LEU103      0.0000 BACKBONE|DICT|DIRECT
+   1623 O          41.2850  -11.1290   25.2840 O.2     101 LEU103      0.0000 BACKBONE|DICT|DIRECT
+   1624 CB         38.9070   -9.1080   26.2480 C.3     101 LEU103      0.0000 DICT
+   1625 CG         38.1650   -8.5740   27.4720 C.3     101 LEU103      0.0000 DICT
+   1626 CD1        36.6640   -8.6320   27.2460 C.3     101 LEU103      0.0000 DICT
+   1627 CD2        38.5420   -9.3720   28.6980 C.3     101 LEU103      0.0000 DICT
+   1628 H          40.4720   -7.0520   25.7220 H       101 LEU103      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1629 HA         40.7390   -9.5530   27.1120 H       101 LEU103      0.0000 BACKBONE|DICT|DIRECT
+   1630 HB2        38.6090  -10.0530   26.1120 H       101 LEU103      0.0000 DICT
+   1631 HB3        38.6230   -8.5530   25.4660 H       101 LEU103      0.0000 DICT
+   1632 HG         38.4300   -7.6210   27.6160 H       101 LEU103      0.0000 DICT
+   1633 HD11       36.1910   -8.2800   28.0540 H       101 LEU103      0.0000 DICT
+   1634 HD12       36.4250   -8.0750   26.4510 H       101 LEU103      0.0000 DICT
+   1635 HD13       36.3880   -9.5790   27.0850 H       101 LEU103      0.0000 DICT
+   1636 HD21       38.0510   -9.0140   29.4920 H       101 LEU103      0.0000 DICT
+   1637 HD22       38.2970  -10.3320   28.5590 H       101 LEU103      0.0000 DICT
+   1638 HD23       39.5270   -9.2980   28.8540 H       101 LEU103      0.0000 DICT
+   1639 N          40.9740   -9.4000   23.8890 N.am    102 GLY104      0.0000 BACKBONE|DICT|DIRECT
+   1640 CA         41.2720  -10.1830   22.7040 C.3     102 GLY104      0.0000 BACKBONE|DICT|DIRECT
+   1641 C          40.1930  -11.2220   22.4350 C.2     102 GLY104      0.0000 BACKBONE|DICT|DIRECT
+   1642 O          39.1590  -11.2850   23.0980 O.2     102 GLY104      0.0000 BACKBONE|DICT|DIRECT
+   1643 H          40.7880   -8.4220   23.7960 H       102 GLY104      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1644 HA2        42.1470  -10.6500   22.8350 H       102 GLY104      0.0000 BACKBONE|DICT|DIRECT
+   1645 HA3        41.3360   -9.5700   21.9170 H       102 GLY104      0.0000 DICT
+   1646 N          40.4460  -12.0510   21.4200 N.am    103 GLY105      0.0000 BACKBONE|DICT|DIRECT
+   1647 CA         39.5890  -13.1800   21.1230 C.3     103 GLY105      0.0000 BACKBONE|DICT|DIRECT
+   1648 C          38.9380  -13.0540   19.7520 C.2     103 GLY105      0.0000 BACKBONE|DICT|DIRECT
+   1649 O          39.4780  -12.4270   18.8410 O.2     103 GLY105      0.0000 BACKBONE|DICT|DIRECT
+   1650 H          41.2500  -11.8880   20.8480 H       103 GLY105      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1651 HA2        38.8720  -13.2330   21.8180 H       103 GLY105      0.0000 BACKBONE|DICT|DIRECT
+   1652 HA3        40.1370  -14.0160   21.1450 H       103 GLY105      0.0000 DICT
+   1653 N          37.7620  -13.6710   19.6320 N.am    104 THR106      0.0000 BACKBONE|DICT|DIRECT
+   1654 CA         37.0310  -13.7660   18.3760 C.3     104 THR106      0.0000 BACKBONE|DICT|DIRECT
+   1655 C          35.6430  -13.1600   18.5470 C.2     104 THR106      0.0000 BACKBONE|DICT|DIRECT
+   1656 O          34.9690  -13.4020   19.5530 O.2     104 THR106      0.0000 BACKBONE|DICT|DIRECT
+   1657 CB         36.9180  -15.2330   17.9250 C.3     104 THR106      0.0000 DICT
+   1658 OG1        38.2190  -15.8370   17.9260 O.3     104 THR106      0.0000 DICT
+   1659 CG2        36.3100  -15.3350   16.5290 C.3     104 THR106      0.0000 DICT
+   1660 H          37.3610  -14.0900   20.4470 H       104 THR106      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1661 HA         37.5240  -13.2500   17.6760 H       104 THR106      0.0000 BACKBONE|DICT|DIRECT
+   1662 HB         36.3330  -15.7250   18.5690 H       104 THR106      0.0000 DICT
+   1663 HG1        38.1440  -16.7900   17.6330 H       104 THR106      0.0000 DICT|ESSENTIAL
+   1664 HG21       36.2480  -16.2970   16.2620 H       104 THR106      0.0000 DICT
+   1665 HG22       35.3950  -14.9310   16.5330 H       104 THR106      0.0000 DICT
+   1666 HG23       36.8880  -14.8440   15.8770 H       104 THR106      0.0000 DICT
+   1667 N          35.2180  -12.3740   17.5650 N.am    105 VAL107      0.0000 BACKBONE|DICT|DIRECT
+   1668 CA         33.9170  -11.7150   17.5930 C.3     105 VAL107      0.0000 BACKBONE|DICT|DIRECT
+   1669 C          32.9550  -12.5130   16.7230 C.2     105 VAL107      0.0000 BACKBONE|DICT|DIRECT
+   1670 O          33.2000  -12.7030   15.5260 O.2     105 VAL107      0.0000 BACKBONE|DICT|DIRECT
+   1671 CB         34.0150  -10.2570   17.1160 C.3     105 VAL107      0.0000 DICT
+   1672 CG1        32.6500   -9.5910   17.1660 C.3     105 VAL107      0.0000 DICT
+   1673 CG2        35.0210   -9.4880   17.9560 C.3     105 VAL107      0.0000 DICT
+   1674 H          35.8130  -12.2280   16.7750 H       105 VAL107      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1675 HA         33.5770  -11.7210   18.5330 H       105 VAL107      0.0000 BACKBONE|DICT|DIRECT
+   1676 HB         34.3310  -10.2570   16.1670 H       105 VAL107      0.0000 DICT
+   1677 HG11       32.7290   -8.6440   16.8530 H       105 VAL107      0.0000 DICT
+   1678 HG12       32.0160  -10.0860   16.5720 H       105 VAL107      0.0000 DICT
+   1679 HG13       32.3070   -9.6040   18.1050 H       105 VAL107      0.0000 DICT
+   1680 HG21       35.0720   -8.5430   17.6330 H       105 VAL107      0.0000 DICT
+   1681 HG22       34.7320   -9.4980   18.9130 H       105 VAL107      0.0000 DICT
+   1682 HG23       35.9210   -9.9170   17.8750 H       105 VAL107      0.0000 DICT
+   1683 N          31.8610  -12.9770   17.3200 N.am    106 PHE108      0.0000 BACKBONE|DICT|DIRECT
+   1684 CA         30.8260  -13.7190   16.6100 C.3     106 PHE108      0.0000 BACKBONE|DICT|DIRECT
+   1685 C          29.5610  -12.8790   16.5370 C.2     106 PHE108      0.0000 BACKBONE|DICT|DIRECT
+   1686 O          29.0850  -12.3810   17.5620 O.2     106 PHE108      0.0000 BACKBONE|DICT|DIRECT
+   1687 CB         30.5250  -15.0500   17.2990 C.3     106 PHE108      0.0000 DICT
+   1688 CG         31.6530  -16.0320   17.2450 C.ar    106 PHE108      0.0000 DICT
+   1689 CD1        31.8680  -16.7990   16.1090 C.ar    106 PHE108      0.0000 DICT
+   1690 CD2        32.4940  -16.1990   18.3330 C.ar    106 PHE108      0.0000 DICT
+   1691 CE1        32.9040  -17.7090   16.0590 C.ar    106 PHE108      0.0000 DICT
+   1692 CE2        33.5330  -17.1080   18.2910 C.ar    106 PHE108      0.0000 DICT
+   1693 CZ         33.7390  -17.8650   17.1520 C.ar    106 PHE108      0.0000 DICT
+   1694 H          31.7430  -12.8100   18.2990 H       106 PHE108      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1695 HA         31.1440  -13.9030   15.6800 H       106 PHE108      0.0000 BACKBONE|DICT|DIRECT
+   1696 HB2        29.7290  -15.4610   16.8550 H       106 PHE108      0.0000 DICT
+   1697 HB3        30.3140  -14.8660   18.2590 H       106 PHE108      0.0000 DICT
+   1698 HD1        31.2660  -16.6910   15.3180 H       106 PHE108      0.0000 DICT
+   1699 HD2        32.3470  -15.6550   19.1590 H       106 PHE108      0.0000 DICT
+   1700 HE1        33.0510  -18.2550   15.2340 H       106 PHE108      0.0000 DICT
+   1701 HE2        34.1350  -17.2190   19.0820 H       106 PHE108      0.0000 DICT
+   1702 HZ         34.4900  -18.5240   17.1180 H       106 PHE108      0.0000 DICT
+   1703 N          29.0120  -12.7330   15.3340 N.am    107 ARG109      0.0000 BACKBONE|DICT|DIRECT
+   1704 CA         27.7780  -11.9920   15.1300 C.3     107 ARG109      0.0000 BACKBONE|DICT|DIRECT
+   1705 C          26.6810  -12.9160   14.6250 C.2     107 ARG109      0.0000 BACKBONE|DICT|DIRECT
+   1706 O          26.9380  -13.8780   13.8970 O.2     107 ARG109      0.0000 BACKBONE|DICT|DIRECT
+   1707 CB         27.9740  -10.8390   14.1490 C.3     107 ARG109      0.0000 DICT
+   1708 CG         28.9890   -9.8230   14.6200 C.3     107 ARG109      0.0000 DICT
+   1709 CD         28.8770   -8.5360   13.8440 C.3     107 ARG109      0.0000 DICT
+   1710 NE         29.8190   -7.5370   14.3340 N.pl3   107 ARG109      0.0000 DICT
+   1711 CZ         31.1160   -7.5360   14.0520 C.cat   107 ARG109      0.0000 DICT
+   1712 NH1        31.6190   -8.4860   13.2730 N.pl3   107 ARG109      0.0000 DICT
+   1713 NH2        31.8970   -6.5830   14.5430 N.pl3   107 ARG109      0.0000 DICT
+   1714 H          29.4630  -13.1470   14.5430 H       107 ARG109      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1715 HA         27.4900  -11.6120   16.0090 H       107 ARG109      0.0000 BACKBONE|DICT|DIRECT
+   1716 HB2        27.0960  -10.3770   14.0230 H       107 ARG109      0.0000 DICT
+   1717 HB3        28.2820  -11.2140   13.2750 H       107 ARG109      0.0000 DICT
+   1718 HG2        29.9070  -10.1990   14.4970 H       107 ARG109      0.0000 DICT
+   1719 HG3        28.8340   -9.6330   15.5900 H       107 ARG109      0.0000 DICT
+   1720 HD2        27.9470   -8.1800   13.9370 H       107 ARG109      0.0000 DICT
+   1721 HD3        29.0690   -8.7190   12.8800 H       107 ARG109      0.0000 DICT
+   1722 HE         29.4660   -6.8070   14.9190 H       107 ARG109      0.0000 DICT|ESSENTIAL
+   1723 HH11       32.5950   -8.4910   13.0570 H       107 ARG109      0.0000 DICT|ESSENTIAL
+   1724 HH12       31.0220   -9.1970   12.9020 H       107 ARG109      0.0000 DICT|ESSENTIAL
+   1725 HH21       32.8750   -6.5800   14.3320 H       107 ARG109      0.0000 DICT|ESSENTIAL
+   1726 HH22       31.5080   -5.8680   15.1240 H       107 ARG109      0.0000 DICT|ESSENTIAL
+   1727 N          25.4500  -12.5940   15.0080 N.am    108 GLU110      0.0000 BACKBONE|DICT|DIRECT
+   1728 CA         24.3050  -13.4340   14.6980 C.3     108 GLU110      0.0000 BACKBONE|DICT|DIRECT
+   1729 C          23.0560  -12.5690   14.6720 C.2     108 GLU110      0.0000 BACKBONE|DICT|DIRECT
+   1730 O          22.7980  -11.8210   15.6200 O.2     108 GLU110      0.0000 BACKBONE|DICT|DIRECT
+   1731 CB         24.1650  -14.5550   15.7310 C.3     108 GLU110      0.0000 DICT
+   1732 CG         22.9660  -15.4550   15.5260 C.3     108 GLU110      0.0000 DICT
+   1733 CD         22.8500  -16.5180   16.6070 C.2     108 GLU110      0.0000 DICT
+   1734 OE1        21.8310  -17.2400   16.6260 O.co2   108 GLU110      0.0000 DICT
+   1735 OE2        23.7750  -16.6290   17.4390 O.co2   108 GLU110      0.0000 DICT
+   1736 H          25.3070  -11.7500   15.5240 H       108 GLU110      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1737 HA         24.4370  -13.8410   13.7940 H       108 GLU110      0.0000 BACKBONE|DICT|DIRECT
+   1738 HB2        24.0900  -14.1370   16.6360 H       108 GLU110      0.0000 DICT
+   1739 HB3        24.9890  -15.1200   15.6920 H       108 GLU110      0.0000 DICT
+   1740 HG2        23.0520  -15.9070   14.6380 H       108 GLU110      0.0000 DICT
+   1741 HG3        22.1380  -14.8950   15.5360 H       108 GLU110      0.0000 DICT
+   1742 N          22.2940  -12.6660   13.5880 N.am    109 ALA111      0.0000 BACKBONE|DICT|DIRECT
+   1743 CA         21.0350  -11.9480   13.4640 C.3     109 ALA111      0.0000 BACKBONE|DICT|DIRECT
+   1744 C          19.8900  -12.8300   13.9500 C.2     109 ALA111      0.0000 BACKBONE|DICT|DIRECT
+   1745 O          19.8150  -14.0110   13.5970 O.2     109 ALA111      0.0000 BACKBONE|DICT|DIRECT
+   1746 CB         20.8010  -11.5180   12.0170 C.3     109 ALA111      0.0000 DICT
+   1747 H          22.5950  -13.2500   12.8340 H       109 ALA111      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1748 HA         21.0750  -11.1300   14.0380 H       109 ALA111      0.0000 BACKBONE|DICT|DIRECT
+   1749 HB1        19.9320  -11.0270   11.9520 H       109 ALA111      0.0000 DICT
+   1750 HB2        21.5460  -10.9190   11.7230 H       109 ALA111      0.0000 DICT
+   1751 HB3        20.7720  -12.3270   11.4300 H       109 ALA111      0.0000 DICT
+   1752 N          19.0090  -12.2600   14.7660 N.am    110 ILE112      0.0000 BACKBONE|DICT|DIRECT
+   1753 CA         17.8550  -12.9960   15.2690 C.3     110 ILE112      0.0000 BACKBONE|DICT|DIRECT
+   1754 C          16.8290  -13.1190   14.1530 C.2     110 ILE112      0.0000 BACKBONE|DICT|DIRECT
+   1755 O          16.4170  -12.1160   13.5600 O.2     110 ILE112      0.0000 BACKBONE|DICT|DIRECT
+   1756 CB         17.2520  -12.3090   16.5050 C.3     110 ILE112      0.0000 DICT
+   1757 CG1        18.1630  -12.4810   17.7210 C.3     110 ILE112      0.0000 DICT
+   1758 CG2        15.8800  -12.8780   16.8110 C.3     110 ILE112      0.0000 DICT
+   1759 CD1        19.2240  -11.4370   17.8330 C.3     110 ILE112      0.0000 DICT
+   1760 H          19.1400  -11.3070   15.0400 H       110 ILE112      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1761 HA         18.1530  -13.9140   15.5300 H       110 ILE112      0.0000 BACKBONE|DICT|DIRECT
+   1762 HB         17.1570  -11.3320   16.3130 H       110 ILE112      0.0000 DICT
+   1763 HG12       18.6060  -13.3750   17.6590 H       110 ILE112      0.0000 DICT
+   1764 HG13       17.5980  -12.4460   18.5450 H       110 ILE112      0.0000 DICT
+   1765 HG21       15.5020  -12.4210   17.6160 H       110 ILE112      0.0000 DICT
+   1766 HG22       15.2750  -12.7290   16.0290 H       110 ILE112      0.0000 DICT
+   1767 HG23       15.9580  -13.8590   16.9900 H       110 ILE112      0.0000 DICT
+   1768 HD11       19.7790  -11.6110   18.6470 H       110 ILE112      0.0000 DICT
+   1769 HD12       19.8060  -11.4650   17.0200 H       110 ILE112      0.0000 DICT
+   1770 HD13       18.7980  -10.5350   17.9070 H       110 ILE112      0.0000 DICT
+   1771 N          16.4130  -14.3490   13.8660 N.am    111 ILE113      0.0000 BACKBONE|DICT|DIRECT
+   1772 CA         15.4840  -14.6360   12.7810 C.3     111 ILE113      0.0000 BACKBONE|DICT|DIRECT
+   1773 C          14.0840  -14.8040   13.3560 C.2     111 ILE113      0.0000 BACKBONE|DICT|DIRECT
+   1774 O          13.8760  -15.5870   14.2930 O.2     111 ILE113      0.0000 BACKBONE|DICT|DIRECT
+   1775 CB         15.9090  -15.8930   12.0020 C.3     111 ILE113      0.0000 DICT
+   1776 CG1        17.2850  -15.6880   11.3650 C.3     111 ILE113      0.0000 DICT
+   1777 CG2        14.8740  -16.2400   10.9410 C.3     111 ILE113      0.0000 DICT
+   1778 CD1        17.3340  -14.5370   10.3810 C.3     111 ILE113      0.0000 DICT
+   1779 H          16.7530  -15.1100   14.4190 H       111 ILE113      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1780 HA         15.4790  -13.8580   12.1520 H       111 ILE113      0.0000 BACKBONE|DICT|DIRECT
+   1781 HB         15.9700  -16.6570   12.6450 H       111 ILE113      0.0000 DICT
+   1782 HG12       17.5380  -16.5270   10.8830 H       111 ILE113      0.0000 DICT
+   1783 HG13       17.9470  -15.5090   12.0930 H       111 ILE113      0.0000 DICT
+   1784 HG21       15.1660  -17.0580   10.4450 H       111 ILE113      0.0000 DICT
+   1785 HG22       13.9920  -16.4130   11.3800 H       111 ILE113      0.0000 DICT
+   1786 HG23       14.7840  -15.4770   10.3010 H       111 ILE113      0.0000 DICT
+   1787 HD11       18.2570  -14.4600   10.0040 H       111 ILE113      0.0000 DICT
+   1788 HD12       16.6840  -14.7040    9.6400 H       111 ILE113      0.0000 DICT
+   1789 HD13       17.0930  -13.6870   10.8500 H       111 ILE113      0.0000 DICT
+   1790 N          13.1250  -14.0710   12.7950 N.am    112 CYS114      0.0000 BACKBONE|DICT|DIRECT
+   1791 CA         11.7130  -14.2330   13.1050 C.3     112 CYS114      0.0000 BACKBONE|DICT|DIRECT
+   1792 C          10.9590  -14.6130   11.8370 C.2     112 CYS114      0.0000 BACKBONE|DICT|DIRECT
+   1793 O          11.2390  -14.0870   10.7550 O.2     112 CYS114      0.0000 BACKBONE|DICT|DIRECT
+   1794 CB         11.1290  -12.9560   13.7140 C.3     112 CYS114      0.0000 DICT
+   1795 SG         11.6280  -12.6900   15.4270 S.3     112 CYS114      0.0000 DICT
+   1796 H          13.3880  -13.3750   12.1270 H       112 CYS114      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1797 HA         11.6160  -14.9750   13.7680 H       112 CYS114      0.0000 BACKBONE|DICT|DIRECT
+   1798 HB2        10.1310  -13.0150   13.6800 H       112 CYS114      0.0000 DICT
+   1799 HB3        11.4360  -12.1750   13.1690 H       112 CYS114      0.0000 DICT
+   1800 HG         11.2160  -11.8440   15.7670 H       112 CYS114      0.0000 DICT|ESSENTIAL
+   1801 N           9.9960  -15.5260   11.9800 N.am    113 LYS115      0.0000 BACKBONE|DICT|DIRECT
+   1802 CA          9.3280  -16.0990   10.8140 C.3     113 LYS115      0.0000 BACKBONE|DICT|DIRECT
+   1803 C           8.5240  -15.0540   10.0470 C.2     113 LYS115      0.0000 BACKBONE|DICT|DIRECT
+   1804 O           8.4430  -15.1080    8.8150 O.2     113 LYS115      0.0000 BACKBONE|DICT|DIRECT
+   1805 CB          8.4300  -17.2580   11.2480 C.3     113 LYS115      0.0000 DICT
+   1806 CG          9.1990  -18.4570   11.7820 C.3     113 LYS115      0.0000 DICT
+   1807 CD          8.3140  -19.3810   12.6040 C.3     113 LYS115      0.0000 DICT
+   1808 CE          9.1400  -20.4900   13.2420 C.3     113 LYS115      0.0000 DICT
+   1809 NZ          8.3770  -21.2340   14.2810 N.4     113 LYS115      0.0000 DICT
+   1810 H           9.7280  -15.8220   12.8970 H       113 LYS115      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1811 HA         10.0300  -16.4620   10.2010 H       113 LYS115      0.0000 BACKBONE|DICT|DIRECT
+   1812 HB2         7.8920  -17.5540   10.4590 H       113 LYS115      0.0000 DICT
+   1813 HB3         7.8160  -16.9310   11.9660 H       113 LYS115      0.0000 DICT
+   1814 HG2         9.9480  -18.1300   12.3590 H       113 LYS115      0.0000 DICT
+   1815 HG3         9.5730  -18.9710   11.0100 H       113 LYS115      0.0000 DICT
+   1816 HD2         7.6220  -19.7880   12.0080 H       113 LYS115      0.0000 DICT
+   1817 HD3         7.8650  -18.8510   13.3230 H       113 LYS115      0.0000 DICT
+   1818 HE2         9.9500  -20.0850   13.6660 H       113 LYS115      0.0000 DICT
+   1819 HE3         9.4230  -21.1320   12.5290 H       113 LYS115      0.0000 DICT
+   1820 HZ1         8.9560  -21.9500   14.6710 H       113 LYS115      0.0000 DICT|ESSENTIAL
+   1821 HZ2         8.0950  -20.6030   15.0030 H       113 LYS115      0.0000 DICT|ESSENTIAL
+   1822 HZ3         7.5670  -21.6500   13.8660 H       113 LYS115      0.0000 DICT|ESSENTIAL
+   1823 N           7.9200  -14.1000   10.7520 N.am    114 ASN116      0.0000 BACKBONE|DICT|DIRECT
+   1824 CA          7.0730  -13.0980   10.1150 C.3     114 ASN116      0.0000 BACKBONE|DICT|DIRECT
+   1825 C           7.8290  -11.8380    9.7150 C.2     114 ASN116      0.0000 BACKBONE|DICT|DIRECT
+   1826 O           7.2030  -10.8880    9.2350 O.2     114 ASN116      0.0000 BACKBONE|DICT|DIRECT
+   1827 CB          5.9100  -12.7220   11.0380 C.3     114 ASN116      0.0000 DICT
+   1828 CG          6.3770  -12.1950   12.3800 C.2     114 ASN116      0.0000 DICT
+   1829 OD1         7.4180  -12.6040   12.8950 O.2     114 ASN116      0.0000 DICT
+   1830 ND2         5.6020  -11.2880   12.9580 N.am    114 ASN116      0.0000 DICT
+   1831 H           8.0500  -14.0700   11.7430 H       114 ASN116      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1832 HA          6.6890  -13.5030    9.2850 H       114 ASN116      0.0000 BACKBONE|DICT|DIRECT
+   1833 HB2         5.3470  -13.5340   11.1910 H       114 ASN116      0.0000 DICT
+   1834 HB3         5.3610  -12.0160   10.5900 H       114 ASN116      0.0000 DICT
+   1835 HD21        4.7640  -10.9840   12.5040 H       114 ASN116      0.0000 DICT|ESSENTIAL
+   1836 HD22        5.8550  -10.9080   13.8480 H       114 ASN116      0.0000 DICT|ESSENTIAL
+   1837 N           9.1380  -11.7980    9.9000 N.am    115 ILE117      0.0000 BACKBONE|DICT|DIRECT
+   1838 CA          9.9590  -10.6410    9.5530 C.3     115 ILE117      0.0000 BACKBONE|DICT|DIRECT
+   1839 C          10.7670  -10.9960    8.3130 C.2     115 ILE117      0.0000 BACKBONE|DICT|DIRECT
+   1840 O          11.4470  -12.0290    8.3080 O.2     115 ILE117      0.0000 BACKBONE|DICT|DIRECT
+   1841 CB         10.8880  -10.2240   10.7090 C.3     115 ILE117      0.0000 DICT
+   1842 CG1        10.0630   -9.8980   11.9560 C.3     115 ILE117      0.0000 DICT
+   1843 CG2        11.7370   -9.0270   10.3060 C.3     115 ILE117      0.0000 DICT
+   1844 CD1         9.0840   -8.7510   11.7600 C.3     115 ILE117      0.0000 DICT
+   1845 H           9.5870  -12.5990   10.2970 H       115 ILE117      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1846 HA          9.3560   -9.8740    9.3340 H       115 ILE117      0.0000 BACKBONE|DICT|DIRECT
+   1847 HB         11.4960  -10.9890   10.9210 H       115 ILE117      0.0000 DICT
+   1848 HG12       10.6910   -9.6540   12.6950 H       115 ILE117      0.0000 DICT
+   1849 HG13        9.5460  -10.7140   12.2140 H       115 ILE117      0.0000 DICT
+   1850 HG21       12.3330   -8.7700   11.0670 H       115 ILE117      0.0000 DICT
+   1851 HG22       12.2950   -9.2660    9.5110 H       115 ILE117      0.0000 DICT
+   1852 HG23       11.1410   -8.2580   10.0750 H       115 ILE117      0.0000 DICT
+   1853 HD11        8.5810   -8.5930   12.6100 H       115 ILE117      0.0000 DICT
+   1854 HD12        9.5860   -7.9230   11.5110 H       115 ILE117      0.0000 DICT
+   1855 HD13        8.4410   -8.9830   11.0300 H       115 ILE117      0.0000 DICT
+   1856 N          10.7190  -10.1890    7.2550 N.am    116 PRO118      0.0000 BACKBONE|DICT|DIRECT
+   1857 CA         11.4250  -10.5550    6.0240 C.3     116 PRO118      0.0000 BACKBONE|DICT|DIRECT
+   1858 C          12.9260  -10.6210    6.2490 C.2     116 PRO118      0.0000 BACKBONE|DICT|DIRECT
+   1859 O          13.4980   -9.8240    6.9940 O.2     116 PRO118      0.0000 BACKBONE|DICT|DIRECT
+   1860 CB         11.0610   -9.4290    5.0470 C.3     116 PRO118      0.0000 DICT
+   1861 CG          9.9360   -8.6910    5.6740 C.3     116 PRO118      0.0000 DICT
+   1862 CD         10.0530   -8.8830    7.1470 C.3     116 PRO118      0.0000 DICT
+   1863 HA         11.0890  -11.4320    5.6810 H       116 PRO118      0.0000 BACKBONE|DICT|DIRECT
+   1864 HB2        11.8430   -8.8210    4.9110 H       116 PRO118      0.0000 DICT
+   1865 HB3        10.7790   -9.8100    4.1670 H       116 PRO118      0.0000 DICT
+   1866 HG2         9.9960   -7.7180    5.4490 H       116 PRO118      0.0000 DICT
+   1867 HG3         9.0630   -9.0550    5.3490 H       116 PRO118      0.0000 DICT
+   1868 HD2        10.6070   -8.1610    7.5610 H       116 PRO118      0.0000 DICT
+   1869 HD3         9.1520   -8.9020    7.5800 H       116 PRO118      0.0000 DICT
+   1870 N          13.5550  -11.5940    5.6080 N.am    117 ARG119      0.0000 BACKBONE|DICT|DIRECT
+   1871 CA         15.0010  -11.6350    5.4740 C.3     117 ARG119      0.0000 BACKBONE|DICT|DIRECT
+   1872 C          15.3970  -11.1040    4.1000 C.2     117 ARG119      0.0000 BACKBONE|DICT|DIRECT
+   1873 O          14.5650  -10.9540    3.2050 O.2     117 ARG119      0.0000 BACKBONE|DICT|DIRECT
+   1874 CB         15.5210  -13.0600    5.6880 C.3     117 ARG119      0.0000 DICT
+   1875 CG         15.5730  -13.4700    7.1510 C.3     117 ARG119      0.0000 DICT
+   1876 CD         14.6430  -14.6300    7.4680 C.3     117 ARG119      0.0000 DICT
+   1877 NE         13.2300  -14.2920    7.3220 N.pl3   117 ARG119      0.0000 DICT
+   1878 CZ         12.4000  -14.8850    6.4700 C.cat   117 ARG119      0.0000 DICT
+   1879 NH1        11.1280  -14.5120    6.4120 N.pl3   117 ARG119      0.0000 DICT
+   1880 NH2        12.8380  -15.8580    5.6830 N.pl3   117 ARG119      0.0000 DICT
+   1881 H          13.0140  -12.3290    5.2000 H       117 ARG119      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1882 HA         15.4020  -11.0420    6.1720 H       117 ARG119      0.0000 BACKBONE|DICT|DIRECT
+   1883 HB2        16.4440  -13.1210    5.3090 H       117 ARG119      0.0000 DICT
+   1884 HB3        14.9190  -13.6940    5.2020 H       117 ARG119      0.0000 DICT
+   1885 HG2        15.3090  -12.6860    7.7130 H       117 ARG119      0.0000 DICT
+   1886 HG3        16.5090  -13.7400    7.3740 H       117 ARG119      0.0000 DICT
+   1887 HD2        14.8050  -14.9180    8.4120 H       117 ARG119      0.0000 DICT
+   1888 HD3        14.8550  -15.3850    6.8480 H       117 ARG119      0.0000 DICT
+   1889 HE         12.8620  -13.5650    7.9020 H       117 ARG119      0.0000 DICT|ESSENTIAL
+   1890 HH11       10.5050  -14.9590    5.7700 H       117 ARG119      0.0000 DICT|ESSENTIAL
+   1891 HH12       10.7930  -13.7840    7.0100 H       117 ARG119      0.0000 DICT|ESSENTIAL
+   1892 HH21       12.2120  -16.3030    5.0430 H       117 ARG119      0.0000 DICT|ESSENTIAL
+   1893 HH22       13.7940  -16.1470    5.7300 H       117 ARG119      0.0000 DICT|ESSENTIAL
+   1894 N          16.6880  -10.7970    3.9450 N.am    118 LEU120      0.0000 BACKBONE|DICT|DIRECT
+   1895 CA         17.1830  -10.3390    2.6500 C.3     118 LEU120      0.0000 BACKBONE|DICT|DIRECT
+   1896 C          16.8930  -11.3670    1.5640 C.2     118 LEU120      0.0000 BACKBONE|DICT|DIRECT
+   1897 O          16.4830  -11.0130    0.4520 O.2     118 LEU120      0.0000 BACKBONE|DICT|DIRECT
+   1898 CB         18.6840  -10.0440    2.7240 C.3     118 LEU120      0.0000 DICT
+   1899 CG         19.4840  -10.0940    1.4160 C.3     118 LEU120      0.0000 DICT
+   1900 CD1        19.0610   -8.9750    0.4670 C.3     118 LEU120      0.0000 DICT
+   1901 CD2        20.9700   -9.9970    1.7140 C.3     118 LEU120      0.0000 DICT
+   1902 H          17.3170  -10.8810    4.7180 H       118 LEU120      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1903 HA         16.7080   -9.4910    2.4140 H       118 LEU120      0.0000 BACKBONE|DICT|DIRECT
+   1904 HB2        19.0900  -10.7120    3.3480 H       118 LEU120      0.0000 DICT
+   1905 HB3        18.7900   -9.1250    3.1040 H       118 LEU120      0.0000 DICT
+   1906 HG         19.3070  -10.9710    0.9700 H       118 LEU120      0.0000 DICT
+   1907 HD11       19.5970   -9.0320   -0.3750 H       118 LEU120      0.0000 DICT
+   1908 HD12       18.0890   -9.0710    0.2510 H       118 LEU120      0.0000 DICT
+   1909 HD13       19.2190   -8.0900    0.9040 H       118 LEU120      0.0000 DICT
+   1910 HD21       21.4850  -10.0300    0.8570 H       118 LEU120      0.0000 DICT
+   1911 HD22       21.1600   -9.1350    2.1840 H       118 LEU120      0.0000 DICT
+   1912 HD23       21.2440  -10.7620    2.2970 H       118 LEU120      0.0000 DICT
+   1913 N          17.0880  -12.6470    1.8730 N.am    119 VAL121      0.0000 BACKBONE|DICT|DIRECT
+   1914 CA         16.7170  -13.7450    0.9920 C.3     119 VAL121      0.0000 BACKBONE|DICT|DIRECT
+   1915 C          15.6480  -14.5620    1.7000 C.2     119 VAL121      0.0000 BACKBONE|DICT|DIRECT
+   1916 O          15.7900  -14.8760    2.8870 O.2     119 VAL121      0.0000 BACKBONE|DICT|DIRECT
+   1917 CB         17.9320  -14.6190    0.6330 C.3     119 VAL121      0.0000 DICT
+   1918 CG1        17.5360  -15.6990   -0.3600 C.3     119 VAL121      0.0000 DICT
+   1919 CG2        19.0640  -13.7630    0.0820 C.3     119 VAL121      0.0000 DICT
+   1920 H          17.5100  -12.8650    2.7530 H       119 VAL121      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1921 HA         16.3310  -13.3680    0.1500 H       119 VAL121      0.0000 BACKBONE|DICT|DIRECT
+   1922 HB         18.2550  -15.0650    1.4680 H       119 VAL121      0.0000 DICT
+   1923 HG11       18.3360  -16.2570   -0.5820 H       119 VAL121      0.0000 DICT
+   1924 HG12       16.8270  -16.2780    0.0420 H       119 VAL121      0.0000 DICT
+   1925 HG13       17.1850  -15.2730   -1.1940 H       119 VAL121      0.0000 DICT
+   1926 HG21       19.8430  -14.3470   -0.1450 H       119 VAL121      0.0000 DICT
+   1927 HG22       18.7520  -13.2880   -0.7410 H       119 VAL121      0.0000 DICT
+   1928 HG23       19.3400  -13.0920    0.7700 H       119 VAL121      0.0000 DICT
+   1929 N          14.5790  -14.8980    0.9720 N.am    120 SER122      0.0000 BACKBONE|DICT|DIRECT
+   1930 CA         13.4900  -15.6750    1.5580 C.3     120 SER122      0.0000 BACKBONE|DICT|DIRECT
+   1931 C          13.9510  -17.0570    2.0010 C.2     120 SER122      0.0000 BACKBONE|DICT|DIRECT
+   1932 O          13.3910  -17.6230    2.9480 O.2     120 SER122      0.0000 BACKBONE|DICT|DIRECT
+   1933 CB         12.3400  -15.8060    0.5600 C.3     120 SER122      0.0000 DICT
+   1934 OG         11.5640  -14.6240    0.5160 O.3     120 SER122      0.0000 DICT
+   1935 H          14.5240  -14.6140    0.0150 H       120 SER122      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1936 HA         13.1530  -15.1850    2.3620 H       120 SER122      0.0000 BACKBONE|DICT|DIRECT
+   1937 HB2        11.7560  -16.5700    0.8340 H       120 SER122      0.0000 DICT
+   1938 HB3        12.7160  -15.9830   -0.3490 H       120 SER122      0.0000 DICT
+   1939 HG         10.8210  -14.7380   -0.1430 H       120 SER122      0.0000 DICT|ESSENTIAL
+   1940 N          14.9630  -17.6160    1.3330 N.am    121 GLY123      0.0000 BACKBONE|DICT|DIRECT
+   1941 CA         15.4360  -18.9470    1.6740 C.3     121 GLY123      0.0000 BACKBONE|DICT|DIRECT
+   1942 C          16.0450  -19.0520    3.0570 C.2     121 GLY123      0.0000 BACKBONE|DICT|DIRECT
+   1943 O          16.1820  -20.1610    3.5810 O.2     121 GLY123      0.0000 BACKBONE|DICT|DIRECT
+   1944 H          15.4010  -17.1120    0.5880 H       121 GLY123      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1945 HA2        16.1290  -19.2150    1.0050 H       121 GLY123      0.0000 BACKBONE|DICT|DIRECT
+   1946 HA3        14.6620  -19.5780    1.6230 H       121 GLY123      0.0000 DICT
+   1947 N          16.4140  -17.9250    3.6610 N.am    122 TRP124      0.0000 BACKBONE|DICT|DIRECT
+   1948 CA         17.0030  -17.9280    4.9960 C.3     122 TRP124      0.0000 BACKBONE|DICT|DIRECT
+   1949 C          15.9110  -18.1800    6.0300 C.2     122 TRP124      0.0000 BACKBONE|DICT|DIRECT
+   1950 O          15.0040  -17.3600    6.1950 O.2     122 TRP124      0.0000 BACKBONE|DICT|DIRECT
+   1951 CB         17.7080  -16.6000    5.2570 C.3     122 TRP124      0.0000 DICT
+   1952 CG         18.8450  -16.3150    4.3120 C.2     122 TRP124      0.0000 DICT
+   1953 CD1        19.3580  -17.1560    3.3620 C.2     122 TRP124      0.0000 DICT
+   1954 CD2        19.6120  -15.1070    4.2330 C.ar    122 TRP124      0.0000 DICT
+   1955 NE1        20.3920  -16.5440    2.6970 N.pl3   122 TRP124      0.0000 DICT
+   1956 CE2        20.5680  -15.2860    3.2110 C.ar    122 TRP124      0.0000 DICT
+   1957 CE3        19.5820  -13.8910    4.9240 C.ar    122 TRP124      0.0000 DICT
+   1958 CZ2        21.4860  -14.2940    2.8660 C.ar    122 TRP124      0.0000 DICT
+   1959 CZ3        20.4950  -12.9070    4.5780 C.ar    122 TRP124      0.0000 DICT
+   1960 CH2        21.4320  -13.1150    3.5580 C.ar    122 TRP124      0.0000 DICT
+   1961 H          16.2840  -17.0540    3.1880 H       122 TRP124      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1962 HA         17.6750  -18.6660    5.0500 H       122 TRP124      0.0000 BACKBONE|DICT|DIRECT
+   1963 HB2        18.0700  -16.6140    6.1890 H       122 TRP124      0.0000 DICT
+   1964 HB3        17.0360  -15.8650    5.1710 H       122 TRP124      0.0000 DICT
+   1965 HD1        19.0280  -18.0820    3.1790 H       122 TRP124      0.0000 DICT
+   1966 HE1        20.9290  -16.9500    1.9580 H       122 TRP124      0.0000 DICT|ESSENTIAL
+   1967 HE3        18.9150  -13.7350    5.6530 H       122 TRP124      0.0000 DICT
+   1968 HZ2        22.1580  -14.4390    2.1400 H       122 TRP124      0.0000 DICT
+   1969 HZ3        20.4840  -12.0340    5.0650 H       122 TRP124      0.0000 DICT
+   1970 HH2        22.0760  -12.3850    3.3300 H       122 TRP124      0.0000 DICT
+   1971 N          15.9840  -19.3150    6.7240 N.am    123 VAL125      0.0000 BACKBONE|DICT|DIRECT
+   1972 CA         14.9780  -19.6470    7.7280 C.3     123 VAL125      0.0000 BACKBONE|DICT|DIRECT
+   1973 C          15.6520  -20.0420    9.0370 C.2     123 VAL125      0.0000 BACKBONE|DICT|DIRECT
+   1974 O          14.9860  -20.1970   10.0670 O.2     123 VAL125      0.0000 BACKBONE|DICT|DIRECT
+   1975 CB         14.0350  -20.7600    7.2330 C.3     123 VAL125      0.0000 DICT
+   1976 CG1        13.1580  -20.2490    6.0980 C.3     123 VAL125      0.0000 DICT
+   1977 CG2        14.8300  -21.9820    6.7960 C.3     123 VAL125      0.0000 DICT
+   1978 H          16.7390  -19.9490    6.5550 H       123 VAL125      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1979 HA         14.4290  -18.8290    7.8980 H       123 VAL125      0.0000 BACKBONE|DICT|DIRECT
+   1980 HB         13.4410  -21.0280    7.9920 H       123 VAL125      0.0000 DICT
+   1981 HG11       12.5530  -20.9820    5.7880 H       123 VAL125      0.0000 DICT
+   1982 HG12       12.6090  -19.4780    6.4220 H       123 VAL125      0.0000 DICT
+   1983 HG13       13.7360  -19.9510    5.3380 H       123 VAL125      0.0000 DICT
+   1984 HG21       14.2020  -22.6920    6.4790 H       123 VAL125      0.0000 DICT
+   1985 HG22       15.4490  -21.7280    6.0530 H       123 VAL125      0.0000 DICT
+   1986 HG23       15.3610  -22.3280    7.5690 H       123 VAL125      0.0000 DICT
+   1987 N          16.9730  -20.2130    9.0070 N.am    124 LYS126      0.0000 BACKBONE|DICT|DIRECT
+   1988 CA         17.7480  -20.4840   10.2070 C.3     124 LYS126      0.0000 BACKBONE|DICT|DIRECT
+   1989 C          18.9030  -19.4960   10.2900 C.2     124 LYS126      0.0000 BACKBONE|DICT|DIRECT
+   1990 O          19.4680  -19.1150    9.2580 O.2     124 LYS126      0.0000 BACKBONE|DICT|DIRECT
+   1991 CB         18.2810  -21.9270   10.2140 C.3     124 LYS126      0.0000 DICT
+   1992 CG         17.1860  -22.9830   10.1780 C.3     124 LYS126      0.0000 DICT
+   1993 CD         17.7490  -24.3920   10.0440 C.3     124 LYS126      0.0000 DICT
+   1994 CE         18.3960  -24.8650   11.3370 C.3     124 LYS126      0.0000 DICT
+   1995 NZ         18.8710  -26.2750   11.2340 N.4     124 LYS126      0.0000 DICT
+   1996 H          17.4480  -20.1530    8.1290 H       124 LYS126      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   1997 HA         17.1590  -20.3560   11.0050 H       124 LYS126      0.0000 BACKBONE|DICT|DIRECT
+   1998 HB2        18.8210  -22.0600   11.0450 H       124 LYS126      0.0000 DICT
+   1999 HB3        18.8660  -22.0510    9.4130 H       124 LYS126      0.0000 DICT
+   2000 HG2        16.5880  -22.8000    9.3980 H       124 LYS126      0.0000 DICT
+   2001 HG3        16.6570  -22.9270   11.0250 H       124 LYS126      0.0000 DICT
+   2002 HD2        18.4350  -24.3990    9.3170 H       124 LYS126      0.0000 DICT
+   2003 HD3        17.0050  -25.0170    9.8060 H       124 LYS126      0.0000 DICT
+   2004 HE2        17.7260  -24.8020   12.0760 H       124 LYS126      0.0000 DICT
+   2005 HE3        19.1760  -24.2750   11.5440 H       124 LYS126      0.0000 DICT
+   2006 HZ1        19.2890  -26.5500   12.1000 H       124 LYS126      0.0000 DICT|ESSENTIAL
+   2007 HZ2        18.0960  -26.8740   11.0330 H       124 LYS126      0.0000 DICT|ESSENTIAL
+   2008 HZ3        19.5470  -26.3460   10.5000 H       124 LYS126      0.0000 DICT|ESSENTIAL
+   2009 N          19.2720  -19.0550   11.4870 N.am    125 PRO127      0.0000 BACKBONE|DICT|DIRECT
+   2010 CA         20.3150  -18.0330   11.6060 C.3     125 PRO127      0.0000 BACKBONE|DICT|DIRECT
+   2011 C          21.7040  -18.6150   11.3880 C.2     125 PRO127      0.0000 BACKBONE|DICT|DIRECT
+   2012 O          21.9350  -19.8190   11.5010 O.2     125 PRO127      0.0000 BACKBONE|DICT|DIRECT
+   2013 CB         20.1470  -17.5300   13.0440 C.3     125 PRO127      0.0000 DICT
+   2014 CG         19.6430  -18.7270   13.7790 C.3     125 PRO127      0.0000 DICT
+   2015 CD         18.7720  -19.4880   12.8050 C.3     125 PRO127      0.0000 DICT
+   2016 HA         20.1460  -17.2900   10.9580 H       125 PRO127      0.0000 BACKBONE|DICT|DIRECT
+   2017 HB2        21.0220  -17.2230   13.4190 H       125 PRO127      0.0000 DICT
+   2018 HB3        19.4850  -16.7810   13.0850 H       125 PRO127      0.0000 DICT
+   2019 HG2        20.4080  -19.2970   14.0780 H       125 PRO127      0.0000 DICT
+   2020 HG3        19.1070  -18.4440   14.5750 H       125 PRO127      0.0000 DICT
+   2021 HD2        18.8820  -20.4750   12.9230 H       125 PRO127      0.0000 DICT
+   2022 HD3        17.8090  -19.2440   12.9200 H       125 PRO127      0.0000 DICT
+   2023 N          22.6350  -17.7220   11.0580 N.am    126 ILE128      0.0000 BACKBONE|DICT|DIRECT
+   2024 CA         24.0430  -18.0680   10.9380 C.3     126 ILE128      0.0000 BACKBONE|DICT|DIRECT
+   2025 C          24.8340  -17.2130   11.9170 C.2     126 ILE128      0.0000 BACKBONE|DICT|DIRECT
+   2026 O          24.3490  -16.2040   12.4370 O.2     126 ILE128      0.0000 BACKBONE|DICT|DIRECT
+   2027 CB         24.5800  -17.8820    9.5050 C.3     126 ILE128      0.0000 DICT
+   2028 CG1        24.7390  -16.3960    9.1770 C.3     126 ILE128      0.0000 DICT
+   2029 CG2        23.6610  -18.5500    8.5010 C.3     126 ILE128      0.0000 DICT
+   2030 CD1        25.5600  -16.1440    7.9320 C.3     126 ILE128      0.0000 DICT
+   2031 H          22.3560  -16.7770   10.8860 H       126 ILE128      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2032 HA         24.1550  -19.0280   11.1950 H       126 ILE128      0.0000 BACKBONE|DICT|DIRECT
+   2033 HB         25.4790  -18.3160    9.4470 H       126 ILE128      0.0000 DICT
+   2034 HG12       25.1870  -15.9460    9.9500 H       126 ILE128      0.0000 DICT
+   2035 HG13       23.8300  -16.0010    9.0430 H       126 ILE128      0.0000 DICT
+   2036 HG21       24.0240  -18.4200    7.5780 H       126 ILE128      0.0000 DICT
+   2037 HG22       23.6030  -19.5280    8.7010 H       126 ILE128      0.0000 DICT
+   2038 HG23       22.7500  -18.1430    8.5610 H       126 ILE128      0.0000 DICT
+   2039 HD11       25.6280  -15.1590    7.7710 H       126 ILE128      0.0000 DICT
+   2040 HD12       26.4760  -16.5260    8.0540 H       126 ILE128      0.0000 DICT
+   2041 HD13       25.1190  -16.5800    7.1480 H       126 ILE128      0.0000 DICT
+   2042 N          26.0700  -17.6320   12.1680 N.am    127 ILE129      0.0000 BACKBONE|DICT|DIRECT
+   2043 CA         26.9890  -16.9080   13.0380 C.3     127 ILE129      0.0000 BACKBONE|DICT|DIRECT
+   2044 C          28.2760  -16.6660   12.2640 C.2     127 ILE129      0.0000 BACKBONE|DICT|DIRECT
+   2045 O          28.9390  -17.6220   11.8440 O.2     127 ILE129      0.0000 BACKBONE|DICT|DIRECT
+   2046 CB         27.2780  -17.6710   14.3400 C.3     127 ILE129      0.0000 DICT
+   2047 CG1        26.0180  -17.7700   15.1970 C.3     127 ILE129      0.0000 DICT
+   2048 CG2        28.4090  -17.0070   15.1070 C.3     127 ILE129      0.0000 DICT
+   2049 CD1        26.2490  -18.4780   16.5070 C.3     127 ILE129      0.0000 DICT
+   2050 H          26.3830  -18.4810   11.7420 H       127 ILE129      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2051 HA         26.5830  -16.0240   13.2680 H       127 ILE129      0.0000 BACKBONE|DICT|DIRECT
+   2052 HB         27.5660  -18.5980   14.1010 H       127 ILE129      0.0000 DICT
+   2053 HG12       25.3220  -18.2710   14.6830 H       127 ILE129      0.0000 DICT
+   2054 HG13       25.6900  -16.8450   15.3890 H       127 ILE129      0.0000 DICT
+   2055 HG21       28.5840  -17.5160   15.9500 H       127 ILE129      0.0000 DICT
+   2056 HG22       29.2350  -17.0010   14.5440 H       127 ILE129      0.0000 DICT
+   2057 HG23       28.1520  -16.0670   15.3320 H       127 ILE129      0.0000 DICT
+   2058 HD11       25.3930  -18.5120   17.0230 H       127 ILE129      0.0000 DICT
+   2059 HD12       26.5700  -19.4090   16.3310 H       127 ILE129      0.0000 DICT
+   2060 HD13       26.9380  -17.9830   17.0370 H       127 ILE129      0.0000 DICT
+   2061 N          28.6300  -15.3960   12.0800 N.am    128 ILE130      0.0000 BACKBONE|DICT|DIRECT
+   2062 CA         29.8280  -14.9990   11.3480 C.3     128 ILE130      0.0000 BACKBONE|DICT|DIRECT
+   2063 C          30.8920  -14.5660   12.3460 C.2     128 ILE130      0.0000 BACKBONE|DICT|DIRECT
+   2064 O          30.6470  -13.6910   13.1870 O.2     128 ILE130      0.0000 BACKBONE|DICT|DIRECT
+   2065 CB         29.5170  -13.8710   10.3490 C.3     128 ILE130      0.0000 DICT
+   2066 CG1        28.5020  -14.3460    9.3070 C.3     128 ILE130      0.0000 DICT
+   2067 CG2        30.7950  -13.3810    9.6770 C.3     128 ILE130      0.0000 DICT
+   2068 CD1        28.1740  -13.3080    8.2590 C.3     128 ILE130      0.0000 DICT
+   2069 H          28.0470  -14.6790   12.4620 H       128 ILE130      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2070 HA         30.1690  -15.7900   10.8400 H       128 ILE130      0.0000 BACKBONE|DICT|DIRECT
+   2071 HB         29.1150  -13.1070   10.8530 H       128 ILE130      0.0000 DICT
+   2072 HG12       27.6570  -14.5940    9.7800 H       128 ILE130      0.0000 DICT
+   2073 HG13       28.8760  -15.1520    8.8470 H       128 ILE130      0.0000 DICT
+   2074 HG21       30.5730  -12.6490    9.0320 H       128 ILE130      0.0000 DICT
+   2075 HG22       31.4250  -13.0340   10.3720 H       128 ILE130      0.0000 DICT
+   2076 HG23       31.2250  -14.1390    9.1860 H       128 ILE130      0.0000 DICT
+   2077 HD11       27.5080  -13.6840    7.6140 H       128 ILE130      0.0000 DICT
+   2078 HD12       27.7890  -12.4980    8.7010 H       128 ILE130      0.0000 DICT
+   2079 HD13       29.0080  -13.0550    7.7680 H       128 ILE130      0.0000 DICT
+   2080 N          32.0780  -15.1650   12.2470 N.am    129 GLY131      0.0000 BACKBONE|DICT|DIRECT
+   2081 CA         33.1480  -14.8710   13.1810 C.3     129 GLY131      0.0000 BACKBONE|DICT|DIRECT
+   2082 C          34.4140  -14.2960   12.5660 C.2     129 GLY131      0.0000 BACKBONE|DICT|DIRECT
+   2083 O          34.9030  -14.8020   11.5500 O.2     129 GLY131      0.0000 BACKBONE|DICT|DIRECT
+   2084 H          32.2330  -15.8290   11.5160 H       129 GLY131      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2085 HA2        33.3910  -15.7210   13.6480 H       129 GLY131      0.0000 BACKBONE|DICT|DIRECT
+   2086 HA3        32.8020  -14.2110   13.8480 H       129 GLY131      0.0000 DICT
+   2087 N          34.9430  -13.2340   13.1740 N.am    130 HIS132      0.0000 BACKBONE|DICT|DIRECT
+   2088 CA         36.2330  -12.6630   12.8260 C.3     130 HIS132      0.0000 BACKBONE|DICT|DIRECT
+   2089 C          37.1330  -12.6840   14.0520 C.2     130 HIS132      0.0000 BACKBONE|DICT|DIRECT
+   2090 O          36.6620  -12.5540   15.1850 O.2     130 HIS132      0.0000 BACKBONE|DICT|DIRECT
+   2091 CB         36.1270  -11.2000   12.3460 C.3     130 HIS132      0.0000 DICT
+   2092 CG         34.9420  -10.9040   11.4910 C.2     130 HIS132      0.0000 DICT
+   2093 ND1        34.9900  -10.9050   10.1200 N.2     130 HIS132      0.0000 DICT
+   2094 CD2        33.6770  -10.5600   11.8130 C.2     130 HIS132      0.0000 DICT
+   2095 CE1        33.8050  -10.5880    9.6270 C.2     130 HIS132      0.0000 DICT
+   2096 NE2        32.9860  -10.3740   10.6370 N.pl3   130 HIS132      0.0000 DICT
+   2097 H          34.4220  -12.8060   13.9120 H       130 HIS132      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2098 HA         36.6510  -13.2150   12.1040 H       130 HIS132      0.0000 BACKBONE|DICT|DIRECT
+   2099 HB2        36.9500  -10.9850   11.8210 H       130 HIS132      0.0000 DICT
+   2100 HB3        36.0830  -10.6110   13.1530 H       130 HIS132      0.0000 DICT
+   2101 HD2        33.3090  -10.4590   12.7370 H       130 HIS132      0.0000 DICT
+   2102 HE1        33.5710  -10.5220    8.6570 H       130 HIS132      0.0000 DICT
+   2103 HE2        32.0220  -10.1190   10.5620 H       130 HIS132      0.0000 DICT|ESSENTIAL
+   2104 N          38.4360  -12.8180   13.8240 N.am    131 HIS133      0.0000 BACKBONE|DICT|DIRECT
+   2105 CA         39.3920  -12.6400   14.9060 C.3     131 HIS133      0.0000 BACKBONE|DICT|DIRECT
+   2106 C          39.5960  -11.1520   15.1620 C.2     131 HIS133      0.0000 BACKBONE|DICT|DIRECT
+   2107 O          39.6200  -10.3450   14.2280 O.2     131 HIS133      0.0000 BACKBONE|DICT|DIRECT
+   2108 CB         40.7260  -13.3120   14.5760 C.3     131 HIS133      0.0000 DICT
+   2109 CG         41.5070  -13.7250   15.7870 C.2     131 HIS133      0.0000 DICT
+   2110 ND1        40.9630  -14.4950   16.7930 N.pl3   131 HIS133      0.0000 DICT
+   2111 CD2        42.7860  -13.4720   16.1550 C.2     131 HIS133      0.0000 DICT
+   2112 CE1        41.8740  -14.7000   17.7280 C.2     131 HIS133      0.0000 DICT
+   2113 NE2        42.9890  -14.0910   17.3650 N.2     131 HIS133      0.0000 DICT
+   2114 H          38.7600  -13.0420   12.9050 H       131 HIS133      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2115 HA         39.0190  -13.0590   15.7340 H       131 HIS133      0.0000 BACKBONE|DICT|DIRECT
+   2116 HB2        41.2800  -12.6700   14.0460 H       131 HIS133      0.0000 DICT
+   2117 HB3        40.5420  -14.1270   14.0260 H       131 HIS133      0.0000 DICT
+   2118 HD1        40.0260  -14.8440   16.8120 H       131 HIS133      0.0000 DICT|ESSENTIAL
+   2119 HD2        43.4560  -12.9360   15.6420 H       131 HIS133      0.0000 DICT
+   2120 HE1        41.7420  -15.2270   18.5680 H       131 HIS133      0.0000 DICT
+   2121 N          39.7270  -10.7900   16.4370 N.am    132 ALA134      0.0000 BACKBONE|DICT|DIRECT
+   2122 CA         39.8620   -9.3870   16.8260 C.3     132 ALA134      0.0000 BACKBONE|DICT|DIRECT
+   2123 C          41.1960   -8.8080   16.3730 C.2     132 ALA134      0.0000 BACKBONE|DICT|DIRECT
+   2124 O          42.2100   -8.9550   17.0570 O.2     132 ALA134      0.0000 BACKBONE|DICT|DIRECT
+   2125 CB         39.7080   -9.2390   18.3330 C.3     132 ALA134      0.0000 DICT
+   2126 H          39.7330  -11.4950   17.1460 H       132 ALA134      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2127 HA         39.1300   -8.8680   16.3840 H       132 ALA134      0.0000 BACKBONE|DICT|DIRECT
+   2128 HB1        39.8020   -8.2760   18.5850 H       132 ALA134      0.0000 DICT
+   2129 HB2        38.8060   -9.5690   18.6100 H       132 ALA134      0.0000 DICT
+   2130 HB3        40.4150   -9.7750   18.7950 H       132 ALA134      0.0000 DICT
+   2131 N          48.1100   -4.5930   12.8350 N.am    133 ARG140      0.0000 BACKBONE|DICT|DIRECT
+   2132 CA         49.5480   -4.4910   13.0660 C.3     133 ARG140      0.0000 BACKBONE|DICT|DIRECT
+   2133 C          50.3420   -4.6760   11.7730 C.2     133 ARG140      0.0000 BACKBONE|DICT|DIRECT
+   2134 O          50.8300   -5.7670   11.4750 O.2     133 ARG140      0.0000 BACKBONE|DICT|DIRECT
+   2135 CB         49.9950   -5.5150   14.1130 C.3     133 ARG140      0.0000 DICT
+   2136 CG         50.1200   -4.9510   15.5230 C.3     133 ARG140      0.0000 DICT
+   2137 CD         48.8170   -4.3180   15.9810 C.3     133 ARG140      0.0000 DICT
+   2138 NE         48.7110   -4.2630   17.4360 N.pl3   133 ARG140      0.0000 DICT
+   2139 CZ         47.7780   -3.5780   18.0920 C.cat   133 ARG140      0.0000 DICT
+   2140 NH1        47.7540   -3.5870   19.4170 N.pl3   133 ARG140      0.0000 DICT
+   2141 NH2        46.8700   -2.8830   17.4220 N.pl3   133 ARG140      0.0000 DICT
+   2142 H          47.5700   -5.2680   13.3370 H       133 ARG140      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2143 HA         49.7420   -3.5770   13.4220 H       133 ARG140      0.0000 BACKBONE|DICT|DIRECT
+   2144 HB2        50.8870   -5.8750   13.8390 H       133 ARG140      0.0000 DICT
+   2145 HB3        49.3260   -6.2580   14.1300 H       133 ARG140      0.0000 DICT
+   2146 HG2        50.8410   -4.2580   15.5340 H       133 ARG140      0.0000 DICT
+   2147 HG3        50.3610   -5.6920   16.1500 H       133 ARG140      0.0000 DICT
+   2148 HD2        48.0540   -4.8560   15.6230 H       133 ARG140      0.0000 DICT
+   2149 HD3        48.7670   -3.3870   15.6190 H       133 ARG140      0.0000 DICT
+   2150 HE         49.3820   -4.7730   17.9740 H       133 ARG140      0.0000 DICT|ESSENTIAL
+   2151 HH11       47.0520   -3.0710   19.9080 H       133 ARG140      0.0000 DICT|ESSENTIAL
+   2152 HH12       48.4380   -4.1090   19.9260 H       133 ARG140      0.0000 DICT|ESSENTIAL
+   2153 HH21       46.1690   -2.3690   17.9160 H       133 ARG140      0.0000 DICT|ESSENTIAL
+   2154 HH22       46.8860   -2.8730   16.4220 H       133 ARG140      0.0000 DICT|ESSENTIAL
+   2155 N          50.4580   -3.5970   11.0050 N.am    134 ALA141      0.0000 BACKBONE|DICT|DIRECT
+   2156 CA         51.2490   -3.5770    9.7850 C.3     134 ALA141      0.0000 BACKBONE|DICT|DIRECT
+   2157 C          52.2240   -2.4100    9.8460 C.2     134 ALA141      0.0000 BACKBONE|DICT|DIRECT
+   2158 O          52.0270   -1.4490   10.5920 O.2     134 ALA141      0.0000 BACKBONE|DICT|DIRECT
+   2159 CB         50.3640   -3.4670    8.5380 C.3     134 ALA141      0.0000 DICT
+   2160 H          49.9800   -2.7620   11.2780 H       134 ALA141      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2161 HA         51.7720   -4.4270    9.7300 H       134 ALA141      0.0000 BACKBONE|DICT|DIRECT
+   2162 HB1        50.9400   -3.4560    7.7200 H       134 ALA141      0.0000 DICT
+   2163 HB2        49.7440   -4.2510    8.4990 H       134 ALA141      0.0000 DICT
+   2164 HB3        49.8310   -2.6220    8.5810 H       134 ALA141      0.0000 DICT
+   2165 N          53.2860   -2.5030    9.0580 N.am    135 THR142      0.0000 BACKBONE|DICT|DIRECT
+   2166 CA         54.3090   -1.4650    8.9940 C.3     135 THR142      0.0000 BACKBONE|DICT|DIRECT
+   2167 C          54.2670   -0.8620    7.5960 C.2     135 THR142      0.0000 BACKBONE|DICT|DIRECT
+   2168 O          54.8250   -1.4260    6.6500 O.2     135 THR142      0.0000 BACKBONE|DICT|DIRECT
+   2169 CB         55.6880   -2.0290    9.3290 C.3     135 THR142      0.0000 DICT
+   2170 OG1        55.6740   -2.5410   10.6660 O.3     135 THR142      0.0000 DICT
+   2171 CG2        56.7580   -0.9470    9.2200 C.3     135 THR142      0.0000 DICT
+   2172 H          53.3900   -3.3160    8.4850 H       135 THR142      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2173 HA         54.0840   -0.7520    9.6580 H       135 THR142      0.0000 BACKBONE|DICT|DIRECT
+   2174 HB         55.9040   -2.7710    8.6940 H       135 THR142      0.0000 DICT
+   2175 HG1        56.5750   -2.9120   10.8900 H       135 THR142      0.0000 DICT|ESSENTIAL
+   2176 HG21       57.6510   -1.3380    9.4430 H       135 THR142      0.0000 DICT
+   2177 HG22       56.7750   -0.5880    8.2870 H       135 THR142      0.0000 DICT
+   2178 HG23       56.5490   -0.2060    9.8590 H       135 THR142      0.0000 DICT
+   2179 N          53.5920    0.2760    7.4680 N.am    136 ASP143      0.0000 BACKBONE|DICT|DIRECT
+   2180 CA         53.5050    0.9970    6.2090 C.3     136 ASP143      0.0000 BACKBONE|DICT|DIRECT
+   2181 C          54.4190    2.2110    6.2470 C.2     136 ASP143      0.0000 BACKBONE|DICT|DIRECT
+   2182 O          54.6940    2.7730    7.3090 O.2     136 ASP143      0.0000 BACKBONE|DICT|DIRECT
+   2183 CB         52.0660    1.4340    5.9160 C.3     136 ASP143      0.0000 DICT
+   2184 CG         51.5170    2.3850    6.9640 C.2     136 ASP143      0.0000 DICT
+   2185 OD1        51.6750    2.1000    8.1680 O.co2   136 ASP143      0.0000 DICT
+   2186 OD2        50.9280    3.4170    6.5850 O.co2   136 ASP143      0.0000 DICT
+   2187 H          53.1260    0.6510    8.2690 H       136 ASP143      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2188 HA         53.8100    0.3920    5.4740 H       136 ASP143      0.0000 BACKBONE|DICT|DIRECT
+   2189 HB2        51.4850    0.6210    5.8860 H       136 ASP143      0.0000 DICT
+   2190 HB3        52.0450    1.8910    5.0270 H       136 ASP143      0.0000 DICT
+   2191 N          54.8890    2.6110    5.0700 N.am    137 PHE144      0.0000 BACKBONE|DICT|DIRECT
+   2192 CA         55.8290    3.7150    4.9660 C.3     137 PHE144      0.0000 BACKBONE|DICT|DIRECT
+   2193 C          55.7860    4.2570    3.5480 C.2     137 PHE144      0.0000 BACKBONE|DICT|DIRECT
+   2194 O          55.3020    3.5980    2.6250 O.2     137 PHE144      0.0000 BACKBONE|DICT|DIRECT
+   2195 CB         57.2510    3.2780    5.3360 C.3     137 PHE144      0.0000 DICT
+   2196 CG         57.7990    2.1880    4.4590 C.ar    137 PHE144      0.0000 DICT
+   2197 CD1        57.5680    0.8550    4.7610 C.ar    137 PHE144      0.0000 DICT
+   2198 CD2        58.5460    2.4940    3.3330 C.ar    137 PHE144      0.0000 DICT
+   2199 CE1        58.0730   -0.1520    3.9560 C.ar    137 PHE144      0.0000 DICT
+   2200 CE2        59.0540    1.4930    2.5230 C.ar    137 PHE144      0.0000 DICT
+   2201 CZ         58.8170    0.1690    2.8340 C.ar    137 PHE144      0.0000 DICT
+   2202 H          54.5900    2.1430    4.2390 H       137 PHE144      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2203 HA         55.5430    4.4390    5.5940 H       137 PHE144      0.0000 BACKBONE|DICT|DIRECT
+   2204 HB2        57.2440    2.9490    6.2800 H       137 PHE144      0.0000 DICT
+   2205 HB3        57.8540    4.0730    5.2640 H       137 PHE144      0.0000 DICT
+   2206 HD1        57.0300    0.6180    5.5700 H       137 PHE144      0.0000 DICT
+   2207 HD2        58.7210    3.4510    3.1020 H       137 PHE144      0.0000 DICT
+   2208 HE1        57.9000   -1.1100    4.1850 H       137 PHE144      0.0000 DICT
+   2209 HE2        59.5920    1.7290    1.7140 H       137 PHE144      0.0000 DICT
+   2210 HZ         59.1820   -0.5560    2.2500 H       137 PHE144      0.0000 DICT
+   2211 N          56.3090    5.4640    3.3900 N.am    138 VAL145      0.0000 BACKBONE|DICT|DIRECT
+   2212 CA         56.3730    6.1160    2.0900 C.3     138 VAL145      0.0000 BACKBONE|DICT|DIRECT
+   2213 C          57.6240    5.6530    1.3560 C.2     138 VAL145      0.0000 BACKBONE|DICT|DIRECT
+   2214 O          58.7100    5.5660    1.9400 O.2     138 VAL145      0.0000 BACKBONE|DICT|DIRECT
+   2215 CB         56.3580    7.6470    2.2600 C.3     138 VAL145      0.0000 DICT
+   2216 CG1        56.7660    8.3400    0.9680 C.3     138 VAL145      0.0000 DICT
+   2217 CG2        54.9830    8.1140    2.7110 C.3     138 VAL145      0.0000 DICT
+   2218 H          56.6720    5.9430    4.1900 H       138 VAL145      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2219 HA         55.5710    5.8460    1.5570 H       138 VAL145      0.0000 BACKBONE|DICT|DIRECT
+   2220 HB         57.0200    7.8900    2.9690 H       138 VAL145      0.0000 DICT
+   2221 HG11       56.7490    9.3310    1.1020 H       138 VAL145      0.0000 DICT
+   2222 HG12       57.6900    8.0540    0.7130 H       138 VAL145      0.0000 DICT
+   2223 HG13       56.1270    8.0910    0.2400 H       138 VAL145      0.0000 DICT
+   2224 HG21       54.9870    9.1080    2.8170 H       138 VAL145      0.0000 DICT
+   2225 HG22       54.3020    7.8550    2.0260 H       138 VAL145      0.0000 DICT
+   2226 HG23       54.7560    7.6860    3.5860 H       138 VAL145      0.0000 DICT
+   2227 N          57.4710    5.3350    0.0740 N.am    139 VAL146      0.0000 BACKBONE|DICT|DIRECT
+   2228 CA         58.6120    5.0950   -0.8060 C.3     139 VAL146      0.0000 BACKBONE|DICT|DIRECT
+   2229 C          58.9320    6.4200   -1.4860 C.2     139 VAL146      0.0000 BACKBONE|DICT|DIRECT
+   2230 O          58.2140    6.8290   -2.4100 O.2     139 VAL146      0.0000 BACKBONE|DICT|DIRECT
+   2231 CB         58.3190    3.9810   -1.8230 C.3     139 VAL146      0.0000 DICT
+   2232 CG1        59.4670    3.8380   -2.8090 C.3     139 VAL146      0.0000 DICT
+   2233 CG2        58.0690    2.6640   -1.1010 C.3     139 VAL146      0.0000 DICT
+   2234 H          56.5460    5.2580   -0.2990 H       139 VAL146      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2235 HA         59.3960    4.8230   -0.2480 H       139 VAL146      0.0000 BACKBONE|DICT|DIRECT
+   2236 HB         57.4930    4.2250   -2.3310 H       139 VAL146      0.0000 DICT
+   2237 HG11       59.2570    3.1090   -3.4610 H       139 VAL146      0.0000 DICT
+   2238 HG12       59.5930    4.6990   -3.3010 H       139 VAL146      0.0000 DICT
+   2239 HG13       60.3060    3.6110   -2.3140 H       139 VAL146      0.0000 DICT
+   2240 HG21       57.8800    1.9470   -1.7720 H       139 VAL146      0.0000 DICT
+   2241 HG22       58.8790    2.4170   -0.5680 H       139 VAL146      0.0000 DICT
+   2242 HG23       57.2850    2.7630   -0.4890 H       139 VAL146      0.0000 DICT
+   2243 N          59.9840    7.1270   -1.0590 N.am    140 PRO147      0.0000 BACKBONE|DICT|DIRECT
+   2244 CA         60.1750    8.5090   -1.5310 C.3     140 PRO147      0.0000 BACKBONE|DICT|DIRECT
+   2245 C          60.4870    8.6170   -3.0100 C.2     140 PRO147      0.0000 BACKBONE|DICT|DIRECT
+   2246 O          60.2060    9.6600   -3.6110 O.2     140 PRO147      0.0000 BACKBONE|DICT|DIRECT
+   2247 CB         61.3460    9.0120   -0.6740 C.3     140 PRO147      0.0000 DICT
+   2248 CG         62.0880    7.7800   -0.3010 C.3     140 PRO147      0.0000 DICT
+   2249 CD         61.0430    6.7090   -0.1260 C.3     140 PRO147      0.0000 DICT
+   2250 HA         59.3570    9.0460   -1.3240 H       140 PRO147      0.0000 BACKBONE|DICT|DIRECT
+   2251 HB2        61.9290    9.6310   -1.2000 H       140 PRO147      0.0000 DICT
+   2252 HB3        61.0110    9.4830    0.1420 H       140 PRO147      0.0000 DICT
+   2253 HG2        62.7290    7.5260   -1.0260 H       140 PRO147      0.0000 DICT
+   2254 HG3        62.5890    7.9200    0.5530 H       140 PRO147      0.0000 DICT
+   2255 HD2        61.4050    5.8100   -0.3720 H       140 PRO147      0.0000 DICT
+   2256 HD3        60.7050    6.6860    0.8150 H       140 PRO147      0.0000 DICT
+   2257 N          61.0600    7.5840   -3.6180 N.am    141 GLY148      0.0000 BACKBONE|DICT|DIRECT
+   2258 CA         61.3870    7.6320   -5.0220 C.3     141 GLY148      0.0000 BACKBONE|DICT|DIRECT
+   2259 C          61.8340    6.2930   -5.5680 C.2     141 GLY148      0.0000 BACKBONE|DICT|DIRECT
+   2260 O          61.7060    5.2530   -4.9130 O.2     141 GLY148      0.0000 BACKBONE|DICT|DIRECT
+   2261 H          61.2680    6.7590   -3.0930 H       141 GLY148      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2262 HA2        62.1250    8.2940   -5.1550 H       141 GLY148      0.0000 BACKBONE|DICT|DIRECT
+   2263 HA3        60.5770    7.9290   -5.5280 H       141 GLY148      0.0000 DICT
+   2264 N          62.3670    6.3020   -6.7890 N.am    142 PRO149      0.0000 BACKBONE|DICT|DIRECT
+   2265 CA         62.7940    5.0520   -7.4300 C.3     142 PRO149      0.0000 BACKBONE|DICT|DIRECT
+   2266 C          63.7270    4.2440   -6.5410 C.2     142 PRO149      0.0000 BACKBONE|DICT|DIRECT
+   2267 O          64.5550    4.7920   -5.8100 O.2     142 PRO149      0.0000 BACKBONE|DICT|DIRECT
+   2268 CB         63.5030    5.5350   -8.6980 C.3     142 PRO149      0.0000 DICT
+   2269 CG         62.8420    6.8350   -9.0110 C.3     142 PRO149      0.0000 DICT
+   2270 CD         62.5200    7.4630   -7.6810 C.3     142 PRO149      0.0000 DICT
+   2271 HA         61.9950    4.5030   -7.6740 H       142 PRO149      0.0000 BACKBONE|DICT|DIRECT
+   2272 HB2        64.4800    5.6650   -8.5310 H       142 PRO149      0.0000 DICT
+   2273 HB3        63.3760    4.8830   -9.4460 H       142 PRO149      0.0000 DICT
+   2274 HG2        63.4600    7.4230   -9.5330 H       142 PRO149      0.0000 DICT
+   2275 HG3        62.0050    6.6820   -9.5360 H       142 PRO149      0.0000 DICT
+   2276 HD2        63.2650    8.0550   -7.3740 H       142 PRO149      0.0000 DICT
+   2277 HD3        61.6730    7.9920   -7.7300 H       142 PRO149      0.0000 DICT
+   2278 N          63.5760    2.9320   -6.6050 N.am    143 GLY150      0.0000 BACKBONE|DICT|DIRECT
+   2279 CA         64.3420    2.0410   -5.7610 C.3     143 GLY150      0.0000 BACKBONE|DICT|DIRECT
+   2280 C          63.6200    0.7220   -5.5890 C.2     143 GLY150      0.0000 BACKBONE|DICT|DIRECT
+   2281 O          62.5210    0.5120   -6.1020 O.2     143 GLY150      0.0000 BACKBONE|DICT|DIRECT
+   2282 H          62.9170    2.5470   -7.2510 H       143 GLY150      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2283 HA2        64.4700    2.4660   -4.8650 H       143 GLY150      0.0000 BACKBONE|DICT|DIRECT
+   2284 HA3        65.2340    1.8750   -6.1810 H       143 GLY150      0.0000 DICT
+   2285 N          64.2640   -0.1600   -4.8340 N.am    144 LYS151      0.0000 BACKBONE|DICT|DIRECT
+   2286 CA         63.8140   -1.5320   -4.6550 C.3     144 LYS151      0.0000 BACKBONE|DICT|DIRECT
+   2287 C          63.2040   -1.7130   -3.2710 C.2     144 LYS151      0.0000 BACKBONE|DICT|DIRECT
+   2288 O          63.8350   -1.3820   -2.2610 O.2     144 LYS151      0.0000 BACKBONE|DICT|DIRECT
+   2289 CB         64.9820   -2.5020   -4.8450 C.3     144 LYS151      0.0000 DICT
+   2290 CG         64.6030   -3.8080   -5.4950 C.3     144 LYS151      0.0000 DICT
+   2291 CD         65.8280   -4.6490   -5.7990 C.3     144 LYS151      0.0000 DICT
+   2292 CE         65.7900   -5.1750   -7.2260 C.3     144 LYS151      0.0000 DICT
+   2293 NZ         66.9640   -6.0450   -7.5230 N.4     144 LYS151      0.0000 DICT
+   2294 H          65.0980    0.1330   -4.3660 H       144 LYS151      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2295 HA         63.1160   -1.7330   -5.3420 H       144 LYS151      0.0000 BACKBONE|DICT|DIRECT
+   2296 HB2        65.3730   -2.7010   -3.9470 H       144 LYS151      0.0000 DICT
+   2297 HB3        65.6700   -2.0560   -5.4170 H       144 LYS151      0.0000 DICT
+   2298 HG2        64.1180   -3.6180   -6.3490 H       144 LYS151      0.0000 DICT
+   2299 HG3        64.0040   -4.3170   -4.8770 H       144 LYS151      0.0000 DICT
+   2300 HD2        65.8580   -5.4230   -5.1660 H       144 LYS151      0.0000 DICT
+   2301 HD3        66.6470   -4.0880   -5.6790 H       144 LYS151      0.0000 DICT
+   2302 HE2        65.7930   -4.4000   -7.8580 H       144 LYS151      0.0000 DICT
+   2303 HE3        64.9520   -5.7060   -7.3540 H       144 LYS151      0.0000 DICT
+   2304 HZ1        66.9060   -6.3720   -8.4660 H       144 LYS151      0.0000 DICT|ESSENTIAL
+   2305 HZ2        67.8070   -5.5200   -7.4030 H       144 LYS151      0.0000 DICT|ESSENTIAL
+   2306 HZ3        66.9660   -6.8260   -6.8990 H       144 LYS151      0.0000 DICT|ESSENTIAL
+   2307 N          61.9850   -2.2420   -3.2260 N.am    145 VAL152      0.0000 BACKBONE|DICT|DIRECT
+   2308 CA         61.3350   -2.6260   -1.9770 C.3     145 VAL152      0.0000 BACKBONE|DICT|DIRECT
+   2309 C          61.2990   -4.1460   -1.9230 C.2     145 VAL152      0.0000 BACKBONE|DICT|DIRECT
+   2310 O          60.6830   -4.7930   -2.7800 O.2     145 VAL152      0.0000 BACKBONE|DICT|DIRECT
+   2311 CB         59.9220   -2.0330   -1.8540 C.3     145 VAL152      0.0000 DICT
+   2312 CG1        59.2250   -2.5890   -0.6220 C.3     145 VAL152      0.0000 DICT
+   2313 CG2        59.9870   -0.5150   -1.7830 C.3     145 VAL152      0.0000 DICT
+   2314 H          61.4920   -2.3830   -4.0850 H       145 VAL152      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2315 HA         61.8880   -2.2930   -1.2140 H       145 VAL152      0.0000 BACKBONE|DICT|DIRECT
+   2316 HB         59.3950   -2.2930   -2.6630 H       145 VAL152      0.0000 DICT
+   2317 HG11       58.3080   -2.1970   -0.5520 H       145 VAL152      0.0000 DICT
+   2318 HG12       59.1570   -3.5840   -0.6980 H       145 VAL152      0.0000 DICT
+   2319 HG13       59.7520   -2.3520    0.1940 H       145 VAL152      0.0000 DICT
+   2320 HG21       59.0610   -0.1450   -1.7030 H       145 VAL152      0.0000 DICT
+   2321 HG22       60.5250   -0.2410   -0.9860 H       145 VAL152      0.0000 DICT
+   2322 HG23       60.4170   -0.1610   -2.6130 H       145 VAL152      0.0000 DICT
+   2323 N          61.9680   -4.7150   -0.9250 N.am    146 GLU153      0.0000 BACKBONE|DICT|DIRECT
+   2324 CA         62.0250   -6.1540   -0.7290 C.3     146 GLU153      0.0000 BACKBONE|DICT|DIRECT
+   2325 C          61.6230   -6.4890    0.6990 C.2     146 GLU153      0.0000 BACKBONE|DICT|DIRECT
+   2326 O          61.8130   -5.6900    1.6190 O.2     146 GLU153      0.0000 BACKBONE|DICT|DIRECT
+   2327 CB         63.4290   -6.7100   -1.0180 C.3     146 GLU153      0.0000 DICT
+   2328 CG         64.0030   -6.2690   -2.3510 C.3     146 GLU153      0.0000 DICT
+   2329 CD         65.5050   -6.4500   -2.4290 C.2     146 GLU153      0.0000 DICT
+   2330 OE1        65.9560   -7.4340   -3.0510 O.co2   146 GLU153      0.0000 DICT
+   2331 OE2        66.2350   -5.6110   -1.8610 O.co2   146 GLU153      0.0000 DICT
+   2332 H          62.4540   -4.1260   -0.2800 H       146 GLU153      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2333 HA         61.3750   -6.5870   -1.3540 H       146 GLU153      0.0000 BACKBONE|DICT|DIRECT
+   2334 HB2        63.3790   -7.7090   -1.0120 H       146 GLU153      0.0000 DICT
+   2335 HB3        64.0450   -6.4020   -0.2930 H       146 GLU153      0.0000 DICT
+   2336 HG2        63.7900   -5.3010   -2.4870 H       146 GLU153      0.0000 DICT
+   2337 HG3        63.5770   -6.8090   -3.0770 H       146 GLU153      0.0000 DICT
+   2338 N          61.0620   -7.6790    0.8730 N.am    147 ILE154      0.0000 BACKBONE|DICT|DIRECT
+   2339 CA         60.7150   -8.2040    2.1850 C.3     147 ILE154      0.0000 BACKBONE|DICT|DIRECT
+   2340 C          61.5170   -9.4800    2.3970 C.2     147 ILE154      0.0000 BACKBONE|DICT|DIRECT
+   2341 O          61.6700  -10.2890    1.4750 O.2     147 ILE154      0.0000 BACKBONE|DICT|DIRECT
+   2342 CB         59.1950   -8.4460    2.3210 C.3     147 ILE154      0.0000 DICT
+   2343 CG1        58.8410   -8.9120    3.7350 C.3     147 ILE154      0.0000 DICT
+   2344 CG2        58.6950   -9.4290    1.2620 C.3     147 ILE154      0.0000 DICT
+   2345 CD1        57.3600   -8.8310    4.0390 C.3     147 ILE154      0.0000 DICT
+   2346 H          60.8690   -8.2390    0.0670 H       147 ILE154      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2347 HA         60.9930   -7.5370    2.8760 H       147 ILE154      0.0000 BACKBONE|DICT|DIRECT
+   2348 HB         58.7340   -7.5720    2.1650 H       147 ILE154      0.0000 DICT
+   2349 HG12       59.3310   -8.3380    4.3910 H       147 ILE154      0.0000 DICT
+   2350 HG13       59.1350   -9.8620    3.8390 H       147 ILE154      0.0000 DICT
+   2351 HG21       57.7110   -9.5670    1.3730 H       147 ILE154      0.0000 DICT
+   2352 HG22       58.8790   -9.0600    0.3510 H       147 ILE154      0.0000 DICT
+   2353 HG23       59.1680  -10.3030    1.3690 H       147 ILE154      0.0000 DICT
+   2354 HD11       57.1940   -9.1470    4.9730 H       147 ILE154      0.0000 DICT
+   2355 HD12       57.0520   -7.8840    3.9480 H       147 ILE154      0.0000 DICT
+   2356 HD13       56.8560   -9.4080    3.3970 H       147 ILE154      0.0000 DICT
+   2357 N          62.0560   -9.6450    3.6010 N.am    148 THR155      0.0000 BACKBONE|DICT|DIRECT
+   2358 CA         63.0690  -10.6610    3.8400 C.3     148 THR155      0.0000 BACKBONE|DICT|DIRECT
+   2359 C          62.7790  -11.4060    5.1330 C.2     148 THR155      0.0000 BACKBONE|DICT|DIRECT
+   2360 O          62.3520  -10.8080    6.1230 O.2     148 THR155      0.0000 BACKBONE|DICT|DIRECT
+   2361 CB         64.4670  -10.0250    3.8860 C.3     148 THR155      0.0000 DICT
+   2362 OG1        64.7810   -9.4880    2.5950 O.3     148 THR155      0.0000 DICT
+   2363 CG2        65.5290  -11.0470    4.2610 C.3     148 THR155      0.0000 DICT
+   2364 H          61.7600   -9.0600    4.3560 H       148 THR155      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2365 HA         63.0440  -11.3160    3.0850 H       148 THR155      0.0000 BACKBONE|DICT|DIRECT
+   2366 HB         64.4700   -9.2860    4.5590 H       148 THR155      0.0000 DICT
+   2367 HG1        65.2370  -10.1870    2.0450 H       148 THR155      0.0000 DICT|ESSENTIAL
+   2368 HG21       66.4250  -10.6040    4.2820 H       148 THR155      0.0000 DICT
+   2369 HG22       65.3230  -11.4260    5.1630 H       148 THR155      0.0000 DICT
+   2370 HG23       65.5370  -11.7830    3.5840 H       148 THR155      0.0000 DICT
+   2371 N          63.0030  -12.7180    5.1070 N.am    149 TYR156      0.0000 BACKBONE|DICT|DIRECT
+   2372 CA         62.9100  -13.5680    6.2840 C.3     149 TYR156      0.0000 BACKBONE|DICT|DIRECT
+   2373 C          64.2810  -14.1600    6.5770 C.2     149 TYR156      0.0000 BACKBONE|DICT|DIRECT
+   2374 O          64.9260  -14.7180    5.6830 O.2     149 TYR156      0.0000 BACKBONE|DICT|DIRECT
+   2375 CB         61.8830  -14.6860    6.0850 C.3     149 TYR156      0.0000 DICT
+   2376 CG         61.9090  -15.7410    7.1700 C.ar    149 TYR156      0.0000 DICT
+   2377 CD1        61.5410  -15.4350    8.4750 C.ar    149 TYR156      0.0000 DICT
+   2378 CD2        62.2980  -17.0450    6.8870 C.ar    149 TYR156      0.0000 DICT
+   2379 CE1        61.5620  -16.3970    9.4680 C.ar    149 TYR156      0.0000 DICT
+   2380 CE2        62.3220  -18.0150    7.8740 C.ar    149 TYR156      0.0000 DICT
+   2381 CZ         61.9520  -17.6860    9.1620 C.ar    149 TYR156      0.0000 DICT
+   2382 OH         61.9730  -18.6480   10.1450 O.3     149 TYR156      0.0000 DICT
+   2383 H          63.2480  -13.1410    4.2340 H       149 TYR156      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2384 HA         62.6290  -13.0080    7.0630 H       149 TYR156      0.0000 BACKBONE|DICT|DIRECT
+   2385 HB2        62.0670  -15.1310    5.2090 H       149 TYR156      0.0000 DICT
+   2386 HB3        60.9710  -14.2760    6.0660 H       149 TYR156      0.0000 DICT
+   2387 HD1        61.2560  -14.5030    8.7000 H       149 TYR156      0.0000 DICT
+   2388 HD2        62.5650  -17.2870    5.9540 H       149 TYR156      0.0000 DICT
+   2389 HE1        61.2960  -16.1610   10.4030 H       149 TYR156      0.0000 DICT
+   2390 HE2        62.6060  -18.9490    7.6550 H       149 TYR156      0.0000 DICT
+   2391 HH         62.2550  -19.5820    9.9250 H       149 TYR156      0.0000 DICT|ESSENTIAL
+   2392 N          64.7230  -14.0280    7.8210 N.am    150 THR157      0.0000 BACKBONE|DICT|DIRECT
+   2393 CA         65.9800  -14.6140    8.2780 C.3     150 THR157      0.0000 BACKBONE|DICT|DIRECT
+   2394 C          65.6770  -15.4460    9.5140 C.2     150 THR157      0.0000 BACKBONE|DICT|DIRECT
+   2395 O          65.3890  -14.8700   10.5840 O.2     150 THR157      0.0000 BACKBONE|DICT|DIRECT
+   2396 CB         67.0200  -13.5400    8.5890 C.3     150 THR157      0.0000 DICT
+   2397 OG1        67.1570  -12.6600    7.4660 O.3     150 THR157      0.0000 DICT
+   2398 CG2        68.3680  -14.1750    8.8910 C.3     150 THR157      0.0000 DICT
+   2399 H          64.1730  -13.5060    8.4720 H       150 THR157      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2400 HA         66.3370  -15.2140    7.5620 H       150 THR157      0.0000 BACKBONE|DICT|DIRECT
+   2401 HB         66.7200  -13.0130    9.3840 H       150 THR157      0.0000 DICT
+   2402 HG1        66.5120  -11.9010    7.5560 H       150 THR157      0.0000 DICT|ESSENTIAL
+   2403 HG21       69.0360  -13.4590    9.0920 H       150 THR157      0.0000 DICT
+   2404 HG22       68.2810  -14.7810    9.6810 H       150 THR157      0.0000 DICT
+   2405 HG23       68.6730  -14.7020    8.0980 H       150 THR157      0.0000 DICT
+   2406 N          65.6970  -16.7760    9.4190 N.am    151 PRO158      0.0000 BACKBONE|DICT|DIRECT
+   2407 CA         65.4640  -17.5980   10.6110 C.3     151 PRO158      0.0000 BACKBONE|DICT|DIRECT
+   2408 C          66.5470  -17.3600   11.6500 C.2     151 PRO158      0.0000 BACKBONE|DICT|DIRECT
+   2409 O          67.7010  -17.0770   11.3210 O.2     151 PRO158      0.0000 BACKBONE|DICT|DIRECT
+   2410 CB         65.5050  -19.0330   10.0720 C.3     151 PRO158      0.0000 DICT
+   2411 CG         66.3000  -18.9340    8.8000 C.3     151 PRO158      0.0000 DICT
+   2412 CD         65.9460  -17.5970    8.2210 C.3     151 PRO158      0.0000 DICT
+   2413 HA         64.5640  -17.3990   10.9980 H       151 PRO158      0.0000 BACKBONE|DICT|DIRECT
+   2414 HB2        65.9560  -19.6430   10.7240 H       151 PRO158      0.0000 DICT
+   2415 HB3        64.5810  -19.3670    9.8860 H       151 PRO158      0.0000 DICT
+   2416 HG2        67.2800  -18.9840    8.9940 H       151 PRO158      0.0000 DICT
+   2417 HG3        66.0470  -19.6680    8.1700 H       151 PRO158      0.0000 DICT
+   2418 HD2        66.7020  -17.2270    7.6820 H       151 PRO158      0.0000 DICT
+   2419 HD3        65.1280  -17.6580    7.6500 H       151 PRO158      0.0000 DICT
+   2420 N          66.1580  -17.4710   12.9220 N.am    152 SER159      0.0000 BACKBONE|DICT|DIRECT
+   2421 CA         67.0720  -17.1380   14.0090 C.3     152 SER159      0.0000 BACKBONE|DICT|DIRECT
+   2422 C          68.2670  -18.0820   14.0820 C.2     152 SER159      0.0000 BACKBONE|DICT|DIRECT
+   2423 O          69.2910  -17.7080   14.6640 O.2     152 SER159      0.0000 BACKBONE|DICT|DIRECT
+   2424 CB         66.3200  -17.1210   15.3430 C.3     152 SER159      0.0000 DICT
+   2425 OG         65.4650  -18.2430   15.4670 O.3     152 SER159      0.0000 DICT
+   2426 H          65.2320  -17.7850   13.1320 H       152 SER159      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2427 HA         67.4210  -16.2160   13.8430 H       152 SER159      0.0000 BACKBONE|DICT|DIRECT
+   2428 HB2        65.7720  -16.2860   15.3970 H       152 SER159      0.0000 DICT
+   2429 HB3        66.9840  -17.1330   16.0910 H       152 SER159      0.0000 DICT
+   2430 HG         64.9890  -18.2040   16.3460 H       152 SER159      0.0000 DICT|ESSENTIAL
+   2431 N          68.1760  -19.2800   13.4970 N.am    153 ASP160      0.0000 BACKBONE|DICT|DIRECT
+   2432 CA         69.3330  -20.1690   13.4320 C.3     153 ASP160      0.0000 BACKBONE|DICT|DIRECT
+   2433 C          70.3180  -19.7860   12.3310 C.2     153 ASP160      0.0000 BACKBONE|DICT|DIRECT
+   2434 O          71.3140  -20.4930   12.1430 O.2     153 ASP160      0.0000 BACKBONE|DICT|DIRECT
+   2435 CB         68.8900  -21.6290   13.2520 C.3     153 ASP160      0.0000 DICT
+   2436 CG         68.1750  -21.8870   11.9280 C.2     153 ASP160      0.0000 DICT
+   2437 OD1        68.0830  -20.9770   11.0760 O.co2   153 ASP160      0.0000 DICT
+   2438 OD2        67.7080  -23.0290   11.7350 O.co2   153 ASP160      0.0000 DICT
+   2439 H          67.3060  -19.5710   13.0990 H       153 ASP160      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2440 HA         69.8150  -20.1040   14.3060 H       153 ASP160      0.0000 BACKBONE|DICT|DIRECT
+   2441 HB2        68.2690  -21.8660   13.9990 H       153 ASP160      0.0000 DICT
+   2442 HB3        69.7000  -22.2140   13.2940 H       153 ASP160      0.0000 DICT
+   2443 N          70.0540  -18.7080   11.5910 N.am    154 GLY161      0.0000 BACKBONE|DICT|DIRECT
+   2444 CA         70.9770  -18.1670   10.6130 C.3     154 GLY161      0.0000 BACKBONE|DICT|DIRECT
+   2445 C          71.2780  -19.0400    9.4150 C.2     154 GLY161      0.0000 BACKBONE|DICT|DIRECT
+   2446 O          72.1730  -18.6980    8.6360 O.2     154 GLY161      0.0000 BACKBONE|DICT|DIRECT
+   2447 H          69.1740  -18.2500   11.7170 H       154 GLY161      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2448 HA2        71.8420  -17.9830   11.0800 H       154 GLY161      0.0000 BACKBONE|DICT|DIRECT
+   2449 HA3        70.5920  -17.3080   10.2740 H       154 GLY161      0.0000 DICT
+   2450 N          70.5570  -20.1460    9.2260 N.am    155 THR162      0.0000 BACKBONE|DICT|DIRECT
+   2451 CA         70.9090  -21.0980    8.1790 C.3     155 THR162      0.0000 BACKBONE|DICT|DIRECT
+   2452 C          70.4650  -20.6690    6.7850 C.2     155 THR162      0.0000 BACKBONE|DICT|DIRECT
+   2453 O          70.8360  -21.3360    5.8120 O.2     155 THR162      0.0000 BACKBONE|DICT|DIRECT
+   2454 CB         70.3190  -22.4800    8.4830 C.3     155 THR162      0.0000 DICT
+   2455 OG1        68.8870  -22.4090    8.4640 O.3     155 THR162      0.0000 DICT
+   2456 CG2        70.7910  -22.9750    9.8420 C.3     155 THR162      0.0000 DICT
+   2457 H          69.7650  -20.3250    9.8100 H       155 THR162      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2458 HA         71.9050  -21.1860    8.1690 H       155 THR162      0.0000 BACKBONE|DICT|DIRECT
+   2459 HB         70.6210  -23.1240    7.7800 H       155 THR162      0.0000 DICT
+   2460 HG1        68.5760  -21.7570    9.1550 H       155 THR162      0.0000 DICT|ESSENTIAL
+   2461 HG21       70.3970  -23.8760   10.0240 H       155 THR162      0.0000 DICT
+   2462 HG22       71.7890  -23.0410    9.8450 H       155 THR162      0.0000 DICT
+   2463 HG23       70.4970  -22.3340   10.5510 H       155 THR162      0.0000 DICT
+   2464 N          69.6900  -19.5950    6.6520 N.am    156 GLN163      0.0000 BACKBONE|DICT|DIRECT
+   2465 CA         69.2900  -19.1450    5.3250 C.3     156 GLN163      0.0000 BACKBONE|DICT|DIRECT
+   2466 C          68.7820  -17.7110    5.3970 C.2     156 GLN163      0.0000 BACKBONE|DICT|DIRECT
+   2467 O          68.6470  -17.1250    6.4740 O.2     156 GLN163      0.0000 BACKBONE|DICT|DIRECT
+   2468 CB         68.2300  -20.0680    4.7120 C.3     156 GLN163      0.0000 DICT
+   2469 CG         66.9340  -20.1700    5.4850 C.3     156 GLN163      0.0000 DICT
+   2470 CD         65.9280  -21.0790    4.8000 C.2     156 GLN163      0.0000 DICT
+   2471 OE1        65.0890  -20.6210    4.0260 O.2     156 GLN163      0.0000 DICT
+   2472 NE2        66.0130  -22.3770    5.0780 N.am    156 GLN163      0.0000 DICT
+   2473 H          69.3820  -19.0970    7.4630 H       156 GLN163      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2474 HA         70.0970  -19.1610    4.7340 H       156 GLN163      0.0000 BACKBONE|DICT|DIRECT
+   2475 HB2        68.6220  -20.9860    4.6440 H       156 GLN163      0.0000 DICT
+   2476 HB3        68.0170  -19.7280    3.7960 H       156 GLN163      0.0000 DICT
+   2477 HG2        66.5370  -19.2560    5.5700 H       156 GLN163      0.0000 DICT
+   2478 HG3        67.1300  -20.5340    6.3950 H       156 GLN163      0.0000 DICT
+   2479 HE21       66.7110  -22.7080    5.7140 H       156 GLN163      0.0000 DICT|ESSENTIAL
+   2480 HE22       65.3790  -23.0220    4.6510 H       156 GLN163      0.0000 DICT|ESSENTIAL
+   2481 N          68.5200  -17.1510    4.2160 N.am    157 LYS164      0.0000 BACKBONE|DICT|DIRECT
+   2482 CA         67.9350  -15.8210    4.0860 C.3     157 LYS164      0.0000 BACKBONE|DICT|DIRECT
+   2483 C          67.1400  -15.7810    2.7910 C.2     157 LYS164      0.0000 BACKBONE|DICT|DIRECT
+   2484 O          67.6910  -16.0350    1.7150 O.2     157 LYS164      0.0000 BACKBONE|DICT|DIRECT
+   2485 CB         69.0090  -14.7330    4.0940 C.3     157 LYS164      0.0000 DICT
+   2486 CG         68.4490  -13.3290    3.9280 C.3     157 LYS164      0.0000 DICT
+   2487 CD         69.5440  -12.3300    3.6080 C.3     157 LYS164      0.0000 DICT
+   2488 CE         69.2500  -10.9720    4.2270 C.3     157 LYS164      0.0000 DICT
+   2489 NZ         69.6850  -10.9090    5.6530 N.4     157 LYS164      0.0000 DICT
+   2490 H          68.7330  -17.6640    3.3850 H       157 LYS164      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2491 HA         67.3120  -15.6660    4.8530 H       157 LYS164      0.0000 BACKBONE|DICT|DIRECT
+   2492 HB2        69.6460  -14.9110    3.3440 H       157 LYS164      0.0000 DICT
+   2493 HB3        69.4990  -14.7780    4.9650 H       157 LYS164      0.0000 DICT
+   2494 HG2        67.9980  -13.0560    4.7780 H       157 LYS164      0.0000 DICT
+   2495 HG3        67.7820  -13.3310    3.1830 H       157 LYS164      0.0000 DICT
+   2496 HD2        69.6120  -12.2280    2.6160 H       157 LYS164      0.0000 DICT
+   2497 HD3        70.4120  -12.6710    3.9680 H       157 LYS164      0.0000 DICT
+   2498 HE2        68.2660  -10.8010    4.1810 H       157 LYS164      0.0000 DICT
+   2499 HE3        69.7350  -10.2680    3.7090 H       157 LYS164      0.0000 DICT
+   2500 HZ1        69.9420   -9.9700    5.8820 H       157 LYS164      0.0000 DICT|ESSENTIAL
+   2501 HZ2        68.9340  -11.2030    6.2440 H       157 LYS164      0.0000 DICT|ESSENTIAL
+   2502 HZ3        70.4710  -11.5120    5.7890 H       157 LYS164      0.0000 DICT|ESSENTIAL
+   2503 N          65.8530  -15.4670    2.8930 N.am    158 VAL165      0.0000 BACKBONE|DICT|DIRECT
+   2504 CA         64.9520  -15.4290    1.7480 C.3     158 VAL165      0.0000 BACKBONE|DICT|DIRECT
+   2505 C          64.5510  -13.9800    1.5180 C.2     158 VAL165      0.0000 BACKBONE|DICT|DIRECT
+   2506 O          64.0220  -13.3240    2.4240 O.2     158 VAL165      0.0000 BACKBONE|DICT|DIRECT
+   2507 CB         63.7140  -16.3120    1.9680 C.3     158 VAL165      0.0000 DICT
+   2508 CG1        63.0450  -16.6180    0.6420 C.3     158 VAL165      0.0000 DICT
+   2509 CG2        64.0920  -17.5940    2.6940 C.3     158 VAL165      0.0000 DICT
+   2510 H          65.4860  -15.2470    3.7970 H       158 VAL165      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2511 HA         65.4430  -15.7590    0.9420 H       158 VAL165      0.0000 BACKBONE|DICT|DIRECT
+   2512 HB         63.0660  -15.8080    2.5380 H       158 VAL165      0.0000 DICT
+   2513 HG11       62.2420  -17.1930    0.7990 H       158 VAL165      0.0000 DICT
+   2514 HG12       62.7640  -15.7630    0.2060 H       158 VAL165      0.0000 DICT
+   2515 HG13       63.6890  -17.1000    0.0470 H       158 VAL165      0.0000 DICT
+   2516 HG21       63.2750  -18.1550    2.8280 H       158 VAL165      0.0000 DICT
+   2517 HG22       64.7590  -18.1020    2.1490 H       158 VAL165      0.0000 DICT
+   2518 HG23       64.4910  -17.3690    3.5830 H       158 VAL165      0.0000 DICT
+   2519 N          64.8000  -13.4810    0.3120 N.am    159 THR166      0.0000 BACKBONE|DICT|DIRECT
+   2520 CA         64.4320  -12.1260   -0.0700 C.3     159 THR166      0.0000 BACKBONE|DICT|DIRECT
+   2521 C          63.4140  -12.1920   -1.1970 C.2     159 THR166      0.0000 BACKBONE|DICT|DIRECT
+   2522 O          63.6420  -12.8690   -2.2030 O.2     159 THR166      0.0000 BACKBONE|DICT|DIRECT
+   2523 CB         65.6550  -11.3200   -0.5090 C.3     159 THR166      0.0000 DICT
+   2524 OG1        66.5960  -11.2590    0.5690 O.3     159 THR166      0.0000 DICT
+   2525 CG2        65.2490   -9.9060   -0.9000 C.3     159 THR166      0.0000 DICT
+   2526 H          65.2590  -14.0610   -0.3610 H       159 THR166      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2527 HA         64.0130  -11.6720    0.7160 H       159 THR166      0.0000 BACKBONE|DICT|DIRECT
+   2528 HB         66.0820  -11.7690   -1.2940 H       159 THR166      0.0000 DICT
+   2529 HG1        67.3960  -10.7320    0.2830 H       159 THR166      0.0000 DICT|ESSENTIAL
+   2530 HG21       66.0590   -9.3930   -1.1840 H       159 THR166      0.0000 DICT
+   2531 HG22       64.5960   -9.9440   -1.6570 H       159 THR166      0.0000 DICT
+   2532 HG23       64.8250   -9.4520   -0.1160 H       159 THR166      0.0000 DICT
+   2533 N          62.2930  -11.4980   -1.0220 N.am    160 TYR167      0.0000 BACKBONE|DICT|DIRECT
+   2534 CA         61.2450  -11.4300   -2.0300 C.3     160 TYR167      0.0000 BACKBONE|DICT|DIRECT
+   2535 C          61.1150   -9.9960   -2.5140 C.2     160 TYR167      0.0000 BACKBONE|DICT|DIRECT
+   2536 O          60.9830   -9.0740   -1.7030 O.2     160 TYR167      0.0000 BACKBONE|DICT|DIRECT
+   2537 CB         59.9000  -11.9060   -1.4780 C.3     160 TYR167      0.0000 DICT
+   2538 CG         59.8720  -13.3300   -0.9760 C.ar    160 TYR167      0.0000 DICT
+   2539 CD1        59.6740  -14.3920   -1.8480 C.ar    160 TYR167      0.0000 DICT
+   2540 CD2        60.0140  -13.6110    0.3760 C.ar    160 TYR167      0.0000 DICT
+   2541 CE1        59.6380  -15.6940   -1.3900 C.ar    160 TYR167      0.0000 DICT
+   2542 CE2        59.9780  -14.9100    0.8450 C.ar    160 TYR167      0.0000 DICT
+   2543 CZ         59.7880  -15.9470   -0.0430 C.ar    160 TYR167      0.0000 DICT
+   2544 OH         59.7530  -17.2420    0.4210 O.3     160 TYR167      0.0000 DICT
+   2545 H          62.1650  -11.0030   -0.1630 H       160 TYR167      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2546 HA         61.5010  -12.0100   -2.8030 H       160 TYR167      0.0000 BACKBONE|DICT|DIRECT
+   2547 HB2        59.2210  -11.8230   -2.2070 H       160 TYR167      0.0000 DICT
+   2548 HB3        59.6490  -11.3060   -0.7180 H       160 TYR167      0.0000 DICT
+   2549 HD1        59.5550  -14.2110   -2.8240 H       160 TYR167      0.0000 DICT
+   2550 HD2        60.1450  -12.8590    1.0220 H       160 TYR167      0.0000 DICT
+   2551 HE1        59.5040  -16.4490   -2.0320 H       160 TYR167      0.0000 DICT
+   2552 HE2        60.0890  -15.0970    1.8210 H       160 TYR167      0.0000 DICT
+   2553 HH         59.8620  -17.4260    1.3980 H       160 TYR167      0.0000 DICT|ESSENTIAL
+   2554 N          61.1480   -9.8070   -3.8280 N.am    161 LEU168      0.0000 BACKBONE|DICT|DIRECT
+   2555 CA         60.8990   -8.4870   -4.3880 C.3     161 LEU168      0.0000 BACKBONE|DICT|DIRECT
+   2556 C          59.4310   -8.1290   -4.2010 C.2     161 LEU168      0.0000 BACKBONE|DICT|DIRECT
+   2557 O          58.5440   -8.8610   -4.6540 O.2     161 LEU168      0.0000 BACKBONE|DICT|DIRECT
+   2558 CB         61.2750   -8.4500   -5.8670 C.3     161 LEU168      0.0000 DICT
+   2559 CG         61.0380   -7.0900   -6.5310 C.3     161 LEU168      0.0000 DICT
+   2560 CD1        61.9240   -6.0480   -5.8870 C.3     161 LEU168      0.0000 DICT
+   2561 CD2        61.2670   -7.1410   -8.0360 C.3     161 LEU168      0.0000 DICT
+   2562 H          61.3450  -10.5760   -4.4360 H       161 LEU168      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2563 HA         61.4580   -7.8190   -3.8970 H       161 LEU168      0.0000 BACKBONE|DICT|DIRECT
+   2564 HB2        60.7290   -9.1350   -6.3480 H       161 LEU168      0.0000 DICT
+   2565 HB3        62.2450   -8.6770   -5.9520 H       161 LEU168      0.0000 DICT
+   2566 HG         60.0860   -6.8290   -6.3710 H       161 LEU168      0.0000 DICT
+   2567 HD11       61.7670   -5.1620   -6.3230 H       161 LEU168      0.0000 DICT
+   2568 HD12       61.7090   -5.9830   -4.9130 H       161 LEU168      0.0000 DICT
+   2569 HD13       62.8830   -6.3100   -6.0000 H       161 LEU168      0.0000 DICT
+   2570 HD21       61.1020   -6.2360   -8.4290 H       161 LEU168      0.0000 DICT
+   2571 HD22       62.2100   -7.4180   -8.2200 H       161 LEU168      0.0000 DICT
+   2572 HD23       60.6390   -7.8020   -8.4470 H       161 LEU168      0.0000 DICT
+   2573 N          59.1690   -7.0170   -3.5160 N.am    162 VAL169      0.0000 BACKBONE|DICT|DIRECT
+   2574 CA         57.8040   -6.5110   -3.4400 C.3     162 VAL169      0.0000 BACKBONE|DICT|DIRECT
+   2575 C          57.4610   -5.7350   -4.7020 C.2     162 VAL169      0.0000 BACKBONE|DICT|DIRECT
+   2576 O          56.4300   -5.9750   -5.3390 O.2     162 VAL169      0.0000 BACKBONE|DICT|DIRECT
+   2577 CB         57.6140   -5.6460   -2.1800 C.3     162 VAL169      0.0000 DICT
+   2578 CG1        56.1840   -5.1210   -2.1130 C.3     162 VAL169      0.0000 DICT
+   2579 CG2        57.9670   -6.4370   -0.9270 C.3     162 VAL169      0.0000 DICT
+   2580 H          59.9090   -6.5290   -3.0540 H       162 VAL169      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2581 HA         57.1850   -7.2940   -3.3770 H       162 VAL169      0.0000 BACKBONE|DICT|DIRECT
+   2582 HB         58.2330   -4.8630   -2.2410 H       162 VAL169      0.0000 DICT
+   2583 HG11       56.0720   -4.5610   -1.2920 H       162 VAL169      0.0000 DICT
+   2584 HG12       55.9940   -4.5660   -2.9230 H       162 VAL169      0.0000 DICT
+   2585 HG13       55.5470   -5.8910   -2.0800 H       162 VAL169      0.0000 DICT
+   2586 HG21       57.8380   -5.8600   -0.1210 H       162 VAL169      0.0000 DICT
+   2587 HG22       57.3740   -7.2390   -0.8610 H       162 VAL169      0.0000 DICT
+   2588 HG23       58.9210   -6.7310   -0.9760 H       162 VAL169      0.0000 DICT
+   2589 N          58.3310   -4.8060   -5.0860 N.am    163 HIS170      0.0000 BACKBONE|DICT|DIRECT
+   2590 CA         58.1670   -4.0230   -6.3020 C.3     163 HIS170      0.0000 BACKBONE|DICT|DIRECT
+   2591 C          59.4390   -3.2290   -6.5270 C.2     163 HIS170      0.0000 BACKBONE|DICT|DIRECT
+   2592 O          60.0670   -2.7750   -5.5680 O.2     163 HIS170      0.0000 BACKBONE|DICT|DIRECT
+   2593 CB         56.9690   -3.0690   -6.2100 C.3     163 HIS170      0.0000 DICT
+   2594 CG         56.7700   -2.2300   -7.4340 C.2     163 HIS170      0.0000 DICT
+   2595 ND1        56.5380   -2.7720   -8.6800 N.2     163 HIS170      0.0000 DICT
+   2596 CD2        56.7630   -0.8860   -7.6010 C.2     163 HIS170      0.0000 DICT
+   2597 CE1        56.3990   -1.7990   -9.5620 C.2     163 HIS170      0.0000 DICT
+   2598 NE2        56.5320   -0.6450   -8.9340 N.pl3   163 HIS170      0.0000 DICT
+   2599 H          59.1340   -4.6380   -4.5140 H       163 HIS170      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2600 HA         58.0300   -4.6440   -7.0740 H       163 HIS170      0.0000 BACKBONE|DICT|DIRECT
+   2601 HB2        57.1100   -2.4600   -5.4300 H       163 HIS170      0.0000 DICT
+   2602 HB3        56.1430   -3.6130   -6.0630 H       163 HIS170      0.0000 DICT
+   2603 HD2        56.9000   -0.1980   -6.8880 H       163 HIS170      0.0000 DICT
+   2604 HE1        56.2230   -1.9160  -10.5390 H       163 HIS170      0.0000 DICT
+   2605 HE2        56.4740    0.2580   -9.3600 H       163 HIS170      0.0000 DICT|ESSENTIAL
+   2606 N          59.8130   -3.0650   -7.7900 N.am    164 ASN171      0.0000 BACKBONE|DICT|DIRECT
+   2607 CA         60.9200   -2.1910   -8.1580 C.3     164 ASN171      0.0000 BACKBONE|DICT|DIRECT
+   2608 C          60.3100   -0.9050   -8.6990 C.2     164 ASN171      0.0000 BACKBONE|DICT|DIRECT
+   2609 O          59.8630   -0.8510   -9.8480 O.2     164 ASN171      0.0000 BACKBONE|DICT|DIRECT
+   2610 CB         61.8420   -2.8550   -9.1750 C.3     164 ASN171      0.0000 DICT
+   2611 CG         63.2150   -2.2070   -9.2240 C.2     164 ASN171      0.0000 DICT
+   2612 OD1        63.3780   -1.0370   -8.8720 O.2     164 ASN171      0.0000 DICT
+   2613 ND2        64.2110   -2.9680   -9.6570 N.am    164 ASN171      0.0000 DICT
+   2614 H          59.3210   -3.5550   -8.5100 H       164 ASN171      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2615 HA         61.4480   -1.9760   -7.3360 H       164 ASN171      0.0000 BACKBONE|DICT|DIRECT
+   2616 HB2        61.4230   -2.7870  -10.0800 H       164 ASN171      0.0000 DICT
+   2617 HB3        61.9500   -3.8180   -8.9290 H       164 ASN171      0.0000 DICT
+   2618 HD21       64.0350   -3.9130   -9.9330 H       164 ASN171      0.0000 DICT|ESSENTIAL
+   2619 HD22       65.1380   -2.5970   -9.7070 H       164 ASN171      0.0000 DICT|ESSENTIAL
+   2620 N          60.2670    0.1230   -7.8550 N.am    165 PHE172      0.0000 BACKBONE|DICT|DIRECT
+   2621 CA         59.8140    1.4350   -8.2950 C.3     165 PHE172      0.0000 BACKBONE|DICT|DIRECT
+   2622 C          60.8180    2.0040   -9.2860 C.2     165 PHE172      0.0000 BACKBONE|DICT|DIRECT
+   2623 O          62.0260    1.9990   -9.0290 O.2     165 PHE172      0.0000 BACKBONE|DICT|DIRECT
+   2624 CB         59.6500    2.3730   -7.1000 C.3     165 PHE172      0.0000 DICT
+   2625 CG         58.5700    1.9540   -6.1440 C.ar    165 PHE172      0.0000 DICT
+   2626 CD1        58.7950    0.9440   -5.2200 C.ar    165 PHE172      0.0000 DICT
+   2627 CD2        57.3320    2.5770   -6.1610 C.ar    165 PHE172      0.0000 DICT
+   2628 CE1        57.8030    0.5560   -4.3370 C.ar    165 PHE172      0.0000 DICT
+   2629 CE2        56.3370    2.1940   -5.2790 C.ar    165 PHE172      0.0000 DICT
+   2630 CZ         56.5740    1.1810   -4.3650 C.ar    165 PHE172      0.0000 DICT
+   2631 H          60.5500   -0.0070   -6.9050 H       165 PHE172      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2632 HA         58.9300    1.3350   -8.7520 H       165 PHE172      0.0000 BACKBONE|DICT|DIRECT
+   2633 HB2        59.4300    3.2860   -7.4440 H       165 PHE172      0.0000 DICT
+   2634 HB3        60.5170    2.4040   -6.6020 H       165 PHE172      0.0000 DICT
+   2635 HD1        59.6860    0.4900   -5.1920 H       165 PHE172      0.0000 DICT
+   2636 HD2        57.1560    3.3110   -6.8170 H       165 PHE172      0.0000 DICT
+   2637 HE1        57.9770   -0.1770   -3.6790 H       165 PHE172      0.0000 DICT
+   2638 HE2        55.4470    2.6490   -5.3020 H       165 PHE172      0.0000 DICT
+   2639 HZ         55.8560    0.9030   -3.7270 H       165 PHE172      0.0000 DICT
+   2640 N          60.3260    2.4800  -10.4180 N.am    166 GLU173      0.0000 BACKBONE|DICT|DIRECT
+   2641 CA         61.2580    2.8510  -11.4780 C.3     166 GLU173      0.0000 BACKBONE|DICT|DIRECT
+   2642 C          61.0680    4.2660  -12.0000 C.2     166 GLU173      0.0000 BACKBONE|DICT|DIRECT
+   2643 O          62.0590    4.9350  -12.2980 O.2     166 GLU173      0.0000 BACKBONE|DICT|DIRECT
+   2644 CB         61.1520    1.8440  -12.6260 C.3     166 GLU173      0.0000 DICT
+   2645 CG         61.7400    0.4870  -12.2770 C.3     166 GLU173      0.0000 DICT
+   2646 CD         61.6630   -0.5000  -13.4200 C.2     166 GLU173      0.0000 DICT
+   2647 OE1        60.6170   -0.5450  -14.1030 O.co2   166 GLU173      0.0000 DICT
+   2648 OE2        62.6520   -1.2310  -13.6360 O.co2   166 GLU173      0.0000 DICT
+   2649 H          59.3390    2.5830  -10.5440 H       166 GLU173      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2650 HA         62.1830    2.7880  -11.1040 H       166 GLU173      0.0000 BACKBONE|DICT|DIRECT
+   2651 HB2        61.6410    2.2100  -13.4180 H       166 GLU173      0.0000 DICT
+   2652 HB3        60.1870    1.7240  -12.8570 H       166 GLU173      0.0000 DICT
+   2653 HG2        61.2370    0.1120  -11.4980 H       166 GLU173      0.0000 DICT
+   2654 HG3        62.7000    0.6100  -12.0260 H       166 GLU173      0.0000 DICT
+   2655 N          59.8300    4.7430  -12.1240 N.am    167 GLU174      0.0000 BACKBONE|DICT|DIRECT
+   2656 CA         59.5980    6.1020  -12.5950 C.3     167 GLU174      0.0000 BACKBONE|DICT|DIRECT
+   2657 C          59.1490    7.0610  -11.5030 C.2     167 GLU174      0.0000 BACKBONE|DICT|DIRECT
+   2658 O          59.0850    8.2690  -11.7540 O.2     167 GLU174      0.0000 BACKBONE|DICT|DIRECT
+   2659 CB         58.5660    6.1130  -13.7340 C.3     167 GLU174      0.0000 DICT
+   2660 CG         59.0770    5.5170  -15.0320 C.3     167 GLU174      0.0000 DICT
+   2661 CD         58.4060    4.1990  -15.3600 C.2     167 GLU174      0.0000 DICT
+   2662 OE1        57.1780    4.0780  -15.1530 O.co2   167 GLU174      0.0000 DICT
+   2663 OE2        59.1040    3.2630  -15.8120 O.co2   167 GLU174      0.0000 DICT
+   2664 H          59.0510    4.1610  -11.8910 H       167 GLU174      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2665 HA         60.4610    6.4460  -12.9650 H       167 GLU174      0.0000 BACKBONE|DICT|DIRECT
+   2666 HB2        58.2980    7.0610  -13.9070 H       167 GLU174      0.0000 DICT
+   2667 HB3        57.7670    5.5890  -13.4400 H       167 GLU174      0.0000 DICT
+   2668 HG2        60.0620    5.3650  -14.9510 H       167 GLU174      0.0000 DICT
+   2669 HG3        58.8990    6.1630  -15.7750 H       167 GLU174      0.0000 DICT
+   2670 N          58.8540    6.5710  -10.3080 N.am    168 GLY175      0.0000 BACKBONE|DICT|DIRECT
+   2671 CA         58.4650    7.4610   -9.2370 C.3     168 GLY175      0.0000 BACKBONE|DICT|DIRECT
+   2672 C          58.4680    6.7450   -7.9070 C.2     168 GLY175      0.0000 BACKBONE|DICT|DIRECT
+   2673 O          58.9990    5.6410   -7.7720 O.2     168 GLY175      0.0000 BACKBONE|DICT|DIRECT
+   2674 H          58.9000    5.5850  -10.1470 H       168 GLY175      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2675 HA2        57.5450    7.8080   -9.4190 H       168 GLY175      0.0000 BACKBONE|DICT|DIRECT
+   2676 HA3        59.1080    8.2260   -9.1980 H       168 GLY175      0.0000 DICT
+   2677 N          57.8630    7.3960   -6.9190 N.am    169 GLY176      0.0000 BACKBONE|DICT|DIRECT
+   2678 CA         57.7220    6.8430   -5.5940 C.3     169 GLY176      0.0000 BACKBONE|DICT|DIRECT
+   2679 C          56.3570    6.2280   -5.3710 C.2     169 GLY176      0.0000 BACKBONE|DICT|DIRECT
+   2680 O          55.6570    5.8330   -6.3110 O.2     169 GLY176      0.0000 BACKBONE|DICT|DIRECT
+   2681 H          57.4900    8.3060   -7.1010 H       169 GLY176      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2682 HA2        57.8590    7.5730   -4.9240 H       169 GLY176      0.0000 BACKBONE|DICT|DIRECT
+   2683 HA3        58.4180    6.1370   -5.4640 H       169 GLY176      0.0000 DICT
+   2684 N          55.9700    6.1510   -4.1010 N.am    170 GLY177      0.0000 BACKBONE|DICT|DIRECT
+   2685 CA         54.6970    5.5670   -3.7290 C.3     170 GLY177      0.0000 BACKBONE|DICT|DIRECT
+   2686 C          54.6550    5.1440   -2.2760 C.2     170 GLY177      0.0000 BACKBONE|DICT|DIRECT
+   2687 O          55.2420    5.8040   -1.4140 O.2     170 GLY177      0.0000 BACKBONE|DICT|DIRECT
+   2688 H          56.5720    6.5050   -3.3850 H       170 GLY177      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2689 HA2        54.5330    4.7640   -4.3020 H       170 GLY177      0.0000 BACKBONE|DICT|DIRECT
+   2690 HA3        53.9760    6.2420   -3.8870 H       170 GLY177      0.0000 DICT
+   2691 N          53.9630    4.0460   -1.9880 N.am    171 VAL178      0.0000 BACKBONE|DICT|DIRECT
+   2692 CA         53.8560    3.5290   -0.6320 C.3     171 VAL178      0.0000 BACKBONE|DICT|DIRECT
+   2693 C          54.0890    2.0270   -0.6490 C.2     171 VAL178      0.0000 BACKBONE|DICT|DIRECT
+   2694 O          53.8530    1.3490   -1.6530 O.2     171 VAL178      0.0000 BACKBONE|DICT|DIRECT
+   2695 CB         52.4870    3.8530    0.0080 C.3     171 VAL178      0.0000 DICT
+   2696 CG1        52.3930    5.3320    0.3370 C.3     171 VAL178      0.0000 DICT
+   2697 CG2        51.3520    3.4310   -0.9160 C.3     171 VAL178      0.0000 DICT
+   2698 H          53.5000    3.5590   -2.7290 H       171 VAL178      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2699 HA         54.5710    3.9520   -0.0760 H       171 VAL178      0.0000 BACKBONE|DICT|DIRECT
+   2700 HB         52.4080    3.3360    0.8600 H       171 VAL178      0.0000 DICT
+   2701 HG11       51.5030    5.5260    0.7500 H       171 VAL178      0.0000 DICT
+   2702 HG12       53.1190    5.5770    0.9800 H       171 VAL178      0.0000 DICT
+   2703 HG13       52.4950    5.8670   -0.5020 H       171 VAL178      0.0000 DICT
+   2704 HG21       50.4750    3.6480   -0.4870 H       171 VAL178      0.0000 DICT
+   2705 HG22       51.4290    3.9220   -1.7840 H       171 VAL178      0.0000 DICT
+   2706 HG23       51.4070    2.4470   -1.0840 H       171 VAL178      0.0000 DICT
+   2707 N          54.5610    1.5110    0.4810 N.am    172 ALA179      0.0000 BACKBONE|DICT|DIRECT
+   2708 CA         54.7480    0.0830    0.6730 C.3     172 ALA179      0.0000 BACKBONE|DICT|DIRECT
+   2709 C          54.3680   -0.2590    2.1040 C.2     172 ALA179      0.0000 BACKBONE|DICT|DIRECT
+   2710 O          54.2600    0.6170    2.9660 O.2     172 ALA179      0.0000 BACKBONE|DICT|DIRECT
+   2711 CB         56.1890   -0.3570    0.3750 C.3     172 ALA179      0.0000 DICT
+   2712 H          54.7970    2.1310    1.2300 H       172 ALA179      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2713 HA         54.1320   -0.4050    0.0550 H       172 ALA179      0.0000 BACKBONE|DICT|DIRECT
+   2714 HB1        56.2730   -1.3430    0.5190 H       172 ALA179      0.0000 DICT
+   2715 HB2        56.4150   -0.1390   -0.5740 H       172 ALA179      0.0000 DICT
+   2716 HB3        56.8180    0.1240    0.9860 H       172 ALA179      0.0000 DICT
+   2717 N          54.1720   -1.5500    2.3540 N.am    173 MET180      0.0000 BACKBONE|DICT|DIRECT
+   2718 CA         53.6600   -1.9880    3.6410 C.3     173 MET180      0.0000 BACKBONE|DICT|DIRECT
+   2719 C          53.9750   -3.4640    3.8290 C.2     173 MET180      0.0000 BACKBONE|DICT|DIRECT
+   2720 O          53.8830   -4.2490    2.8810 O.2     173 MET180      0.0000 BACKBONE|DICT|DIRECT
+   2721 CB         52.1480   -1.7370    3.7350 C.3     173 MET180      0.0000 DICT
+   2722 CG         51.3990   -2.6470    4.6890 C.3     173 MET180      0.0000 DICT
+   2723 SD         49.6310   -2.2770    4.7460 S.3     173 MET180      0.0000 DICT
+   2724 CE         49.3040   -1.8920    3.0360 C.3     173 MET180      0.0000 DICT
+   2725 H          54.3790   -2.2270    1.6480 H       173 MET180      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2726 HA         54.1170   -1.4680    4.3620 H       173 MET180      0.0000 BACKBONE|DICT|DIRECT
+   2727 HB2        51.7570   -1.8570    2.8220 H       173 MET180      0.0000 DICT
+   2728 HB3        52.0090   -0.7930    4.0350 H       173 MET180      0.0000 DICT
+   2729 HG2        51.7810   -2.5350    5.6060 H       173 MET180      0.0000 DICT
+   2730 HG3        51.5200   -3.5940    4.3910 H       173 MET180      0.0000 DICT
+   2731 HE1        48.3370   -1.6630    2.9250 H       173 MET180      0.0000 DICT
+   2732 HE2        49.8650   -1.1130    2.7570 H       173 MET180      0.0000 DICT
+   2733 HE3        49.5270   -2.6840    2.4680 H       173 MET180      0.0000 DICT
+   2734 N          54.3650   -3.8210    5.0440 N.am    174 GLY181      0.0000 BACKBONE|DICT|DIRECT
+   2735 CA         54.5140   -5.2140    5.4350 C.3     174 GLY181      0.0000 BACKBONE|DICT|DIRECT
+   2736 C          53.5350   -5.5520    6.5420 C.2     174 GLY181      0.0000 BACKBONE|DICT|DIRECT
+   2737 O          53.2920   -4.7360    7.4320 O.2     174 GLY181      0.0000 BACKBONE|DICT|DIRECT
+   2738 H          54.5640   -3.1080    5.7160 H       174 GLY181      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2739 HA2        55.4470   -5.3680    5.7600 H       174 GLY181      0.0000 BACKBONE|DICT|DIRECT
+   2740 HA3        54.3350   -5.8000    4.6450 H       174 GLY181      0.0000 DICT
+   2741 N          52.9610   -6.7500    6.4700 N.am    175 MET182      0.0000 BACKBONE|DICT|DIRECT
+   2742 CA         52.0810   -7.2310    7.5220 C.3     175 MET182      0.0000 BACKBONE|DICT|DIRECT
+   2743 C          52.3230   -8.7180    7.7310 C.2     175 MET182      0.0000 BACKBONE|DICT|DIRECT
+   2744 O          52.8170   -9.4200    6.8470 O.2     175 MET182      0.0000 BACKBONE|DICT|DIRECT
+   2745 CB         50.6040   -6.9610    7.2070 C.3     175 MET182      0.0000 DICT
+   2746 CG         50.0520   -7.7400    6.0360 C.3     175 MET182      0.0000 DICT
+   2747 SD         48.2980   -7.3890    5.7800 S.3     175 MET182      0.0000 DICT
+   2748 CE         48.3260   -5.6090    5.5990 C.3     175 MET182      0.0000 DICT
+   2749 H          53.1390   -7.3310    5.6760 H       175 MET182      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2750 HA         52.3140   -6.7530    8.3690 H       175 MET182      0.0000 BACKBONE|DICT|DIRECT
+   2751 HB2        50.5020   -5.9860    7.0080 H       175 MET182      0.0000 DICT
+   2752 HB3        50.0660   -7.1940    8.0170 H       175 MET182      0.0000 DICT
+   2753 HG2        50.1660   -8.7180    6.2130 H       175 MET182      0.0000 DICT
+   2754 HG3        50.5580   -7.4890    5.2110 H       175 MET182      0.0000 DICT
+   2755 HE1        47.3960   -5.2750    5.4480 H       175 MET182      0.0000 DICT
+   2756 HE2        48.6980   -5.1950    6.4300 H       175 MET182      0.0000 DICT
+   2757 HE3        48.9000   -5.3620    4.8180 H       175 MET182      0.0000 DICT
+   2758 N          51.9680   -9.1890    8.9230 N.am    176 TYR183      0.0000 BACKBONE|DICT|DIRECT
+   2759 CA         52.2680  -10.5460    9.3480 C.3     176 TYR183      0.0000 BACKBONE|DICT|DIRECT
+   2760 C          51.0820  -11.1030   10.1210 C.2     176 TYR183      0.0000 BACKBONE|DICT|DIRECT
+   2761 O          50.1060  -10.4030   10.4030 O.2     176 TYR183      0.0000 BACKBONE|DICT|DIRECT
+   2762 CB         53.5220  -10.5840   10.2250 C.3     176 TYR183      0.0000 DICT
+   2763 CG         53.2730   -9.9900   11.5930 C.ar    176 TYR183      0.0000 DICT
+   2764 CD1        53.2380   -8.6140   11.7770 C.ar    176 TYR183      0.0000 DICT
+   2765 CD2        53.0500  -10.8050   12.6970 C.ar    176 TYR183      0.0000 DICT
+   2766 CE1        53.0010   -8.0660   13.0240 C.ar    176 TYR183      0.0000 DICT
+   2767 CE2        52.8090  -10.2660   13.9460 C.ar    176 TYR183      0.0000 DICT
+   2768 CZ         52.7880   -8.8970   14.1030 C.ar    176 TYR183      0.0000 DICT
+   2769 OH         52.5530   -8.3560   15.3430 O.3     176 TYR183      0.0000 DICT
+   2770 H          51.4760   -8.5860    9.5510 H       176 TYR183      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2771 HA         52.4220  -11.1120    8.5380 H       176 TYR183      0.0000 BACKBONE|DICT|DIRECT
+   2772 HB2        54.2470  -10.0640    9.7740 H       176 TYR183      0.0000 DICT
+   2773 HB3        53.8120  -11.5350   10.3340 H       176 TYR183      0.0000 DICT
+   2774 HD1        53.3870   -8.0090   10.9940 H       176 TYR183      0.0000 DICT
+   2775 HD2        53.0640  -11.7990   12.5850 H       176 TYR183      0.0000 DICT
+   2776 HE1        52.9840   -7.0730   13.1420 H       176 TYR183      0.0000 DICT
+   2777 HE2        52.6510  -10.8650   14.7310 H       176 TYR183      0.0000 DICT
+   2778 HH         52.3980   -8.9550   16.1290 H       176 TYR183      0.0000 DICT|ESSENTIAL
+   2779 N          51.1920  -12.3740   10.4910 N.am    177 ASN184      0.0000 BACKBONE|DICT|DIRECT
+   2780 CA         50.2270  -13.0090   11.3720 C.3     177 ASN184      0.0000 BACKBONE|DICT|DIRECT
+   2781 C          50.9030  -14.2050   12.0250 C.2     177 ASN184      0.0000 BACKBONE|DICT|DIRECT
+   2782 O          51.6860  -14.9070   11.3810 O.2     177 ASN184      0.0000 BACKBONE|DICT|DIRECT
+   2783 CB         48.9690  -13.4380   10.6080 C.3     177 ASN184      0.0000 DICT
+   2784 CG         47.7210  -13.3700   11.4610 C.2     177 ASN184      0.0000 DICT
+   2785 OD1        47.7700  -13.5870   12.6710 O.2     177 ASN184      0.0000 DICT
+   2786 ND2        46.5930  -13.0590   10.8340 N.am    177 ASN184      0.0000 DICT
+   2787 H          51.9640  -12.9110   10.1520 H       177 ASN184      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2788 HA         49.9650  -12.3580   12.0850 H       177 ASN184      0.0000 BACKBONE|DICT|DIRECT
+   2789 HB2        49.0910  -14.3790   10.2930 H       177 ASN184      0.0000 DICT
+   2790 HB3        48.8520  -12.8350    9.8190 H       177 ASN184      0.0000 DICT
+   2791 HD21       46.5990  -12.8900    9.8480 H       177 ASN184      0.0000 DICT|ESSENTIAL
+   2792 HD22       45.7370  -12.9930   11.3470 H       177 ASN184      0.0000 DICT|ESSENTIAL
+   2793 N          50.6060  -14.4200   13.3030 N.am    178 GLN185      0.0000 BACKBONE|DICT|DIRECT
+   2794 CA         51.2100  -15.5010   14.0670 C.3     178 GLN185      0.0000 BACKBONE|DICT|DIRECT
+   2795 C          50.3520  -16.7580   14.0070 C.2     178 GLN185      0.0000 BACKBONE|DICT|DIRECT
+   2796 O          49.1250  -16.6920   13.9000 O.2     178 GLN185      0.0000 BACKBONE|DICT|DIRECT
+   2797 CB         51.4050  -15.0840   15.5240 C.3     178 GLN185      0.0000 DICT
+   2798 CG         52.4620  -14.0250   15.7280 C.3     178 GLN185      0.0000 DICT
+   2799 CD         52.1920  -13.1730   16.9490 C.2     178 GLN185      0.0000 DICT
+   2800 OE1        51.2170  -12.4220   16.9910 O.2     178 GLN185      0.0000 DICT
+   2801 NE2        53.0510  -13.2890   17.9560 N.am    178 GLN185      0.0000 DICT
+   2802 H          49.9460  -13.8190   13.7540 H       178 GLN185      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2803 HA         52.1050  -15.7080   13.6730 H       178 GLN185      0.0000 BACKBONE|DICT|DIRECT
+   2804 HB2        51.6660  -15.8940   16.0500 H       178 GLN185      0.0000 DICT
+   2805 HB3        50.5350  -14.7300   15.8680 H       178 GLN185      0.0000 DICT
+   2806 HG2        52.4850  -13.4340   14.9220 H       178 GLN185      0.0000 DICT
+   2807 HG3        53.3490  -14.4730   15.8380 H       178 GLN185      0.0000 DICT
+   2808 HE21       53.8300  -13.9110   17.8800 H       178 GLN185      0.0000 DICT|ESSENTIAL
+   2809 HE22       52.9190  -12.7540   18.7900 H       178 GLN185      0.0000 DICT|ESSENTIAL
+   2810 N          51.0200  -17.9140   14.0740 N.am    179 ASP186      0.0000 BACKBONE|DICT|DIRECT
+   2811 CA         50.3000  -19.1810   14.1520 C.3     179 ASP186      0.0000 BACKBONE|DICT|DIRECT
+   2812 C          49.3590  -19.2050   15.3480 C.2     179 ASP186      0.0000 BACKBONE|DICT|DIRECT
+   2813 O          48.2080  -19.6420   15.2310 O.2     179 ASP186      0.0000 BACKBONE|DICT|DIRECT
+   2814 CB         51.2840  -20.3480   14.2350 C.3     179 ASP186      0.0000 DICT
+   2815 CG         51.9150  -20.6790   12.8990 C.2     179 ASP186      0.0000 DICT
+   2816 OD1        51.3280  -20.3290   11.8540 O.co2   179 ASP186      0.0000 DICT
+   2817 OD2        52.9960  -21.3050   12.8940 O.co2   179 ASP186      0.0000 DICT
+   2818 H          52.0200  -17.9110   14.0710 H       179 ASP186      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2819 HA         49.7550  -19.2860   13.3200 H       179 ASP186      0.0000 BACKBONE|DICT|DIRECT
+   2820 HB2        50.7950  -21.1550   14.5660 H       179 ASP186      0.0000 DICT
+   2821 HB3        52.0090  -20.1090   14.8810 H       179 ASP186      0.0000 DICT
+   2822 N          49.8310  -18.7230   16.5020 N.am    180 LYS187      0.0000 BACKBONE|DICT|DIRECT
+   2823 CA         49.0390  -18.7570   17.7280 C.3     180 LYS187      0.0000 BACKBONE|DICT|DIRECT
+   2824 C          47.6810  -18.0900   17.5390 C.2     180 LYS187      0.0000 BACKBONE|DICT|DIRECT
+   2825 O          46.6450  -18.6360   17.9380 O.2     180 LYS187      0.0000 BACKBONE|DICT|DIRECT
+   2826 CB         49.8130  -18.0810   18.8620 C.3     180 LYS187      0.0000 DICT
+   2827 CG         49.0050  -17.8900   20.1300 C.3     180 LYS187      0.0000 DICT
+   2828 CD         48.9000  -19.1870   20.9170 C.3     180 LYS187      0.0000 DICT
+   2829 CE         47.7300  -19.1500   21.8910 C.3     180 LYS187      0.0000 DICT
+   2830 NZ         47.8070  -17.9990   22.8320 N.4     180 LYS187      0.0000 DICT
+   2831 H          50.7500  -18.3290   16.5260 H       180 LYS187      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2832 HA         48.8870  -19.7130   17.9780 H       180 LYS187      0.0000 BACKBONE|DICT|DIRECT
+   2833 HB2        50.1170  -17.1830   18.5440 H       180 LYS187      0.0000 DICT
+   2834 HB3        50.6100  -18.6450   19.0790 H       180 LYS187      0.0000 DICT
+   2835 HG2        48.0860  -17.5810   19.8870 H       180 LYS187      0.0000 DICT
+   2836 HG3        49.4500  -17.1980   20.6990 H       180 LYS187      0.0000 DICT
+   2837 HD2        49.7470  -19.3260   21.4300 H       180 LYS187      0.0000 DICT
+   2838 HD3        48.7690  -19.9460   20.2790 H       180 LYS187      0.0000 DICT
+   2839 HE2        47.7270  -19.9980   22.4210 H       180 LYS187      0.0000 DICT
+   2840 HE3        46.8800  -19.0810   21.3690 H       180 LYS187      0.0000 DICT
+   2841 HZ1        46.9980  -17.4220   22.7190 H       180 LYS187      0.0000 DICT|ESSENTIAL
+   2842 HZ2        47.8460  -18.3390   23.7720 H       180 LYS187      0.0000 DICT|ESSENTIAL
+   2843 HZ3        48.6290  -17.4640   22.6370 H       180 LYS187      0.0000 DICT|ESSENTIAL
+   2844 N          47.6670  -16.9010   16.9280 N.am    181 SER188      0.0000 BACKBONE|DICT|DIRECT
+   2845 CA         46.4050  -16.1990   16.7090 C.3     181 SER188      0.0000 BACKBONE|DICT|DIRECT
+   2846 C          45.5180  -16.9280   15.7110 C.2     181 SER188      0.0000 BACKBONE|DICT|DIRECT
+   2847 O          44.2870  -16.8670   15.8210 O.2     181 SER188      0.0000 BACKBONE|DICT|DIRECT
+   2848 CB         46.6670  -14.7700   16.2380 C.3     181 SER188      0.0000 DICT
+   2849 OG         47.7380  -14.1920   16.9670 O.3     181 SER188      0.0000 DICT
+   2850 H          48.5250  -16.4900   16.6190 H       181 SER188      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2851 HA         45.9190  -16.1540   17.5820 H       181 SER188      0.0000 BACKBONE|DICT|DIRECT
+   2852 HB2        45.8420  -14.2220   16.3760 H       181 SER188      0.0000 DICT
+   2853 HB3        46.9000  -14.7820   15.2660 H       181 SER188      0.0000 DICT
+   2854 HG         47.8950  -13.2580   16.6450 H       181 SER188      0.0000 DICT|ESSENTIAL
+   2855 N          46.1140  -17.6100   14.7310 N.am    182 ILE189      0.0000 BACKBONE|DICT|DIRECT
+   2856 CA         45.3200  -18.4350   13.8270 C.3     182 ILE189      0.0000 BACKBONE|DICT|DIRECT
+   2857 C          44.7170  -19.6110   14.5850 C.2     182 ILE189      0.0000 BACKBONE|DICT|DIRECT
+   2858 O          43.5790  -20.0210   14.3260 O.2     182 ILE189      0.0000 BACKBONE|DICT|DIRECT
+   2859 CB         46.1770  -18.9020   12.6360 C.3     182 ILE189      0.0000 DICT
+   2860 CG1        46.7140  -17.7020   11.8550 C.3     182 ILE189      0.0000 DICT
+   2861 CG2        45.3770  -19.8140   11.7190 C.3     182 ILE189      0.0000 DICT
+   2862 CD1        47.5150  -18.0870   10.6240 C.3     182 ILE189      0.0000 DICT
+   2863 H          47.1060  -17.5560   14.6160 H       182 ILE189      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2864 HA         44.5710  -17.8760   13.4720 H       182 ILE189      0.0000 BACKBONE|DICT|DIRECT
+   2865 HB         46.9550  -19.4190   12.9920 H       182 ILE189      0.0000 DICT
+   2866 HG12       47.3030  -17.1680   12.4610 H       182 ILE189      0.0000 DICT
+   2867 HG13       45.9390  -17.1410   11.5650 H       182 ILE189      0.0000 DICT
+   2868 HG21       45.9520  -20.1050   10.9540 H       182 ILE189      0.0000 DICT
+   2869 HG22       45.0720  -20.6170   12.2310 H       182 ILE189      0.0000 DICT
+   2870 HG23       44.5810  -19.3200   11.3690 H       182 ILE189      0.0000 DICT
+   2871 HD11       47.8350  -17.2600   10.1620 H       182 ILE189      0.0000 DICT
+   2872 HD12       48.3010  -18.6410   10.8980 H       182 ILE189      0.0000 DICT
+   2873 HD13       46.9370  -18.6140   10.0010 H       182 ILE189      0.0000 DICT
+   2874 N          45.4640  -20.1570   15.5460 N.am    183 GLU190      0.0000 BACKBONE|DICT|DIRECT
+   2875 CA         44.9690  -21.2820   16.3300 C.3     183 GLU190      0.0000 BACKBONE|DICT|DIRECT
+   2876 C          43.8340  -20.8580   17.2560 C.2     183 GLU190      0.0000 BACKBONE|DICT|DIRECT
+   2877 O          42.8400  -21.5810   17.3950 O.2     183 GLU190      0.0000 BACKBONE|DICT|DIRECT
+   2878 CB         46.1200  -21.9060   17.1180 C.3     183 GLU190      0.0000 DICT
+   2879 CG         47.2160  -22.4780   16.2270 C.3     183 GLU190      0.0000 DICT
+   2880 CD         48.4980  -22.7740   16.9790 C.2     183 GLU190      0.0000 DICT
+   2881 OE1        48.5690  -22.4640   18.1860 O.co2   183 GLU190      0.0000 DICT
+   2882 OE2        49.4370  -23.3160   16.3600 O.co2   183 GLU190      0.0000 DICT
+   2883 H          46.3760  -19.7900   15.7310 H       183 GLU190      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2884 HA         44.6150  -21.9710   15.6980 H       183 GLU190      0.0000 BACKBONE|DICT|DIRECT
+   2885 HB2        45.7540  -22.6440   17.6850 H       183 GLU190      0.0000 DICT
+   2886 HB3        46.5220  -21.2030   17.7050 H       183 GLU190      0.0000 DICT
+   2887 HG2        47.4160  -21.8170   15.5040 H       183 GLU190      0.0000 DICT
+   2888 HG3        46.8830  -23.3280   15.8180 H       183 GLU190      0.0000 DICT
+   2889 N          43.9610  -19.6880   17.8940 N.am    184 ASP191      0.0000 BACKBONE|DICT|DIRECT
+   2890 CA         42.8630  -19.1630   18.7020 C.3     184 ASP191      0.0000 BACKBONE|DICT|DIRECT
+   2891 C          41.5990  -18.9980   17.8690 C.2     184 ASP191      0.0000 BACKBONE|DICT|DIRECT
+   2892 O          40.4970  -19.3380   18.3180 O.2     184 ASP191      0.0000 BACKBONE|DICT|DIRECT
+   2893 CB         43.2550  -17.8230   19.3270 C.3     184 ASP191      0.0000 DICT
+   2894 CG         44.3930  -17.9500   20.3150 C.2     184 ASP191      0.0000 DICT
+   2895 OD1        44.6490  -19.0780   20.7850 O.co2   184 ASP191      0.0000 DICT
+   2896 OD2        45.0260  -16.9170   20.6270 O.co2   184 ASP191      0.0000 DICT
+   2897 H          44.8130  -19.1700   17.8170 H       184 ASP191      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2898 HA         42.6740  -19.8120   19.4390 H       184 ASP191      0.0000 BACKBONE|DICT|DIRECT
+   2899 HB2        42.4600  -17.4470   19.8020 H       184 ASP191      0.0000 DICT
+   2900 HB3        43.5330  -17.1990   18.5970 H       184 ASP191      0.0000 DICT
+   2901 N          41.7420  -18.4740   16.6500 N.am    185 PHE192      0.0000 BACKBONE|DICT|DIRECT
+   2902 CA         40.5980  -18.3010   15.7640 C.3     185 PHE192      0.0000 BACKBONE|DICT|DIRECT
+   2903 C          39.9870  -19.6430   15.3740 C.2     185 PHE192      0.0000 BACKBONE|DICT|DIRECT
+   2904 O          38.7660  -19.7470   15.2130 O.2     185 PHE192      0.0000 BACKBONE|DICT|DIRECT
+   2905 CB         41.0390  -17.5120   14.5290 C.3     185 PHE192      0.0000 DICT
+   2906 CG         39.9260  -17.1740   13.5840 C.ar    185 PHE192      0.0000 DICT
+   2907 CD1        38.6900  -16.7680   14.0590 C.ar    185 PHE192      0.0000 DICT
+   2908 CD2        40.1270  -17.2360   12.2140 C.ar    185 PHE192      0.0000 DICT
+   2909 CE1        37.6700  -16.4500   13.1860 C.ar    185 PHE192      0.0000 DICT
+   2910 CE2        39.1140  -16.9170   11.3360 C.ar    185 PHE192      0.0000 DICT
+   2911 CZ         37.8820  -16.5240   11.8210 C.ar    185 PHE192      0.0000 DICT
+   2912 H          42.6510  -18.1950   16.3390 H       185 PHE192      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2913 HA         39.9040  -17.7670   16.2470 H       185 PHE192      0.0000 BACKBONE|DICT|DIRECT
+   2914 HB2        41.7160  -18.0570   14.0340 H       185 PHE192      0.0000 DICT
+   2915 HB3        41.4590  -16.6580   14.8360 H       185 PHE192      0.0000 DICT
+   2916 HD1        38.5350  -16.7050   15.0450 H       185 PHE192      0.0000 DICT
+   2917 HD2        41.0190  -17.5160   11.8580 H       185 PHE192      0.0000 DICT
+   2918 HE1        36.7790  -16.1660   13.5400 H       185 PHE192      0.0000 DICT
+   2919 HE2        39.2710  -16.9700   10.3500 H       185 PHE192      0.0000 DICT
+   2920 HZ         37.1440  -16.2930   11.1860 H       185 PHE192      0.0000 DICT
+   2921 N          40.8130  -20.6810   15.2370 N.am    186 ALA193      0.0000 BACKBONE|DICT|DIRECT
+   2922 CA         40.2930  -22.0000   14.8900 C.3     186 ALA193      0.0000 BACKBONE|DICT|DIRECT
+   2923 C          39.5790  -22.6410   16.0740 C.2     186 ALA193      0.0000 BACKBONE|DICT|DIRECT
+   2924 O          38.4540  -23.1360   15.9380 O.2     186 ALA193      0.0000 BACKBONE|DICT|DIRECT
+   2925 CB         41.4280  -22.8970   14.3900 C.3     186 ALA193      0.0000 DICT
+   2926 H          41.7960  -20.5550   15.3730 H       186 ALA193      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2927 HA         39.6310  -21.8900   14.1480 H       186 ALA193      0.0000 BACKBONE|DICT|DIRECT
+   2928 HB1        41.0620  -23.7980   14.1550 H       186 ALA193      0.0000 DICT
+   2929 HB2        41.8460  -22.4850   13.5800 H       186 ALA193      0.0000 DICT
+   2930 HB3        42.1170  -22.9940   15.1080 H       186 ALA193      0.0000 DICT
+   2931 N          40.2140  -22.6320   17.2500 N.am    187 HIS194      0.0000 BACKBONE|DICT|DIRECT
+   2932 CA         39.6340  -23.2950   18.4140 C.3     187 HIS194      0.0000 BACKBONE|DICT|DIRECT
+   2933 C          38.3060  -22.6660   18.8190 C.2     187 HIS194      0.0000 BACKBONE|DICT|DIRECT
+   2934 O          37.3550  -23.3800   19.1580 O.2     187 HIS194      0.0000 BACKBONE|DICT|DIRECT
+   2935 CB         40.6190  -23.2660   19.5810 C.3     187 HIS194      0.0000 DICT
+   2936 CG         41.6830  -24.3120   19.4920 C.2     187 HIS194      0.0000 DICT
+   2937 ND1        41.4050  -25.6600   19.5620 N.2     187 HIS194      0.0000 DICT
+   2938 CD2        43.0240  -24.2110   19.3350 C.2     187 HIS194      0.0000 DICT
+   2939 CE1        42.5290  -26.3450   19.4510 C.2     187 HIS194      0.0000 DICT
+   2940 NE2        43.5270  -25.4900   19.3120 N.pl3   187 HIS194      0.0000 DICT
+   2941 H          41.0950  -22.1660   17.3330 H       187 HIS194      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2942 HA         39.4650  -24.2510   18.1740 H       187 HIS194      0.0000 BACKBONE|DICT|DIRECT
+   2943 HB2        40.1080  -23.4060   20.4290 H       187 HIS194      0.0000 DICT
+   2944 HB3        41.0590  -22.3680   19.6010 H       187 HIS194      0.0000 DICT
+   2945 HD2        43.5500  -23.3650   19.2510 H       187 HIS194      0.0000 DICT
+   2946 HE1        42.6110  -27.3410   19.4690 H       187 HIS194      0.0000 DICT
+   2947 HE2        44.4910  -25.7340   19.2070 H       187 HIS194      0.0000 DICT|ESSENTIAL
+   2948 N          38.2200  -21.3340   18.7980 N.am    188 SER195      0.0000 BACKBONE|DICT|DIRECT
+   2949 CA         36.9520  -20.6790   19.1040 C.3     188 SER195      0.0000 BACKBONE|DICT|DIRECT
+   2950 C          35.8730  -21.0750   18.1050 C.2     188 SER195      0.0000 BACKBONE|DICT|DIRECT
+   2951 O          34.7180  -21.3030   18.4840 O.2     188 SER195      0.0000 BACKBONE|DICT|DIRECT
+   2952 CB         37.1290  -19.1600   19.1220 C.3     188 SER195      0.0000 DICT
+   2953 OG         37.9920  -18.7600   20.1700 O.3     188 SER195      0.0000 DICT
+   2954 H          39.0250  -20.7850   18.5730 H       188 SER195      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2955 HA         36.6590  -20.9720   20.0140 H       188 SER195      0.0000 BACKBONE|DICT|DIRECT
+   2956 HB2        36.2360  -18.7290   19.2520 H       188 SER195      0.0000 DICT
+   2957 HB3        37.5180  -18.8660   18.2490 H       188 SER195      0.0000 DICT
+   2958 HG         38.9350  -18.7450   19.8380 H       188 SER195      0.0000 DICT|ESSENTIAL
+   2959 N          36.2340  -21.1740   16.8230 N.am    189 SER196      0.0000 BACKBONE|DICT|DIRECT
+   2960 CA         35.2490  -21.4960   15.7970 C.3     189 SER196      0.0000 BACKBONE|DICT|DIRECT
+   2961 C          34.7640  -22.9350   15.9220 C.2     189 SER196      0.0000 BACKBONE|DICT|DIRECT
+   2962 O          33.5610  -23.2020   15.8120 O.2     189 SER196      0.0000 BACKBONE|DICT|DIRECT
+   2963 CB         35.8430  -21.2470   14.4110 C.3     189 SER196      0.0000 DICT
+   2964 OG         36.2790  -19.9060   14.2780 O.3     189 SER196      0.0000 DICT
+   2965 H          37.1890  -21.0260   16.5640 H       189 SER196      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2966 HA         34.4630  -20.8890   15.9150 H       189 SER196      0.0000 BACKBONE|DICT|DIRECT
+   2967 HB2        35.1460  -21.4340   13.7180 H       189 SER196      0.0000 DICT
+   2968 HB3        36.6220  -21.8590   14.2740 H       189 SER196      0.0000 DICT
+   2969 HG         37.2340  -19.8360   14.5680 H       189 SER196      0.0000 DICT|ESSENTIAL
+   2970 N          35.6870  -23.8760   16.1460 N.am    190 PHE197      0.0000 BACKBONE|DICT|DIRECT
+   2971 CA         35.2990  -25.2750   16.2990 C.3     190 PHE197      0.0000 BACKBONE|DICT|DIRECT
+   2972 C          34.4140  -25.4710   17.5250 C.2     190 PHE197      0.0000 BACKBONE|DICT|DIRECT
+   2973 O          33.4350  -26.2240   17.4770 O.2     190 PHE197      0.0000 BACKBONE|DICT|DIRECT
+   2974 CB         36.5440  -26.1600   16.3810 C.3     190 PHE197      0.0000 DICT
+   2975 CG         37.2350  -26.3560   15.0620 C.ar    190 PHE197      0.0000 DICT
+   2976 CD1        36.5310  -26.8120   13.9580 C.ar    190 PHE197      0.0000 DICT
+   2977 CD2        38.5850  -26.0740   14.9200 C.ar    190 PHE197      0.0000 DICT
+   2978 CE1        37.1610  -26.9870   12.7400 C.ar    190 PHE197      0.0000 DICT
+   2979 CE2        39.2200  -26.2450   13.7030 C.ar    190 PHE197      0.0000 DICT
+   2980 CZ         38.5080  -26.7020   12.6130 C.ar    190 PHE197      0.0000 DICT
+   2981 H          36.6510  -23.6190   16.2090 H       190 PHE197      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   2982 HA         34.7770  -25.5450   15.4900 H       190 PHE197      0.0000 BACKBONE|DICT|DIRECT
+   2983 HB2        36.2710  -27.0560   16.7310 H       190 PHE197      0.0000 DICT
+   2984 HB3        37.1900  -25.7370   17.0160 H       190 PHE197      0.0000 DICT
+   2985 HD1        35.5560  -27.0170   14.0440 H       190 PHE197      0.0000 DICT
+   2986 HD2        39.1060  -25.7430   15.7070 H       190 PHE197      0.0000 DICT
+   2987 HE1        36.6430  -27.3190   11.9520 H       190 PHE197      0.0000 DICT
+   2988 HE2        40.1940  -26.0380   13.6130 H       190 PHE197      0.0000 DICT
+   2989 HZ         38.9650  -26.8270   11.7330 H       190 PHE197      0.0000 DICT
+   2990 N          34.7340  -24.7890   18.6280 N.am    191 GLN198      0.0000 BACKBONE|DICT|DIRECT
+   2991 CA         33.9460  -24.9430   19.8460 C.3     191 GLN198      0.0000 BACKBONE|DICT|DIRECT
+   2992 C          32.5860  -24.2680   19.7190 C.2     191 GLN198      0.0000 BACKBONE|DICT|DIRECT
+   2993 O          31.5840  -24.7770   20.2360 O.2     191 GLN198      0.0000 BACKBONE|DICT|DIRECT
+   2994 CB         34.7160  -24.3880   21.0410 C.3     191 GLN198      0.0000 DICT
+   2995 CG         35.9930  -25.1540   21.3470 C.3     191 GLN198      0.0000 DICT
+   2996 CD         36.8140  -24.5110   22.4460 C.2     191 GLN198      0.0000 DICT
+   2997 OE1        36.3140  -23.6820   23.2060 O.2     191 GLN198      0.0000 DICT
+   2998 NE2        38.0850  -24.8860   22.5320 N.am    191 GLN198      0.0000 DICT
+   2999 H          35.5190  -24.1690   18.6190 H       191 GLN198      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3000 HA         33.7960  -25.9200   19.9990 H       191 GLN198      0.0000 BACKBONE|DICT|DIRECT
+   3001 HB2        34.1230  -24.4270   21.8450 H       191 GLN198      0.0000 DICT
+   3002 HB3        34.9560  -23.4360   20.8490 H       191 GLN198      0.0000 DICT
+   3003 HG2        36.5480  -25.1950   20.5160 H       191 GLN198      0.0000 DICT
+   3004 HG3        35.7490  -26.0810   21.6310 H       191 GLN198      0.0000 DICT
+   3005 HE21       38.4510  -25.5630   21.8940 H       191 GLN198      0.0000 DICT|ESSENTIAL
+   3006 HE22       38.6760  -24.4910   23.2350 H       191 GLN198      0.0000 DICT|ESSENTIAL
+   3007 N          32.5290  -23.1220   19.0360 N.am    192 MET199      0.0000 BACKBONE|DICT|DIRECT
+   3008 CA         31.2490  -22.4550   18.8210 C.3     192 MET199      0.0000 BACKBONE|DICT|DIRECT
+   3009 C          30.3230  -23.3080   17.9660 C.2     192 MET199      0.0000 BACKBONE|DICT|DIRECT
+   3010 O          29.1190  -23.3940   18.2360 O.2     192 MET199      0.0000 BACKBONE|DICT|DIRECT
+   3011 CB         31.4690  -21.0880   18.1720 C.3     192 MET199      0.0000 DICT
+   3012 CG         30.1810  -20.3680   17.7950 C.3     192 MET199      0.0000 DICT
+   3013 SD         29.2330  -19.8350   19.2340 S.3     192 MET199      0.0000 DICT
+   3014 CE         30.3330  -18.5990   19.9210 C.3     192 MET199      0.0000 DICT
+   3015 H          33.3680  -22.7190   18.6700 H       192 MET199      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3016 HA         30.8150  -22.3140   19.7110 H       192 MET199      0.0000 BACKBONE|DICT|DIRECT
+   3017 HB2        32.0120  -21.2170   17.3420 H       192 MET199      0.0000 DICT
+   3018 HB3        31.9750  -20.5120   18.8150 H       192 MET199      0.0000 DICT
+   3019 HG2        29.6150  -20.9880   17.2510 H       192 MET199      0.0000 DICT
+   3020 HG3        30.4130  -19.5630   17.2490 H       192 MET199      0.0000 DICT
+   3021 HE1        29.9230  -18.2090   20.7460 H       192 MET199      0.0000 DICT
+   3022 HE2        31.2080  -19.0240   20.1530 H       192 MET199      0.0000 DICT
+   3023 HE3        30.4820  -17.8740   19.2480 H       192 MET199      0.0000 DICT
+   3024 N          30.8660  -23.9450   16.9270 N.am    193 ALA200      0.0000 BACKBONE|DICT|DIRECT
+   3025 CA         30.0620  -24.8450   16.1080 C.3     193 ALA200      0.0000 BACKBONE|DICT|DIRECT
+   3026 C          29.5130  -25.9990   16.9370 C.2     193 ALA200      0.0000 BACKBONE|DICT|DIRECT
+   3027 O          28.3680  -26.4240   16.7410 O.2     193 ALA200      0.0000 BACKBONE|DICT|DIRECT
+   3028 CB         30.8910  -25.3710   14.9370 C.3     193 ALA200      0.0000 DICT
+   3029 H          31.8320  -23.8040   16.7080 H       193 ALA200      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3030 HA         29.2900  -24.3280   15.7390 H       193 ALA200      0.0000 BACKBONE|DICT|DIRECT
+   3031 HB1        30.3310  -25.9860   14.3820 H       193 ALA200      0.0000 DICT
+   3032 HB2        31.1990  -24.6030   14.3750 H       193 ALA200      0.0000 DICT
+   3033 HB3        31.6850  -25.8680   15.2870 H       193 ALA200      0.0000 DICT
+   3034 N          30.3130  -26.5150   17.8740 N.am    194 LEU201      0.0000 BACKBONE|DICT|DIRECT
+   3035 CA         29.8520  -27.6050   18.7270 C.3     194 LEU201      0.0000 BACKBONE|DICT|DIRECT
+   3036 C          28.8060  -27.1280   19.7240 C.2     194 LEU201      0.0000 BACKBONE|DICT|DIRECT
+   3037 O          27.8570  -27.8580   20.0320 O.2     194 LEU201      0.0000 BACKBONE|DICT|DIRECT
+   3038 CB         31.0350  -28.2390   19.4570 C.3     194 LEU201      0.0000 DICT
+   3039 CG         32.0780  -28.9440   18.5950 C.3     194 LEU201      0.0000 DICT
+   3040 CD1        33.2790  -29.3360   19.4350 C.3     194 LEU201      0.0000 DICT
+   3041 CD2        31.4710  -30.1650   17.9180 C.3     194 LEU201      0.0000 DICT
+   3042 H          31.2370  -26.1510   17.9920 H       194 LEU201      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3043 HA         29.4340  -28.3020   18.1450 H       194 LEU201      0.0000 BACKBONE|DICT|DIRECT
+   3044 HB2        30.6690  -28.9120   20.0990 H       194 LEU201      0.0000 DICT
+   3045 HB3        31.5010  -27.5140   19.9640 H       194 LEU201      0.0000 DICT
+   3046 HG         32.3830  -28.3090   17.8860 H       194 LEU201      0.0000 DICT
+   3047 HD11       33.9530  -29.7960   18.8580 H       194 LEU201      0.0000 DICT
+   3048 HD12       33.6870  -28.5160   19.8360 H       194 LEU201      0.0000 DICT
+   3049 HD13       32.9880  -29.9540   20.1650 H       194 LEU201      0.0000 DICT
+   3050 HD21       32.1660  -30.6150   17.3580 H       194 LEU201      0.0000 DICT
+   3051 HD22       31.1400  -30.8020   18.6140 H       194 LEU201      0.0000 DICT
+   3052 HD23       30.7080  -29.8800   17.3380 H       194 LEU201      0.0000 DICT
+   3053 N          28.9630  -25.9070   20.2380 N.am    195 SER202      0.0000 BACKBONE|DICT|DIRECT
+   3054 CA         28.0230  -25.3840   21.2220 C.3     195 SER202      0.0000 BACKBONE|DICT|DIRECT
+   3055 C          26.6210  -25.2350   20.6450 C.2     195 SER202      0.0000 BACKBONE|DICT|DIRECT
+   3056 O          25.6350  -25.2950   21.3880 O.2     195 SER202      0.0000 BACKBONE|DICT|DIRECT
+   3057 CB         28.5260  -24.0410   21.7540 C.3     195 SER202      0.0000 DICT
+   3058 OG         27.4590  -23.2610   22.2640 O.3     195 SER202      0.0000 DICT
+   3059 H          29.7350  -25.3430   19.9450 H       195 SER202      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3060 HA         27.9800  -26.0270   21.9870 H       195 SER202      0.0000 BACKBONE|DICT|DIRECT
+   3061 HB2        28.9690  -23.5410   21.0100 H       195 SER202      0.0000 DICT
+   3062 HB3        29.1880  -24.2070   22.4850 H       195 SER202      0.0000 DICT
+   3063 HG         27.8150  -22.3910   22.6040 H       195 SER202      0.0000 DICT|ESSENTIAL
+   3064 N          26.5090  -25.0450   19.3310 N.am    196 LYS203      0.0000 BACKBONE|DICT|DIRECT
+   3065 CA         25.2190  -24.8910   18.6760 C.3     196 LYS203      0.0000 BACKBONE|DICT|DIRECT
+   3066 C          24.8440  -26.0880   17.8160 C.2     196 LYS203      0.0000 BACKBONE|DICT|DIRECT
+   3067 O          23.7290  -26.1230   17.2840 O.2     196 LYS203      0.0000 BACKBONE|DICT|DIRECT
+   3068 CB         25.2080  -23.6180   17.8210 C.3     196 LYS203      0.0000 DICT
+   3069 CG         25.7240  -22.3860   18.5430 C.3     196 LYS203      0.0000 DICT
+   3070 CD         24.8380  -21.1820   18.2890 C.3     196 LYS203      0.0000 DICT
+   3071 CE         23.7800  -21.0310   19.3640 C.3     196 LYS203      0.0000 DICT
+   3072 NZ         22.8740  -19.8800   19.0870 N.4     196 LYS203      0.0000 DICT
+   3073 H          27.3400  -25.0070   18.7760 H       196 LYS203      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3074 HA         24.5220  -24.7910   19.3860 H       196 LYS203      0.0000 BACKBONE|DICT|DIRECT
+   3075 HB2        24.2670  -23.4420   17.5310 H       196 LYS203      0.0000 DICT
+   3076 HB3        25.7810  -23.7740   17.0170 H       196 LYS203      0.0000 DICT
+   3077 HG2        26.6480  -22.1830   18.2200 H       196 LYS203      0.0000 DICT
+   3078 HG3        25.7470  -22.5710   19.5250 H       196 LYS203      0.0000 DICT
+   3079 HD2        24.3870  -21.2920   17.4030 H       196 LYS203      0.0000 DICT
+   3080 HD3        25.4060  -20.3590   18.2740 H       196 LYS203      0.0000 DICT
+   3081 HE2        24.2310  -20.8840   20.2440 H       196 LYS203      0.0000 DICT
+   3082 HE3        23.2360  -21.8690   19.4040 H       196 LYS203      0.0000 DICT
+   3083 HZ1        22.0970  -20.1910   18.5400 H       196 LYS203      0.0000 DICT|ESSENTIAL
+   3084 HZ2        22.5430  -19.5010   19.9510 H       196 LYS203      0.0000 DICT|ESSENTIAL
+   3085 HZ3        23.3750  -19.1750   18.5840 H       196 LYS203      0.0000 DICT|ESSENTIAL
+   3086 N          25.7340  -27.0650   17.6700 N.am    197 GLY204      0.0000 BACKBONE|DICT|DIRECT
+   3087 CA         25.4480  -28.2120   16.8220 C.3     197 GLY204      0.0000 BACKBONE|DICT|DIRECT
+   3088 C          25.2930  -27.8550   15.3600 C.2     197 GLY204      0.0000 BACKBONE|DICT|DIRECT
+   3089 O          24.4310  -28.4170   14.6720 O.2     197 GLY204      0.0000 BACKBONE|DICT|DIRECT
+   3090 H          26.6100  -27.0110   18.1490 H       197 GLY204      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3091 HA2        24.5980  -28.6350   17.1370 H       197 GLY204      0.0000 BACKBONE|DICT|DIRECT
+   3092 HA3        26.1990  -28.8670   16.9110 H       197 GLY204      0.0000 DICT
+   3093 N          26.1060  -26.9220   14.8690 N.am    198 TRP205      0.0000 BACKBONE|DICT|DIRECT
+   3094 CA         26.0550  -26.4770   13.4870 C.3     198 TRP205      0.0000 BACKBONE|DICT|DIRECT
+   3095 C          27.3730  -26.7750   12.7830 C.2     198 TRP205      0.0000 BACKBONE|DICT|DIRECT
+   3096 O          28.4350  -26.7640   13.4130 O.2     198 TRP205      0.0000 BACKBONE|DICT|DIRECT
+   3097 CB         25.7710  -24.9710   13.3920 C.3     198 TRP205      0.0000 DICT
+   3098 CG         24.4350  -24.5530   13.9220 C.2     198 TRP205      0.0000 DICT
+   3099 CD1        23.4320  -25.3670   14.3640 C.2     198 TRP205      0.0000 DICT
+   3100 CD2        23.9540  -23.2100   14.0630 C.ar    198 TRP205      0.0000 DICT
+   3101 NE1        22.3580  -24.6140   14.7730 N.pl3   198 TRP205      0.0000 DICT
+   3102 CE2        22.6520  -23.2870   14.5970 C.ar    198 TRP205      0.0000 DICT
+   3103 CE3        24.4980  -21.9510   13.7890 C.ar    198 TRP205      0.0000 DICT
+   3104 CZ2        21.8850  -22.1540   14.8630 C.ar    198 TRP205      0.0000 DICT
+   3105 CZ3        23.7350  -20.8270   14.0530 C.ar    198 TRP205      0.0000 DICT
+   3106 CH2        22.4430  -20.9360   14.5860 C.ar    198 TRP205      0.0000 DICT
+   3107 H          26.7820  -26.5090   15.4790 H       198 TRP205      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3108 HA         25.3230  -26.9710   13.0180 H       198 TRP205      0.0000 BACKBONE|DICT|DIRECT
+   3109 HB2        25.8220  -24.7040   12.4300 H       198 TRP205      0.0000 DICT
+   3110 HB3        26.4770  -24.4870   13.9100 H       198 TRP205      0.0000 DICT
+   3111 HD1        23.4730  -26.3660   14.3870 H       198 TRP205      0.0000 DICT
+   3112 HE1        21.5010  -24.9760   15.1400 H       198 TRP205      0.0000 DICT|ESSENTIAL
+   3113 HE3        25.4190  -21.8650   13.4100 H       198 TRP205      0.0000 DICT
+   3114 HZ2        20.9620  -22.2290   15.2420 H       198 TRP205      0.0000 DICT
+   3115 HZ3        24.1120  -19.9210   13.8600 H       198 TRP205      0.0000 DICT
+   3116 HH2        21.9170  -20.1050   14.7680 H       198 TRP205      0.0000 DICT
+   3117 N          27.3370  -27.0440   11.4810 N.am    199 PRO206      0.0000 BACKBONE|DICT|DIRECT
+   3118 CA         28.5870  -27.1670   10.7260 C.3     199 PRO206      0.0000 BACKBONE|DICT|DIRECT
+   3119 C          29.3200  -25.8360   10.6510 C.2     199 PRO206      0.0000 BACKBONE|DICT|DIRECT
+   3120 O          28.7210  -24.7590   10.7110 O.2     199 PRO206      0.0000 BACKBONE|DICT|DIRECT
+   3121 CB         28.1230  -27.6270    9.3380 C.3     199 PRO206      0.0000 DICT
+   3122 CG         26.6980  -27.1880    9.2500 C.3     199 PRO206      0.0000 DICT
+   3123 CD         26.1530  -27.3000   10.6440 C.3     199 PRO206      0.0000 DICT
+   3124 HA         29.1740  -27.8620   11.1410 H       199 PRO206      0.0000 BACKBONE|DICT|DIRECT
+   3125 HB2        28.6700  -27.1940    8.6220 H       199 PRO206      0.0000 DICT
+   3126 HB3        28.1920  -28.6210    9.2550 H       199 PRO206      0.0000 DICT
+   3127 HG2        26.6430  -26.2420    8.9290 H       199 PRO206      0.0000 DICT
+   3128 HG3        26.1880  -27.7810    8.6270 H       199 PRO206      0.0000 DICT
+   3129 HD2        25.4420  -26.6170   10.8080 H       199 PRO206      0.0000 DICT
+   3130 HD3        25.7830  -28.2140   10.8130 H       199 PRO206      0.0000 DICT
+   3131 N          30.6400  -25.9260   10.5170 N.am    200 LEU207      0.0000 BACKBONE|DICT|DIRECT
+   3132 CA         31.5100  -24.7600   10.4670 C.3     200 LEU207      0.0000 BACKBONE|DICT|DIRECT
+   3133 C          32.1740  -24.6790    9.1000 C.2     200 LEU207      0.0000 BACKBONE|DICT|DIRECT
+   3134 O          32.7090  -25.6760    8.6060 O.2     200 LEU207      0.0000 BACKBONE|DICT|DIRECT
+   3135 CB         32.5740  -24.8230   11.5650 C.3     200 LEU207      0.0000 DICT
+   3136 CG         33.7250  -23.8270   11.4270 C.3     200 LEU207      0.0000 DICT
+   3137 CD1        33.2290  -22.3950   11.5990 C.3     200 LEU207      0.0000 DICT
+   3138 CD2        34.8310  -24.1470   12.4170 C.3     200 LEU207      0.0000 DICT
+   3139 H          31.0530  -26.8340   10.4480 H       200 LEU207      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3140 HA         30.9550  -23.9390   10.6040 H       200 LEU207      0.0000 BACKBONE|DICT|DIRECT
+   3141 HB2        32.9630  -25.7440   11.5640 H       200 LEU207      0.0000 DICT
+   3142 HB3        32.1230  -24.6520   12.4410 H       200 LEU207      0.0000 DICT
+   3143 HG         34.1010  -23.9150   10.5050 H       200 LEU207      0.0000 DICT
+   3144 HD11       33.9980  -21.7620   11.5050 H       200 LEU207      0.0000 DICT
+   3145 HD12       32.5440  -22.1930   10.8990 H       200 LEU207      0.0000 DICT
+   3146 HD13       32.8200  -22.2900   12.5060 H       200 LEU207      0.0000 DICT
+   3147 HD21       35.5740  -23.4860   12.3120 H       200 LEU207      0.0000 DICT
+   3148 HD22       34.4700  -24.0970   13.3480 H       200 LEU207      0.0000 DICT
+   3149 HD23       35.1780  -25.0690   12.2430 H       200 LEU207      0.0000 DICT
+   3150 N          32.1380  -23.4940    8.4970 N.am    201 TYR208      0.0000 BACKBONE|DICT|DIRECT
+   3151 CA         32.8220  -23.2240    7.2410 C.3     201 TYR208      0.0000 BACKBONE|DICT|DIRECT
+   3152 C          33.8560  -22.1290    7.4560 C.2     201 TYR208      0.0000 BACKBONE|DICT|DIRECT
+   3153 O          33.5570  -21.0990    8.0690 O.2     201 TYR208      0.0000 BACKBONE|DICT|DIRECT
+   3154 CB         31.8390  -22.8010    6.1470 C.3     201 TYR208      0.0000 DICT
+   3155 CG         30.7910  -23.8350    5.8130 C.ar    201 TYR208      0.0000 DICT
+   3156 CD1        31.0460  -24.8340    4.8820 C.ar    201 TYR208      0.0000 DICT
+   3157 CD2        29.5410  -23.8050    6.4200 C.ar    201 TYR208      0.0000 DICT
+   3158 CE1        30.0860  -25.7820    4.5720 C.ar    201 TYR208      0.0000 DICT
+   3159 CE2        28.5760  -24.7460    6.1160 C.ar    201 TYR208      0.0000 DICT
+   3160 CZ         28.8530  -25.7310    5.1920 C.ar    201 TYR208      0.0000 DICT
+   3161 OH         27.8950  -26.6680    4.8890 O.3     201 TYR208      0.0000 DICT
+   3162 H          31.6180  -22.7560    8.9260 H       201 TYR208      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3163 HA         33.2920  -24.0560    6.9460 H       201 TYR208      0.0000 BACKBONE|DICT|DIRECT
+   3164 HB2        32.3610  -22.6060    5.3170 H       201 TYR208      0.0000 DICT
+   3165 HB3        31.3720  -21.9700    6.4510 H       201 TYR208      0.0000 DICT
+   3166 HD1        31.9370  -24.8690    4.4290 H       201 TYR208      0.0000 DICT
+   3167 HD2        29.3360  -23.0900    7.0880 H       201 TYR208      0.0000 DICT
+   3168 HE1        30.2840  -26.4990    3.9040 H       201 TYR208      0.0000 DICT
+   3169 HE2        27.6820  -24.7130    6.5630 H       201 TYR208      0.0000 DICT
+   3170 HH         27.0020  -26.6330    5.3370 H       201 TYR208      0.0000 DICT|ESSENTIAL
+   3171 N          35.0660  -22.3560    6.9570 N.am    202 LEU209      0.0000 BACKBONE|DICT|DIRECT
+   3172 CA         36.0960  -21.3310    6.8820 C.3     202 LEU209      0.0000 BACKBONE|DICT|DIRECT
+   3173 C          36.2240  -20.8630    5.4400 C.2     202 LEU209      0.0000 BACKBONE|DICT|DIRECT
+   3174 O          36.2040  -21.6760    4.5110 O.2     202 LEU209      0.0000 BACKBONE|DICT|DIRECT
+   3175 CB         37.4420  -21.8610    7.3800 C.3     202 LEU209      0.0000 DICT
+   3176 CG         38.6650  -21.0010    7.0530 C.3     202 LEU209      0.0000 DICT
+   3177 CD1        38.6150  -19.6810    7.8040 C.3     202 LEU209      0.0000 DICT
+   3178 CD2        39.9520  -21.7500    7.3540 C.3     202 LEU209      0.0000 DICT
+   3179 H          35.2790  -23.2720    6.6180 H       202 LEU209      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3180 HA         35.8230  -20.5550    7.4510 H       202 LEU209      0.0000 BACKBONE|DICT|DIRECT
+   3181 HB2        37.5850  -22.7630    6.9730 H       202 LEU209      0.0000 DICT
+   3182 HB3        37.3870  -21.9490    8.3750 H       202 LEU209      0.0000 DICT
+   3183 HG         38.6470  -20.7990    6.0740 H       202 LEU209      0.0000 DICT
+   3184 HD11       39.4220  -19.1370    7.5750 H       202 LEU209      0.0000 DICT
+   3185 HD12       37.7900  -19.1800    7.5430 H       202 LEU209      0.0000 DICT
+   3186 HD13       38.6000  -19.8580    8.7880 H       202 LEU209      0.0000 DICT
+   3187 HD21       40.7350  -21.1690    7.1330 H       202 LEU209      0.0000 DICT
+   3188 HD22       39.9790  -21.9900    8.3240 H       202 LEU209      0.0000 DICT
+   3189 HD23       39.9890  -22.5840    6.8030 H       202 LEU209      0.0000 DICT
+   3190 N          36.3470  -19.5520    5.2530 N.am    203 SER210      0.0000 BACKBONE|DICT|DIRECT
+   3191 CA         36.4660  -18.9710    3.9230 C.3     203 SER210      0.0000 BACKBONE|DICT|DIRECT
+   3192 C          37.7200  -18.1160    3.8490 C.2     203 SER210      0.0000 BACKBONE|DICT|DIRECT
+   3193 O          37.9610  -17.2820    4.7280 O.2     203 SER210      0.0000 BACKBONE|DICT|DIRECT
+   3194 CB         35.2300  -18.1370    3.5640 C.3     203 SER210      0.0000 DICT
+   3195 OG         35.0780  -17.0350    4.4410 O.3     203 SER210      0.0000 DICT
+   3196 H          36.3580  -18.9470    6.0490 H       203 SER210      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3197 HA         36.5500  -19.7140    3.2590 H       203 SER210      0.0000 BACKBONE|DICT|DIRECT
+   3198 HB2        34.4170  -18.7160    3.6260 H       203 SER210      0.0000 DICT
+   3199 HB3        35.3270  -17.7970    2.6280 H       203 SER210      0.0000 DICT
+   3200 HG         35.4520  -17.2690    5.3380 H       203 SER210      0.0000 DICT|ESSENTIAL
+   3201 N          38.5260  -18.3410    2.8100 N.am    204 THR211      0.0000 BACKBONE|DICT|DIRECT
+   3202 CA         39.6960  -17.5210    2.5230 C.3     204 THR211      0.0000 BACKBONE|DICT|DIRECT
+   3203 C          39.7610  -17.2620    1.0240 C.2     204 THR211      0.0000 BACKBONE|DICT|DIRECT
+   3204 O          38.9170  -17.7280    0.2500 O.2     204 THR211      0.0000 BACKBONE|DICT|DIRECT
+   3205 CB         41.0070  -18.1790    2.9800 C.3     204 THR211      0.0000 DICT
+   3206 OG1        41.2920  -19.3130    2.1500 O.3     204 THR211      0.0000 DICT
+   3207 CG2        40.9380  -18.6160    4.4360 C.3     204 THR211      0.0000 DICT
+   3208 H          38.3180  -19.1060    2.2010 H       204 THR211      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3209 HA         39.5960  -16.6450    2.9950 H       204 THR211      0.0000 BACKBONE|DICT|DIRECT
+   3210 HB         41.7490  -17.5160    2.8800 H       204 THR211      0.0000 DICT
+   3211 HG1        42.1460  -19.7390    2.4500 H       204 THR211      0.0000 DICT|ESSENTIAL
+   3212 HG21       41.8050  -19.0390    4.6990 H       204 THR211      0.0000 DICT
+   3213 HG22       40.7670  -17.8190    5.0150 H       204 THR211      0.0000 DICT
+   3214 HG23       40.1970  -19.2770    4.5510 H       204 THR211      0.0000 DICT
+   3215 N          40.7850  -16.5110    0.6190 N.am    205 LYS212      0.0000 BACKBONE|DICT|DIRECT
+   3216 CA         41.0790  -16.2870   -0.7910 C.3     205 LYS212      0.0000 BACKBONE|DICT|DIRECT
+   3217 C          42.4530  -16.8630   -1.1100 C.2     205 LYS212      0.0000 BACKBONE|DICT|DIRECT
+   3218 O          43.3400  -16.1620   -1.6090 O.2     205 LYS212      0.0000 BACKBONE|DICT|DIRECT
+   3219 CB         41.0070  -14.7950   -1.1370 C.3     205 LYS212      0.0000 DICT
+   3220 CG         41.0120  -14.4960   -2.6370 C.3     205 LYS212      0.0000 DICT
+   3221 CD         39.6400  -14.0590   -3.1160 C.3     205 LYS212      0.0000 DICT
+   3222 CE         39.7230  -13.3270   -4.4460 C.3     205 LYS212      0.0000 DICT
+   3223 NZ         38.4520  -13.4040   -5.2180 N.4     205 LYS212      0.0000 DICT
+   3224 H          41.3730  -16.0860    1.3070 H       205 LYS212      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3225 HA         40.3970  -16.7720   -1.3380 H       205 LYS212      0.0000 BACKBONE|DICT|DIRECT
+   3226 HB2        41.7960  -14.3390   -0.7240 H       205 LYS212      0.0000 DICT
+   3227 HB3        40.1650  -14.4230   -0.7460 H       205 LYS212      0.0000 DICT
+   3228 HG2        41.2830  -15.3210   -3.1330 H       205 LYS212      0.0000 DICT
+   3229 HG3        41.6690  -13.7650   -2.8210 H       205 LYS212      0.0000 DICT
+   3230 HD2        39.2360  -13.4490   -2.4340 H       205 LYS212      0.0000 DICT
+   3231 HD3        39.0610  -14.8670   -3.2250 H       205 LYS212      0.0000 DICT
+   3232 HE2        40.4550  -13.7350   -4.9920 H       205 LYS212      0.0000 DICT
+   3233 HE3        39.9340  -12.3650   -4.2700 H       205 LYS212      0.0000 DICT
+   3234 HZ1        37.8670  -12.6310   -4.9740 H       205 LYS212      0.0000 DICT|ESSENTIAL
+   3235 HZ2        38.6540  -13.3740   -6.1970 H       205 LYS212      0.0000 DICT|ESSENTIAL
+   3236 HZ3        37.9820  -14.2590   -5.0010 H       205 LYS212      0.0000 DICT|ESSENTIAL
+   3237 N          42.6310  -18.1500   -0.8170 N.am    206 ASN213      0.0000 BACKBONE|DICT|DIRECT
+   3238 CA         43.9020  -18.8350   -1.0160 C.3     206 ASN213      0.0000 BACKBONE|DICT|DIRECT
+   3239 C          44.1990  -19.1330   -2.4800 C.2     206 ASN213      0.0000 BACKBONE|DICT|DIRECT
+   3240 O          45.2330  -19.7430   -2.7700 O.2     206 ASN213      0.0000 BACKBONE|DICT|DIRECT
+   3241 CB         43.9430  -20.1340   -0.1960 C.3     206 ASN213      0.0000 DICT
+   3242 CG         43.0350  -21.2280   -0.7490 C.2     206 ASN213      0.0000 DICT
+   3243 OD1        41.8170  -21.1120   -0.6810 O.2     206 ASN213      0.0000 DICT
+   3244 ND2        43.6160  -22.2880   -1.2910 N.am    206 ASN213      0.0000 DICT
+   3245 H          41.8610  -18.6680   -0.4450 H       206 ASN213      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3246 HA         44.6270  -18.2370   -0.6740 H       206 ASN213      0.0000 BACKBONE|DICT|DIRECT
+   3247 HB2        43.6570  -19.9270    0.7400 H       206 ASN213      0.0000 DICT
+   3248 HB3        44.8830  -20.4750   -0.1900 H       206 ASN213      0.0000 DICT
+   3249 HD21       44.6130  -22.3470   -1.3280 H       206 ASN213      0.0000 DICT|ESSENTIAL
+   3250 HD22       43.0560  -23.0290   -1.6620 H       206 ASN213      0.0000 DICT|ESSENTIAL
+   3251 N          43.3260  -18.7280   -3.4040 N.am    207 THR214      0.0000 BACKBONE|DICT|DIRECT
+   3252 CA         43.6490  -18.8020   -4.8220 C.3     207 THR214      0.0000 BACKBONE|DICT|DIRECT
+   3253 C          44.5900  -17.6860   -5.2570 C.2     207 THR214      0.0000 BACKBONE|DICT|DIRECT
+   3254 O          45.2310  -17.8060   -6.3060 O.2     207 THR214      0.0000 BACKBONE|DICT|DIRECT
+   3255 CB         42.3730  -18.7520   -5.6690 C.3     207 THR214      0.0000 DICT
+   3256 OG1        41.5740  -17.6310   -5.2720 O.3     207 THR214      0.0000 DICT
+   3257 CG2        41.5670  -20.0350   -5.5030 C.3     207 THR214      0.0000 DICT
+   3258 H          42.4370  -18.3690   -3.1190 H       207 THR214      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3259 HA         44.1030  -19.6770   -4.9930 H       207 THR214      0.0000 BACKBONE|DICT|DIRECT
+   3260 HB         42.6250  -18.6480   -6.6310 H       207 THR214      0.0000 DICT
+   3261 HG1        40.7420  -17.6010   -5.8270 H       207 THR214      0.0000 DICT|ESSENTIAL
+   3262 HG21       40.7400  -19.9840   -6.0620 H       207 THR214      0.0000 DICT
+   3263 HG22       42.1190  -20.8160   -5.7960 H       207 THR214      0.0000 DICT
+   3264 HG23       41.3130  -20.1470   -4.5420 H       207 THR214      0.0000 DICT
+   3265 N          44.6860  -16.6120   -4.4760 N.am    208 ILE215      0.0000 BACKBONE|DICT|DIRECT
+   3266 CA         45.5800  -15.4930   -4.7650 C.3     208 ILE215      0.0000 BACKBONE|DICT|DIRECT
+   3267 C          46.7160  -15.4270   -3.7490 C.2     208 ILE215      0.0000 BACKBONE|DICT|DIRECT
+   3268 O          47.8920  -15.4830   -4.1120 O.2     208 ILE215      0.0000 BACKBONE|DICT|DIRECT
+   3269 CB         44.8010  -14.1620   -4.8230 C.3     208 ILE215      0.0000 DICT
+   3270 CG1        43.6080  -14.2930   -5.7710 C.3     208 ILE215      0.0000 DICT
+   3271 CG2        45.7150  -13.0290   -5.2510 C.3     208 ILE215      0.0000 DICT
+   3272 CD1        42.9140  -12.9820   -6.0680 C.3     208 ILE215      0.0000 DICT
+   3273 H          44.1200  -16.5690   -3.6530 H       208 ILE215      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3274 HA         45.9850  -15.6500   -5.6660 H       208 ILE215      0.0000 BACKBONE|DICT|DIRECT
+   3275 HB         44.4550  -13.9590   -3.9070 H       208 ILE215      0.0000 DICT
+   3276 HG12       42.9430  -14.9140   -5.3560 H       208 ILE215      0.0000 DICT
+   3277 HG13       43.9330  -14.6800   -6.6340 H       208 ILE215      0.0000 DICT
+   3278 HG21       45.1950  -12.1750   -5.2830 H       208 ILE215      0.0000 DICT
+   3279 HG22       46.4640  -12.9390   -4.5940 H       208 ILE215      0.0000 DICT
+   3280 HG23       46.0890  -13.2260   -6.1570 H       208 ILE215      0.0000 DICT
+   3281 HD11       42.1480  -13.1440   -6.6910 H       208 ILE215      0.0000 DICT
+   3282 HD12       42.5730  -12.5850   -5.2160 H       208 ILE215      0.0000 DICT
+   3283 HD13       43.5620  -12.3510   -6.4940 H       208 ILE215      0.0000 DICT
+   3284 N          46.3820  -15.3080   -2.4650 N.am    209 LEU216      0.0000 BACKBONE|DICT|DIRECT
+   3285 CA         47.3820  -15.3410   -1.3980 C.3     209 LEU216      0.0000 BACKBONE|DICT|DIRECT
+   3286 C          47.5330  -16.7810   -0.9120 C.2     209 LEU216      0.0000 BACKBONE|DICT|DIRECT
+   3287 O          47.1480  -17.1550    0.1960 O.2     209 LEU216      0.0000 BACKBONE|DICT|DIRECT
+   3288 CB         46.9990  -14.3920   -0.2680 C.3     209 LEU216      0.0000 DICT
+   3289 CG         46.4320  -13.0110   -0.6310 C.3     209 LEU216      0.0000 DICT
+   3290 CD1        46.3730  -12.1010    0.6010 C.3     209 LEU216      0.0000 DICT
+   3291 CD2        47.2080  -12.3330   -1.7650 C.3     209 LEU216      0.0000 DICT
+   3292 H          45.4190  -15.1930   -2.2230 H       209 LEU216      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3293 HA         48.2580  -15.0430   -1.7770 H       209 LEU216      0.0000 BACKBONE|DICT|DIRECT
+   3294 HB2        47.8210  -14.2390    0.2800 H       209 LEU216      0.0000 DICT
+   3295 HB3        46.3100  -14.8570    0.2880 H       209 LEU216      0.0000 DICT
+   3296 HG         45.4940  -13.1460   -0.9490 H       209 LEU216      0.0000 DICT
+   3297 HD11       46.0010  -11.2100    0.3400 H       209 LEU216      0.0000 DICT
+   3298 HD12       45.7850  -12.5170    1.2950 H       209 LEU216      0.0000 DICT
+   3299 HD13       47.2940  -11.9820    0.9720 H       209 LEU216      0.0000 DICT
+   3300 HD21       46.8000  -11.4410   -1.9610 H       209 LEU216      0.0000 DICT
+   3301 HD22       48.1610  -12.2100   -1.4890 H       209 LEU216      0.0000 DICT
+   3302 HD23       47.1690  -12.9050   -2.5840 H       209 LEU216      0.0000 DICT
+   3303 N          48.1210  -17.5930   -1.7920 N.am    210 LYS217      0.0000 BACKBONE|DICT|DIRECT
+   3304 CA         48.1710  -19.0350   -1.5870 C.3     210 LYS217      0.0000 BACKBONE|DICT|DIRECT
+   3305 C          49.0070  -19.4320   -0.3800 C.2     210 LYS217      0.0000 BACKBONE|DICT|DIRECT
+   3306 O          48.7990  -20.5180    0.1720 O.2     210 LYS217      0.0000 BACKBONE|DICT|DIRECT
+   3307 CB         48.7120  -19.7120   -2.8470 C.3     210 LYS217      0.0000 DICT
+   3308 CG         48.1160  -19.1520   -4.1270 C.3     210 LYS217      0.0000 DICT
+   3309 CD         48.8030  -19.7120   -5.3580 C.3     210 LYS217      0.0000 DICT
+   3310 CE         47.8930  -19.6240   -6.5720 C.3     210 LYS217      0.0000 DICT
+   3311 NZ         48.5600  -20.1330   -7.8000 N.4     210 LYS217      0.0000 DICT
+   3312 H          48.5380  -17.2030   -2.6130 H       210 LYS217      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3313 HA         47.2370  -19.3590   -1.4370 H       210 LYS217      0.0000 BACKBONE|DICT|DIRECT
+   3314 HB2        48.5020  -20.6890   -2.7990 H       210 LYS217      0.0000 DICT
+   3315 HB3        49.7040  -19.5850   -2.8760 H       210 LYS217      0.0000 DICT
+   3316 HG2        48.2180  -18.1570   -4.1240 H       210 LYS217      0.0000 DICT
+   3317 HG3        47.1450  -19.3880   -4.1620 H       210 LYS217      0.0000 DICT
+   3318 HD2        49.0390  -20.6700   -5.1940 H       210 LYS217      0.0000 DICT
+   3319 HD3        49.6370  -19.1890   -5.5350 H       210 LYS217      0.0000 DICT
+   3320 HE2        47.6360  -18.6680   -6.7160 H       210 LYS217      0.0000 DICT
+   3321 HE3        47.0710  -20.1680   -6.4010 H       210 LYS217      0.0000 DICT
+   3322 HZ1        47.9320  -20.0590   -8.5750 H       210 LYS217      0.0000 DICT|ESSENTIAL
+   3323 HZ2        49.3800  -19.5910   -7.9830 H       210 LYS217      0.0000 DICT|ESSENTIAL
+   3324 HZ3        48.8160  -21.0910   -7.6680 H       210 LYS217      0.0000 DICT|ESSENTIAL
+   3325 N          49.9420  -18.5860    0.0440 N.am    211 LYS218      0.0000 BACKBONE|DICT|DIRECT
+   3326 CA         50.7360  -18.8790    1.2290 C.3     211 LYS218      0.0000 BACKBONE|DICT|DIRECT
+   3327 C          50.1200  -18.2830    2.4880 C.2     211 LYS218      0.0000 BACKBONE|DICT|DIRECT
+   3328 O          50.0690  -18.9470    3.5300 O.2     211 LYS218      0.0000 BACKBONE|DICT|DIRECT
+   3329 CB         52.1650  -18.3560    1.0480 C.3     211 LYS218      0.0000 DICT
+   3330 CG         52.8930  -18.9240   -0.1630 C.3     211 LYS218      0.0000 DICT
+   3331 CD         53.1900  -20.4050    0.0120 C.3     211 LYS218      0.0000 DICT
+   3332 CE         54.0220  -20.9400   -1.1440 C.3     211 LYS218      0.0000 DICT
+   3333 NZ         54.4340  -22.3550   -0.9290 N.4     211 LYS218      0.0000 DICT
+   3334 H          50.1020  -17.7360   -0.4580 H       211 LYS218      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3335 HA         50.7780  -19.8720    1.3400 H       211 LYS218      0.0000 BACKBONE|DICT|DIRECT
+   3336 HB2        52.6900  -18.5900    1.8670 H       211 LYS218      0.0000 DICT
+   3337 HB3        52.1240  -17.3620    0.9510 H       211 LYS218      0.0000 DICT
+   3338 HG2        53.7550  -18.4320   -0.2850 H       211 LYS218      0.0000 DICT
+   3339 HG3        52.3210  -18.8010   -0.9740 H       211 LYS218      0.0000 DICT
+   3340 HD2        52.3270  -20.9080    0.0530 H       211 LYS218      0.0000 DICT
+   3341 HD3        53.6940  -20.5380    0.8650 H       211 LYS218      0.0000 DICT
+   3342 HE2        54.8420  -20.3760   -1.2390 H       211 LYS218      0.0000 DICT
+   3343 HE3        53.4810  -20.8860   -1.9830 H       211 LYS218      0.0000 DICT
+   3344 HZ1        54.9770  -22.6660   -1.7090 H       211 LYS218      0.0000 DICT|ESSENTIAL
+   3345 HZ2        54.9820  -22.4200   -0.0950 H       211 LYS218      0.0000 DICT|ESSENTIAL
+   3346 HZ3        53.6200  -22.9290   -0.8390 H       211 LYS218      0.0000 DICT|ESSENTIAL
+   3347 N          49.6420  -17.0400    2.4010 N.am    212 TYR219      0.0000 BACKBONE|DICT|DIRECT
+   3348 CA         49.0680  -16.3650    3.5610 C.3     212 TYR219      0.0000 BACKBONE|DICT|DIRECT
+   3349 C          47.7640  -17.0280    3.9890 C.2     212 TYR219      0.0000 BACKBONE|DICT|DIRECT
+   3350 O          47.6360  -17.5110    5.1210 O.2     212 TYR219      0.0000 BACKBONE|DICT|DIRECT
+   3351 CB         48.8470  -14.8870    3.2340 C.3     212 TYR219      0.0000 DICT
+   3352 CG         48.9030  -13.9600    4.4250 C.ar    212 TYR219      0.0000 DICT
+   3353 CD1        47.7610  -13.6760    5.1670 C.ar    212 TYR219      0.0000 DICT
+   3354 CD2        50.0990  -13.3530    4.8010 C.ar    212 TYR219      0.0000 DICT
+   3355 CE1        47.8100  -12.8200    6.2550 C.ar    212 TYR219      0.0000 DICT
+   3356 CE2        50.1570  -12.4950    5.8860 C.ar    212 TYR219      0.0000 DICT
+   3357 CZ         49.0100  -12.2330    6.6080 C.ar    212 TYR219      0.0000 DICT
+   3358 OH         49.0650  -11.3830    7.6870 O.3     212 TYR219      0.0000 DICT
+   3359 H          49.6780  -16.5620    1.5240 H       212 TYR219      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3360 HA         49.7180  -16.4280    4.3180 H       212 TYR219      0.0000 BACKBONE|DICT|DIRECT
+   3361 HB2        47.9470  -14.7940    2.8090 H       212 TYR219      0.0000 DICT
+   3362 HB3        49.5530  -14.6030    2.5850 H       212 TYR219      0.0000 DICT
+   3363 HD1        46.8910  -14.0970    4.9110 H       212 TYR219      0.0000 DICT
+   3364 HD2        50.9300  -13.5400    4.2780 H       212 TYR219      0.0000 DICT
+   3365 HE1        46.9820  -12.6280    6.7820 H       212 TYR219      0.0000 DICT
+   3366 HE2        51.0240  -12.0680    6.1450 H       212 TYR219      0.0000 DICT
+   3367 HH         49.9320  -10.9570    7.9440 H       212 TYR219      0.0000 DICT|ESSENTIAL
+   3368 N          46.7800  -17.0620    3.0890 N.am    213 ASP220      0.0000 BACKBONE|DICT|DIRECT
+   3369 CA         45.5010  -17.6860    3.4070 C.3     213 ASP220      0.0000 BACKBONE|DICT|DIRECT
+   3370 C          45.6070  -19.2050    3.4460 C.2     213 ASP220      0.0000 BACKBONE|DICT|DIRECT
+   3371 O          44.8610  -19.8550    4.1870 O.2     213 ASP220      0.0000 BACKBONE|DICT|DIRECT
+   3372 CB         44.4420  -17.2600    2.3930 C.3     213 ASP220      0.0000 DICT
+   3373 CG         44.0510  -15.8040    2.5370 C.2     213 ASP220      0.0000 DICT
+   3374 OD1        44.7890  -15.0540    3.2120 O.co2   213 ASP220      0.0000 DICT
+   3375 OD2        43.0080  -15.4100    1.9700 O.co2   213 ASP220      0.0000 DICT
+   3376 H          46.9210  -16.6550    2.1860 H       213 ASP220      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3377 HA         45.2140  -17.3690    4.3110 H       213 ASP220      0.0000 BACKBONE|DICT|DIRECT
+   3378 HB2        43.6270  -17.8250    2.5240 H       213 ASP220      0.0000 DICT
+   3379 HB3        44.8040  -17.4050    1.4720 H       213 ASP220      0.0000 DICT
+   3380 N          46.5140  -19.7850    2.6550 N.am    214 GLY221      0.0000 BACKBONE|DICT|DIRECT
+   3381 CA         46.6820  -21.2290    2.6710 C.3     214 GLY221      0.0000 BACKBONE|DICT|DIRECT
+   3382 C          47.0460  -21.7670    4.0390 C.2     214 GLY221      0.0000 BACKBONE|DICT|DIRECT
+   3383 O          46.6210  -22.8640    4.4140 O.2     214 GLY221      0.0000 BACKBONE|DICT|DIRECT
+   3384 H          47.0790  -19.2240    2.0500 H       214 GLY221      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3385 HA2        47.4090  -21.4720    2.0290 H       214 GLY221      0.0000 BACKBONE|DICT|DIRECT
+   3386 HA3        45.8240  -21.6530    2.3800 H       214 GLY221      0.0000 DICT
+   3387 N          47.8210  -21.0010    4.8100 N.am    215 ARG222      0.0000 BACKBONE|DICT|DIRECT
+   3388 CA         48.1800  -21.4250    6.1570 C.3     215 ARG222      0.0000 BACKBONE|DICT|DIRECT
+   3389 C          46.9770  -21.3890    7.0950 C.2     215 ARG222      0.0000 BACKBONE|DICT|DIRECT
+   3390 O          46.8870  -22.2140    8.0130 O.2     215 ARG222      0.0000 BACKBONE|DICT|DIRECT
+   3391 CB         49.3220  -20.5550    6.6840 C.3     215 ARG222      0.0000 DICT
+   3392 CG         49.7120  -20.8260    8.1250 C.3     215 ARG222      0.0000 DICT
+   3393 CD         50.5730  -22.0700    8.2480 C.3     215 ARG222      0.0000 DICT
+   3394 NE         51.3740  -22.0420    9.4650 N.pl3   215 ARG222      0.0000 DICT
+   3395 CZ         52.6970  -22.1550    9.4830 C.cat   215 ARG222      0.0000 DICT
+   3396 NH1        53.3620  -22.1170   10.6300 N.pl3   215 ARG222      0.0000 DICT
+   3397 NH2        53.3560  -22.3190    8.3510 N.pl3   215 ARG222      0.0000 DICT
+   3398 H          48.1590  -20.1270    4.4600 H       215 ARG222      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3399 HA         48.5070  -22.3690    6.1080 H       215 ARG222      0.0000 BACKBONE|DICT|DIRECT
+   3400 HB2        49.0430  -19.5970    6.6120 H       215 ARG222      0.0000 DICT
+   3401 HB3        50.1250  -20.7130    6.1090 H       215 ARG222      0.0000 DICT
+   3402 HG2        48.8810  -20.9520    8.6680 H       215 ARG222      0.0000 DICT
+   3403 HG3        50.2240  -20.0420    8.4750 H       215 ARG222      0.0000 DICT
+   3404 HD2        51.1830  -22.1230    7.4580 H       215 ARG222      0.0000 DICT
+   3405 HD3        49.9810  -22.8750    8.2660 H       215 ARG222      0.0000 DICT
+   3406 HE         50.8990  -21.9310   10.3380 H       215 ARG222      0.0000 DICT|ESSENTIAL
+   3407 HH11       54.3580  -22.2030   10.6330 H       215 ARG222      0.0000 DICT|ESSENTIAL
+   3408 HH12       52.8670  -22.0020   11.4910 H       215 ARG222      0.0000 DICT|ESSENTIAL
+   3409 HH21       54.3520  -22.4040    8.3600 H       215 ARG222      0.0000 DICT|ESSENTIAL
+   3410 HH22       52.8590  -22.3580    7.4840 H       215 ARG222      0.0000 DICT|ESSENTIAL
+   3411 N          46.0390  -20.4620    6.8760 N.am    216 PHE223      0.0000 BACKBONE|DICT|DIRECT
+   3412 CA         44.7760  -20.4900    7.6090 C.3     216 PHE223      0.0000 BACKBONE|DICT|DIRECT
+   3413 C          44.0540  -21.8150    7.3980 C.2     216 PHE223      0.0000 BACKBONE|DICT|DIRECT
+   3414 O          43.7040  -22.5100    8.3590 O.2     216 PHE223      0.0000 BACKBONE|DICT|DIRECT
+   3415 CB         43.8830  -19.3260    7.1730 C.3     216 PHE223      0.0000 DICT
+   3416 CG         44.0330  -18.0950    8.0110 C.ar    216 PHE223      0.0000 DICT
+   3417 CD1        45.1110  -17.2450    7.8310 C.ar    216 PHE223      0.0000 DICT
+   3418 CD2        43.0870  -17.7770    8.9730 C.ar    216 PHE223      0.0000 DICT
+   3419 CE1        45.2490  -16.1030    8.6000 C.ar    216 PHE223      0.0000 DICT
+   3420 CE2        43.2190  -16.6360    9.7450 C.ar    216 PHE223      0.0000 DICT
+   3421 CZ         44.3010  -15.7990    9.5580 C.ar    216 PHE223      0.0000 DICT
+   3422 H          46.2040  -19.7410    6.2030 H       216 PHE223      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3423 HA         44.9740  -20.3890    8.5840 H       216 PHE223      0.0000 BACKBONE|DICT|DIRECT
+   3424 HB2        42.9300  -19.6250    7.2220 H       216 PHE223      0.0000 DICT
+   3425 HB3        44.1110  -19.0920    6.2280 H       216 PHE223      0.0000 DICT
+   3426 HD1        45.7980  -17.4590    7.1370 H       216 PHE223      0.0000 DICT
+   3427 HD2        42.3000  -18.3790    9.1110 H       216 PHE223      0.0000 DICT
+   3428 HE1        46.0340  -15.4990    8.4630 H       216 PHE223      0.0000 DICT
+   3429 HE2        42.5310  -16.4180   10.4380 H       216 PHE223      0.0000 DICT
+   3430 HZ         44.3980  -14.9740   10.1150 H       216 PHE223      0.0000 DICT
+   3431 N          43.8110  -22.1730    6.1330 N.am    217 LYS224      0.0000 BACKBONE|DICT|DIRECT
+   3432 CA         43.1730  -23.4490    5.8250 C.3     217 LYS224      0.0000 BACKBONE|DICT|DIRECT
+   3433 C          43.9670  -24.6220    6.3890 C.2     217 LYS224      0.0000 BACKBONE|DICT|DIRECT
+   3434 O          43.3860  -25.5760    6.9210 O.2     217 LYS224      0.0000 BACKBONE|DICT|DIRECT
+   3435 CB         43.0070  -23.5960    4.3130 C.3     217 LYS224      0.0000 DICT
+   3436 CG         42.9970  -25.0410    3.8410 C.3     217 LYS224      0.0000 DICT
+   3437 CD         43.2690  -25.1560    2.3550 C.3     217 LYS224      0.0000 DICT
+   3438 CE         42.0110  -24.9020    1.5490 C.3     217 LYS224      0.0000 DICT
+   3439 NZ         42.3060  -24.4010    0.1790 N.4     217 LYS224      0.0000 DICT
+   3440 H          44.0700  -21.5580    5.3880 H       217 LYS224      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3441 HA         42.2640  -23.4550    6.2430 H       217 LYS224      0.0000 BACKBONE|DICT|DIRECT
+   3442 HB2        43.7640  -23.1220    3.8640 H       217 LYS224      0.0000 DICT
+   3443 HB3        42.1420  -23.1700    4.0470 H       217 LYS224      0.0000 DICT
+   3444 HG2        42.1000  -25.4380    4.0370 H       217 LYS224      0.0000 DICT
+   3445 HG3        43.7010  -25.5480    4.3380 H       217 LYS224      0.0000 DICT
+   3446 HD2        43.6050  -26.0760    2.1550 H       217 LYS224      0.0000 DICT
+   3447 HD3        43.9630  -24.4840    2.0970 H       217 LYS224      0.0000 DICT
+   3448 HE2        41.4550  -24.2220    2.0270 H       217 LYS224      0.0000 DICT
+   3449 HE3        41.4990  -25.7580    1.4750 H       217 LYS224      0.0000 DICT
+   3450 HZ1        41.5850  -24.6980   -0.4470 H       217 LYS224      0.0000 DICT|ESSENTIAL
+   3451 HZ2        42.3470  -23.4020    0.1910 H       217 LYS224      0.0000 DICT|ESSENTIAL
+   3452 HZ3        43.1850  -24.7670   -0.1280 H       217 LYS224      0.0000 DICT|ESSENTIAL
+   3453 N          45.2980  -24.5680    6.2860 N.am    218 ASP225      0.0000 BACKBONE|DICT|DIRECT
+   3454 CA         46.1250  -25.6630    6.7860 C.3     218 ASP225      0.0000 BACKBONE|DICT|DIRECT
+   3455 C          45.9520  -25.8420    8.2890 C.2     218 ASP225      0.0000 BACKBONE|DICT|DIRECT
+   3456 O          45.7410  -26.9600    8.7730 O.2     218 ASP225      0.0000 BACKBONE|DICT|DIRECT
+   3457 CB         47.5930  -25.4110    6.4420 C.3     218 ASP225      0.0000 DICT
+   3458 CG         47.9150  -25.7120    4.9930 C.2     218 ASP225      0.0000 DICT
+   3459 OD1        46.9810  -25.9850    4.2120 O.co2   218 ASP225      0.0000 DICT
+   3460 OD2        49.1090  -25.6620    4.6340 O.co2   218 ASP225      0.0000 DICT
+   3461 H          45.7310  -23.7720    5.8630 H       218 ASP225      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3462 HA         45.8360  -26.5070    6.3340 H       218 ASP225      0.0000 BACKBONE|DICT|DIRECT
+   3463 HB2        48.1620  -25.9930    7.0230 H       218 ASP225      0.0000 DICT
+   3464 HB3        47.8040  -24.4500    6.6230 H       218 ASP225      0.0000 DICT
+   3465 N          46.0250  -24.7450    9.0440 N.am    219 ILE226      0.0000 BACKBONE|DICT|DIRECT
+   3466 CA         45.9620  -24.8320   10.4990 C.3     219 ILE226      0.0000 BACKBONE|DICT|DIRECT
+   3467 C          44.5740  -25.2700   10.9570 C.2     219 ILE226      0.0000 BACKBONE|DICT|DIRECT
+   3468 O          44.4330  -26.0040   11.9430 O.2     219 ILE226      0.0000 BACKBONE|DICT|DIRECT
+   3469 CB         46.3830  -23.4870   11.1200 C.3     219 ILE226      0.0000 DICT
+   3470 CG1        47.8770  -23.2450   10.8780 C.3     219 ILE226      0.0000 DICT
+   3471 CG2        46.0630  -23.4430   12.6070 C.3     219 ILE226      0.0000 DICT
+   3472 CD1        48.3940  -21.9310   11.4250 C.3     219 ILE226      0.0000 DICT
+   3473 H          46.1240  -23.8510    8.6070 H       219 ILE226      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3474 HA         46.6180  -25.5270   10.7950 H       219 ILE226      0.0000 BACKBONE|DICT|DIRECT
+   3475 HB         45.8700  -22.7580   10.6670 H       219 ILE226      0.0000 DICT
+   3476 HG12       48.0400  -23.2590    9.8920 H       219 ILE226      0.0000 DICT
+   3477 HG13       48.3880  -23.9870   11.3110 H       219 ILE226      0.0000 DICT
+   3478 HG21       46.3460  -22.5610   12.9830 H       219 ILE226      0.0000 DICT
+   3479 HG22       45.0790  -23.5610   12.7400 H       219 ILE226      0.0000 DICT
+   3480 HG23       46.5530  -24.1780   13.0750 H       219 ILE226      0.0000 DICT
+   3481 HD11       49.3710  -21.8490   11.2280 H       219 ILE226      0.0000 DICT
+   3482 HD12       47.9020  -21.1740   10.9940 H       219 ILE226      0.0000 DICT
+   3483 HD13       48.2500  -21.9020   12.4140 H       219 ILE226      0.0000 DICT
+   3484 N          43.5300  -24.8450   10.2430 N.am    220 PHE227      0.0000 BACKBONE|DICT|DIRECT
+   3485 CA         42.1720  -25.2370   10.6070 C.3     220 PHE227      0.0000 BACKBONE|DICT|DIRECT
+   3486 C          41.9740  -26.7450   10.4870 C.2     220 PHE227      0.0000 BACKBONE|DICT|DIRECT
+   3487 O          41.4110  -27.3810   11.3850 O.2     220 PHE227      0.0000 BACKBONE|DICT|DIRECT
+   3488 CB         41.1610  -24.4930    9.7340 C.3     220 PHE227      0.0000 DICT
+   3489 CG         40.5730  -23.2740   10.3870 C.ar    220 PHE227      0.0000 DICT
+   3490 CD1        41.3690  -22.1880   10.7110 C.ar    220 PHE227      0.0000 DICT
+   3491 CD2        39.2170  -23.2110   10.6630 C.ar    220 PHE227      0.0000 DICT
+   3492 CE1        40.8240  -21.0660   11.3070 C.ar    220 PHE227      0.0000 DICT
+   3493 CE2        38.6660  -22.0910   11.2590 C.ar    220 PHE227      0.0000 DICT
+   3494 CZ         39.4690  -21.0170   11.5800 C.ar    220 PHE227      0.0000 DICT
+   3495 H          43.6790  -24.2530    9.4510 H       220 PHE227      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3496 HA         42.0150  -24.9760   11.5590 H       220 PHE227      0.0000 BACKBONE|DICT|DIRECT
+   3497 HB2        40.4160  -25.1210    9.5110 H       220 PHE227      0.0000 DICT
+   3498 HB3        41.6210  -24.2090    8.8930 H       220 PHE227      0.0000 DICT
+   3499 HD1        42.3490  -22.2160   10.5120 H       220 PHE227      0.0000 DICT
+   3500 HD2        38.6290  -23.9850   10.4280 H       220 PHE227      0.0000 DICT
+   3501 HE1        41.4090  -20.2900   11.5410 H       220 PHE227      0.0000 DICT
+   3502 HE2        37.6860  -22.0600   11.4570 H       220 PHE227      0.0000 DICT
+   3503 HZ         39.0730  -20.2050   12.0090 H       220 PHE227      0.0000 DICT
+   3504 N          42.4310  -27.3380    9.3790 N.am    221 GLN228      0.0000 BACKBONE|DICT|DIRECT
+   3505 CA         42.1880  -28.7610    9.1620 C.3     221 GLN228      0.0000 BACKBONE|DICT|DIRECT
+   3506 C          43.0730  -29.6280   10.0510 C.2     221 GLN228      0.0000 BACKBONE|DICT|DIRECT
+   3507 O          42.6280  -30.6780   10.5290 O.2     221 GLN228      0.0000 BACKBONE|DICT|DIRECT
+   3508 CB         42.3970  -29.1240    7.6910 C.3     221 GLN228      0.0000 DICT
+   3509 CG         41.8250  -30.4880    7.3160 C.3     221 GLN228      0.0000 DICT
+   3510 CD         40.3860  -30.4060    6.8420 C.2     221 GLN228      0.0000 DICT
+   3511 OE1        40.0280  -29.5280    6.0580 O.2     221 GLN228      0.0000 DICT
+   3512 NE2        39.5490  -31.3170    7.3290 N.am    221 GLN228      0.0000 DICT
+   3513 H          42.9380  -26.8070    8.7000 H       221 GLN228      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3514 HA         41.2340  -28.9510    9.3950 H       221 GLN228      0.0000 BACKBONE|DICT|DIRECT
+   3515 HB2        43.3790  -29.1290    7.5020 H       221 GLN228      0.0000 DICT
+   3516 HB3        41.9530  -28.4280    7.1270 H       221 GLN228      0.0000 DICT
+   3517 HG2        41.8650  -31.0840    8.1180 H       221 GLN228      0.0000 DICT
+   3518 HG3        42.3820  -30.8790    6.5830 H       221 GLN228      0.0000 DICT
+   3519 HE21       39.8830  -32.0140    7.9640 H       221 GLN228      0.0000 DICT|ESSENTIAL
+   3520 HE22       38.5860  -31.3060    7.0600 H       221 GLN228      0.0000 DICT|ESSENTIAL
+   3521 N          44.3240  -29.2160   10.2780 N.am    222 GLU229      0.0000 BACKBONE|DICT|DIRECT
+   3522 CA         45.1740  -29.9370   11.2230 C.3     222 GLU229      0.0000 BACKBONE|DICT|DIRECT
+   3523 C          44.5230  -29.9910   12.5990 C.2     222 GLU229      0.0000 BACKBONE|DICT|DIRECT
+   3524 O          44.4210  -31.0600   13.2120 O.2     222 GLU229      0.0000 BACKBONE|DICT|DIRECT
+   3525 CB         46.5540  -29.2810   11.3110 C.3     222 GLU229      0.0000 DICT
+   3526 CG         47.3670  -29.3160   10.0250 C.3     222 GLU229      0.0000 DICT
+   3527 CD         48.6260  -28.4680   10.1130 C.2     222 GLU229      0.0000 DICT
+   3528 OE1        49.0970  -28.2150   11.2430 O.co2   222 GLU229      0.0000 DICT
+   3529 OE2        49.1420  -28.0480    9.0550 O.co2   222 GLU229      0.0000 DICT
+   3530 H          44.6790  -28.4130    9.8000 H       222 GLU229      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3531 HA         45.2900  -30.8730   10.8920 H       222 GLU229      0.0000 BACKBONE|DICT|DIRECT
+   3532 HB2        47.0770  -29.7530   12.0210 H       222 GLU229      0.0000 DICT
+   3533 HB3        46.4260  -28.3240   11.5710 H       222 GLU229      0.0000 DICT
+   3534 HG2        46.8000  -28.9720    9.2770 H       222 GLU229      0.0000 DICT
+   3535 HG3        47.6300  -30.2620    9.8370 H       222 GLU229      0.0000 DICT
+   3536 N          44.0660  -28.8380   13.0940 N.am    223 ILE230      0.0000 BACKBONE|DICT|DIRECT
+   3537 CA         43.3830  -28.7910   14.3830 C.3     223 ILE230      0.0000 BACKBONE|DICT|DIRECT
+   3538 C          42.1000  -29.6120   14.3360 C.2     223 ILE230      0.0000 BACKBONE|DICT|DIRECT
+   3539 O          41.7560  -30.3110   15.2980 O.2     223 ILE230      0.0000 BACKBONE|DICT|DIRECT
+   3540 CB         43.1140  -27.3280   14.7840 C.3     223 ILE230      0.0000 DICT
+   3541 CG1        44.4270  -26.6350   15.1630 C.3     223 ILE230      0.0000 DICT
+   3542 CG2        42.1110  -27.2500   15.9270 C.3     223 ILE230      0.0000 DICT
+   3543 CD1        44.2630  -25.1900   15.5810 C.3     223 ILE230      0.0000 DICT
+   3544 H          44.1940  -27.9940   12.5730 H       223 ILE230      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3545 HA         43.9870  -29.1960   15.0700 H       223 ILE230      0.0000 BACKBONE|DICT|DIRECT
+   3546 HB         42.7260  -26.8530   13.9940 H       223 ILE230      0.0000 DICT
+   3547 HG12       45.0380  -26.6660   14.3720 H       223 ILE230      0.0000 DICT
+   3548 HG13       44.8390  -27.1370   15.9230 H       223 ILE230      0.0000 DICT
+   3549 HG21       41.9540  -26.2920   16.1680 H       223 ILE230      0.0000 DICT
+   3550 HG22       41.2480  -27.6680   15.6420 H       223 ILE230      0.0000 DICT
+   3551 HG23       42.4720  -27.7390   16.7210 H       223 ILE230      0.0000 DICT
+   3552 HD11       45.1570  -24.8060   15.8120 H       223 ILE230      0.0000 DICT
+   3553 HD12       43.8610  -24.6690   14.8280 H       223 ILE230      0.0000 DICT
+   3554 HD13       43.6620  -25.1400   16.3790 H       223 ILE230      0.0000 DICT
+   3555 N          41.3830  -29.5580   13.2120 N.am    224 TYR231      0.0000 BACKBONE|DICT|DIRECT
+   3556 CA         40.1460  -30.3210   13.0860 C.3     224 TYR231      0.0000 BACKBONE|DICT|DIRECT
+   3557 C          40.4180  -31.8200   13.1120 C.2     224 TYR231      0.0000 BACKBONE|DICT|DIRECT
+   3558 O          39.8020  -32.5590   13.8900 O.2     224 TYR231      0.0000 BACKBONE|DICT|DIRECT
+   3559 CB         39.4150  -29.9280   11.8020 C.3     224 TYR231      0.0000 DICT
+   3560 CG         38.1200  -30.6780   11.5800 C.ar    224 TYR231      0.0000 DICT
+   3561 CD1        37.0120  -30.4430   12.3860 C.ar    224 TYR231      0.0000 DICT
+   3562 CD2        38.0020  -31.6160   10.5600 C.ar    224 TYR231      0.0000 DICT
+   3563 CE1        35.8250  -31.1260   12.1880 C.ar    224 TYR231      0.0000 DICT
+   3564 CE2        36.8180  -32.3020   10.3530 C.ar    224 TYR231      0.0000 DICT
+   3565 CZ         35.7340  -32.0530   11.1700 C.ar    224 TYR231      0.0000 DICT
+   3566 OH         34.5560  -32.7320   10.9700 O.3     224 TYR231      0.0000 DICT
+   3567 H          41.6960  -28.9900   12.4500 H       224 TYR231      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3568 HA         39.5580  -30.0960   13.8630 H       224 TYR231      0.0000 BACKBONE|DICT|DIRECT
+   3569 HB2        40.0200  -30.1090   11.0270 H       224 TYR231      0.0000 DICT
+   3570 HB3        39.2090  -28.9500   11.8430 H       224 TYR231      0.0000 DICT
+   3571 HD1        37.0740  -29.7690   13.1220 H       224 TYR231      0.0000 DICT
+   3572 HD2        38.7860  -31.7980    9.9660 H       224 TYR231      0.0000 DICT
+   3573 HE1        35.0380  -30.9490   12.7790 H       224 TYR231      0.0000 DICT
+   3574 HE2        36.7480  -32.9740    9.6160 H       224 TYR231      0.0000 DICT
+   3575 HH         34.4850  -33.4050   10.2330 H       224 TYR231      0.0000 DICT|ESSENTIAL
+   3576 N          41.3490  -32.2850   12.2720 N.am    225 ASP232      0.0000 BACKBONE|DICT|DIRECT
+   3577 CA         41.5910  -33.7190   12.1410 C.3     225 ASP232      0.0000 BACKBONE|DICT|DIRECT
+   3578 C          42.1400  -34.3310   13.4230 C.2     225 ASP232      0.0000 BACKBONE|DICT|DIRECT
+   3579 O          41.8640  -35.5000   13.7150 O.2     225 ASP232      0.0000 BACKBONE|DICT|DIRECT
+   3580 CB         42.5510  -33.9910   10.9810 C.3     225 ASP232      0.0000 DICT
+   3581 CG         41.9570  -33.6270    9.6360 C.2     225 ASP232      0.0000 DICT
+   3582 OD1        40.7170  -33.4960    9.5490 O.co2   225 ASP232      0.0000 DICT
+   3583 OD2        42.7300  -33.4790    8.6640 O.co2   225 ASP232      0.0000 DICT
+   3584 H          41.8870  -31.6420   11.7260 H       225 ASP232      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3585 HA         40.7190  -34.1630   11.9330 H       225 ASP232      0.0000 BACKBONE|DICT|DIRECT
+   3586 HB2        42.7810  -34.9640   10.9770 H       225 ASP232      0.0000 DICT
+   3587 HB3        43.3820  -33.4530   11.1200 H       225 ASP232      0.0000 DICT
+   3588 N          42.9040  -33.5710   14.2020 N.am    226 LYS233      0.0000 BACKBONE|DICT|DIRECT
+   3589 CA         43.5680  -34.1110   15.3780 C.3     226 LYS233      0.0000 BACKBONE|DICT|DIRECT
+   3590 C          42.8670  -33.7760   16.6880 C.2     226 LYS233      0.0000 BACKBONE|DICT|DIRECT
+   3591 O          43.3210  -34.2310   17.7420 O.2     226 LYS233      0.0000 BACKBONE|DICT|DIRECT
+   3592 CB         45.0220  -33.6210   15.4380 C.3     226 LYS233      0.0000 DICT
+   3593 CG         45.9190  -34.1910   14.3420 C.3     226 LYS233      0.0000 DICT
+   3594 CD         47.3530  -33.7030   14.4890 C.3     226 LYS233      0.0000 DICT
+   3595 CE         48.0780  -33.6960   13.1520 C.3     226 LYS233      0.0000 DICT
+   3596 NZ         48.3300  -32.3080   12.6710 N.4     226 LYS233      0.0000 DICT
+   3597 H          43.0250  -32.6050   13.9740 H       226 LYS233      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3598 HA         43.5860  -35.1070   15.2880 H       226 LYS233      0.0000 BACKBONE|DICT|DIRECT
+   3599 HB2        45.4050  -33.8820   16.3240 H       226 LYS233      0.0000 DICT
+   3600 HB3        45.0210  -32.6240   15.3560 H       226 LYS233      0.0000 DICT
+   3601 HG2        45.5670  -33.9040   13.4510 H       226 LYS233      0.0000 DICT
+   3602 HG3        45.9080  -35.1890   14.3990 H       226 LYS233      0.0000 DICT
+   3603 HD2        47.8390  -34.3080   15.1190 H       226 LYS233      0.0000 DICT
+   3604 HD3        47.3440  -32.7740   14.8590 H       226 LYS233      0.0000 DICT
+   3605 HE2        47.5180  -34.1770   12.4770 H       226 LYS233      0.0000 DICT
+   3606 HE3        48.9540  -34.1680   13.2550 H       226 LYS233      0.0000 DICT
+   3607 HZ1        48.8070  -32.3410   11.7930 H       226 LYS233      0.0000 DICT|ESSENTIAL
+   3608 HZ2        47.4580  -31.8300   12.5600 H       226 LYS233      0.0000 DICT|ESSENTIAL
+   3609 HZ3        48.8940  -31.8210   13.3380 H       226 LYS233      0.0000 DICT|ESSENTIAL
+   3610 N          41.7740  -33.0120   16.6640 N.am    227 GLN234      0.0000 BACKBONE|DICT|DIRECT
+   3611 CA         41.1790  -32.5970   17.9300 C.3     227 GLN234      0.0000 BACKBONE|DICT|DIRECT
+   3612 C          39.6610  -32.4400   17.9190 C.2     227 GLN234      0.0000 BACKBONE|DICT|DIRECT
+   3613 O          39.0480  -32.3790   18.9900 O.2     227 GLN234      0.0000 BACKBONE|DICT|DIRECT
+   3614 CB         41.8090  -31.2820   18.3950 C.3     227 GLN234      0.0000 DICT
+   3615 CG         43.0760  -31.4610   19.2030 C.3     227 GLN234      0.0000 DICT
+   3616 CD         43.2960  -30.3390   20.1890 C.2     227 GLN234      0.0000 DICT
+   3617 OE1        43.9450  -29.3420   19.8770 O.2     227 GLN234      0.0000 DICT
+   3618 NE2        42.7530  -30.4940   21.3930 N.am    227 GLN234      0.0000 DICT
+   3619 H          41.3700  -32.7290   15.7940 H       227 GLN234      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3620 HA         41.4040  -33.2950   18.6100 H       227 GLN234      0.0000 BACKBONE|DICT|DIRECT
+   3621 HB2        41.1420  -30.7950   18.9590 H       227 GLN234      0.0000 DICT
+   3622 HB3        42.0260  -30.7340   17.5870 H       227 GLN234      0.0000 DICT
+   3623 HG2        43.8540  -31.4940   18.5760 H       227 GLN234      0.0000 DICT
+   3624 HG3        43.0160  -32.3230   19.7060 H       227 GLN234      0.0000 DICT
+   3625 HE21       42.2330  -31.3210   21.6040 H       227 GLN234      0.0000 DICT|ESSENTIAL
+   3626 HE22       42.8650  -29.7830   22.0870 H       227 GLN234      0.0000 DICT|ESSENTIAL
+   3627 N          39.0300  -32.3640   16.7470 N.am    228 TYR235      0.0000 BACKBONE|DICT|DIRECT
+   3628 CA         37.6060  -32.0490   16.7070 C.3     228 TYR235      0.0000 BACKBONE|DICT|DIRECT
+   3629 C          36.7580  -32.9330   15.8030 C.2     228 TYR235      0.0000 BACKBONE|DICT|DIRECT
+   3630 O          35.5300  -32.8980   15.9340 O.2     228 TYR235      0.0000 BACKBONE|DICT|DIRECT
+   3631 CB         37.3910  -30.5850   16.2840 C.3     228 TYR235      0.0000 DICT
+   3632 CG         37.8040  -29.5760   17.3310 C.ar    228 TYR235      0.0000 DICT
+   3633 CD1        36.9840  -29.3000   18.4180 C.ar    228 TYR235      0.0000 DICT
+   3634 CD2        39.0130  -28.8990   17.2330 C.ar    228 TYR235      0.0000 DICT
+   3635 CE1        37.3560  -28.3770   19.3790 C.ar    228 TYR235      0.0000 DICT
+   3636 CE2        39.3930  -27.9760   18.1900 C.ar    228 TYR235      0.0000 DICT
+   3637 CZ         38.5620  -27.7180   19.2590 C.ar    228 TYR235      0.0000 DICT
+   3638 OH         38.9400  -26.7990   20.2120 O.3     228 TYR235      0.0000 DICT
+   3639 H          39.5320  -32.5230   15.8970 H       228 TYR235      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3640 HA         37.2520  -32.1460   17.6370 H       228 TYR235      0.0000 BACKBONE|DICT|DIRECT
+   3641 HB2        36.4190  -30.4540   16.0870 H       228 TYR235      0.0000 DICT
+   3642 HB3        37.9250  -30.4150   15.4560 H       228 TYR235      0.0000 DICT
+   3643 HD1        36.1100  -29.7770   18.5070 H       228 TYR235      0.0000 DICT
+   3644 HD2        39.6180  -29.0820   16.4580 H       228 TYR235      0.0000 DICT
+   3645 HE1        36.7550  -28.1890   20.1560 H       228 TYR235      0.0000 DICT
+   3646 HE2        40.2670  -27.4980   18.1070 H       228 TYR235      0.0000 DICT
+   3647 HH         39.8140  -26.3210   20.1260 H       228 TYR235      0.0000 DICT|ESSENTIAL
+   3648 N          37.3530  -33.7190   14.9020 N.am    229 LYS236      0.0000 BACKBONE|DICT|DIRECT
+   3649 CA         36.5420  -34.4530   13.9340 C.3     229 LYS236      0.0000 BACKBONE|DICT|DIRECT
+   3650 C          35.6630  -35.5050   14.6010 C.2     229 LYS236      0.0000 BACKBONE|DICT|DIRECT
+   3651 O          34.5470  -35.7610   14.1330 O.2     229 LYS236      0.0000 BACKBONE|DICT|DIRECT
+   3652 CB         37.4360  -35.0970   12.8730 C.3     229 LYS236      0.0000 DICT
+   3653 CG         36.6620  -35.8150   11.7810 C.3     229 LYS236      0.0000 DICT
+   3654 CD         37.5140  -36.0450   10.5460 C.3     229 LYS236      0.0000 DICT
+   3655 CE         36.7700  -36.8860    9.5190 C.3     229 LYS236      0.0000 DICT
+   3656 NZ         35.3500  -36.4580    9.3620 N.4     229 LYS236      0.0000 DICT
+   3657 H          38.3490  -33.8050   14.8900 H       229 LYS236      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3658 HA         35.9430  -33.7970   13.4750 H       229 LYS236      0.0000 BACKBONE|DICT|DIRECT
+   3659 HB2        38.0350  -35.7590   13.3240 H       229 LYS236      0.0000 DICT
+   3660 HB3        37.9900  -34.3810   12.4490 H       229 LYS236      0.0000 DICT
+   3661 HG2        35.8690  -35.2610   11.5290 H       229 LYS236      0.0000 DICT
+   3662 HG3        36.3530  -36.6990   12.1310 H       229 LYS236      0.0000 DICT
+   3663 HD2        38.3530  -36.5200   10.8110 H       229 LYS236      0.0000 DICT
+   3664 HD3        37.7450  -35.1610   10.1390 H       229 LYS236      0.0000 DICT
+   3665 HE2        36.7880  -37.8420    9.8120 H       229 LYS236      0.0000 DICT
+   3666 HE3        37.2320  -36.7990    8.6360 H       229 LYS236      0.0000 DICT
+   3667 HZ1        35.0470  -36.6440    8.4270 H       229 LYS236      0.0000 DICT|ESSENTIAL
+   3668 HZ2        34.7760  -36.9640   10.0060 H       229 LYS236      0.0000 DICT|ESSENTIAL
+   3669 HZ3        35.2750  -35.4780    9.5480 H       229 LYS236      0.0000 DICT|ESSENTIAL
+   3670 N          36.1320  -36.1140   15.6930 N.am    230 SER237      0.0000 BACKBONE|DICT|DIRECT
+   3671 CA         35.3230  -37.1190   16.3770 C.3     230 SER237      0.0000 BACKBONE|DICT|DIRECT
+   3672 C          34.0710  -36.5030   16.9880 C.2     230 SER237      0.0000 BACKBONE|DICT|DIRECT
+   3673 O          32.9840  -37.0870   16.9110 O.2     230 SER237      0.0000 BACKBONE|DICT|DIRECT
+   3674 CB         36.1530  -37.8230   17.4500 C.3     230 SER237      0.0000 DICT
+   3675 OG         37.1600  -38.6290   16.8670 O.3     230 SER237      0.0000 DICT
+   3676 H          37.0390  -35.8810   16.0430 H       230 SER237      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3677 HA         35.0390  -37.8020   15.7040 H       230 SER237      0.0000 BACKBONE|DICT|DIRECT
+   3678 HB2        35.5510  -38.4000   18.0020 H       230 SER237      0.0000 DICT
+   3679 HB3        36.5830  -37.1350   18.0340 H       230 SER237      0.0000 DICT
+   3680 HG         37.6870  -39.0770   17.5890 H       230 SER237      0.0000 DICT|ESSENTIAL
+   3681 N          34.2030  -35.3240   17.6000 N.am    231 GLN238      0.0000 BACKBONE|DICT|DIRECT
+   3682 CA         33.0420  -34.6740   18.1980 C.3     231 GLN238      0.0000 BACKBONE|DICT|DIRECT
+   3683 C          32.0920  -34.1350   17.1360 C.2     231 GLN238      0.0000 BACKBONE|DICT|DIRECT
+   3684 O          30.8750  -34.1090   17.3510 O.2     231 GLN238      0.0000 BACKBONE|DICT|DIRECT
+   3685 CB         33.4980  -33.5520   19.1250 C.3     231 GLN238      0.0000 DICT
+   3686 CG         34.7050  -33.9160   19.9690 C.3     231 GLN238      0.0000 DICT
+   3687 CD         35.1390  -32.7850   20.8780 C.2     231 GLN238      0.0000 DICT
+   3688 OE1        34.3130  -32.1470   21.5310 O.2     231 GLN238      0.0000 DICT
+   3689 NE2        36.4410  -32.5250   20.9190 N.am    231 GLN238      0.0000 DICT
+   3690 H          35.1000  -34.8850   17.6490 H       231 GLN238      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3691 HA         32.5500  -35.3520   18.7440 H       231 GLN238      0.0000 BACKBONE|DICT|DIRECT
+   3692 HB2        32.7420  -33.3210   19.7370 H       231 GLN238      0.0000 DICT
+   3693 HB3        33.7310  -32.7560   18.5670 H       231 GLN238      0.0000 DICT
+   3694 HG2        35.4640  -34.1480   19.3600 H       231 GLN238      0.0000 DICT
+   3695 HG3        34.4750  -34.7100   20.5320 H       231 GLN238      0.0000 DICT
+   3696 HE21       37.0770  -33.0690   20.3720 H       231 GLN238      0.0000 DICT|ESSENTIAL
+   3697 HE22       36.7850  -31.7850   21.4970 H       231 GLN238      0.0000 DICT|ESSENTIAL
+   3698 N          32.6270  -33.7030   15.9920 N.am    232 PHE239      0.0000 BACKBONE|DICT|DIRECT
+   3699 CA         31.7750  -33.2180   14.9100 C.3     232 PHE239      0.0000 BACKBONE|DICT|DIRECT
+   3700 C          30.9250  -34.3410   14.3300 C.2     232 PHE239      0.0000 BACKBONE|DICT|DIRECT
+   3701 O          29.7390  -34.1430   14.0380 O.2     232 PHE239      0.0000 BACKBONE|DICT|DIRECT
+   3702 CB         32.6310  -32.5720   13.8200 C.3     232 PHE239      0.0000 DICT
+   3703 CG         32.7590  -31.0810   13.9520 C.ar    232 PHE239      0.0000 DICT
+   3704 CD1        33.4440  -30.5200   15.0170 C.ar    232 PHE239      0.0000 DICT
+   3705 CD2        32.1960  -30.2390   13.0050 C.ar    232 PHE239      0.0000 DICT
+   3706 CE1        33.5580  -29.1460   15.1370 C.ar    232 PHE239      0.0000 DICT
+   3707 CE2        32.3050  -28.8690   13.1200 C.ar    232 PHE239      0.0000 DICT
+   3708 CZ         32.9880  -28.3210   14.1860 C.ar    232 PHE239      0.0000 DICT
+   3709 H          33.6200  -33.7120   15.8750 H       232 PHE239      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3710 HA         31.1620  -32.5210   15.2820 H       232 PHE239      0.0000 BACKBONE|DICT|DIRECT
+   3711 HB2        32.2170  -32.7750   12.9330 H       232 PHE239      0.0000 DICT
+   3712 HB3        33.5470  -32.9720   13.8600 H       232 PHE239      0.0000 DICT
+   3713 HD1        33.8600  -31.1130   15.7060 H       232 PHE239      0.0000 DICT
+   3714 HD2        31.7040  -30.6310   12.2280 H       232 PHE239      0.0000 DICT
+   3715 HE1        34.0520  -28.7510   15.9110 H       232 PHE239      0.0000 DICT
+   3716 HE2        31.8900  -28.2740   12.4320 H       232 PHE239      0.0000 DICT
+   3717 HZ         33.0710  -27.3280   14.2700 H       232 PHE239      0.0000 DICT
+   3718 N          31.5120  -35.5270   14.1570 N.am    233 GLU240      0.0000 BACKBONE|DICT|DIRECT
+   3719 CA         30.7570  -36.6510   13.6150 C.3     233 GLU240      0.0000 BACKBONE|DICT|DIRECT
+   3720 C          29.7570  -37.1980   14.6260 C.2     233 GLU240      0.0000 BACKBONE|DICT|DIRECT
+   3721 O          28.6960  -37.6980   14.2350 O.2     233 GLU240      0.0000 BACKBONE|DICT|DIRECT
+   3722 CB         31.7160  -37.7460   13.1540 C.3     233 GLU240      0.0000 DICT
+   3723 CG         32.5670  -37.3410   11.9610 C.3     233 GLU240      0.0000 DICT
+   3724 CD         33.6890  -38.3200   11.6830 C.2     233 GLU240      0.0000 DICT
+   3725 OE1        34.1560  -38.9780   12.6370 O.co2   233 GLU240      0.0000 DICT
+   3726 OE2        34.1030  -38.4320   10.5100 O.co2   233 GLU240      0.0000 DICT
+   3727 H          32.4750  -35.6460   14.4000 H       233 GLU240      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3728 HA         30.2480  -36.3280   12.8170 H       233 GLU240      0.0000 BACKBONE|DICT|DIRECT
+   3729 HB2        31.1800  -38.5510   12.9020 H       233 GLU240      0.0000 DICT
+   3730 HB3        32.3240  -37.9750   13.9140 H       233 GLU240      0.0000 DICT
+   3731 HG2        32.9650  -36.4420   12.1430 H       233 GLU240      0.0000 DICT
+   3732 HG3        31.9800  -37.2890   11.1530 H       233 GLU240      0.0000 DICT
+   3733 N          30.0730  -37.1110   15.9220 N.am    234 ALA241      0.0000 BACKBONE|DICT|DIRECT
+   3734 CA         29.1210  -37.5280   16.9470 C.3     234 ALA241      0.0000 BACKBONE|DICT|DIRECT
+   3735 C          27.8690  -36.6640   16.9140 C.2     234 ALA241      0.0000 BACKBONE|DICT|DIRECT
+   3736 O          26.7490  -37.1710   17.0540 O.2     234 ALA241      0.0000 BACKBONE|DICT|DIRECT
+   3737 CB         29.7770  -37.4770   18.3270 C.3     234 ALA241      0.0000 DICT
+   3738 H          30.9690  -36.7570   16.1910 H       234 ALA241      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3739 HA         28.8540  -38.4740   16.7610 H       234 ALA241      0.0000 BACKBONE|DICT|DIRECT
+   3740 HB1        29.1170  -37.7640   19.0210 H       234 ALA241      0.0000 DICT
+   3741 HB2        30.5660  -38.0910   18.3440 H       234 ALA241      0.0000 DICT
+   3742 HB3        30.0770  -36.5430   18.5190 H       234 ALA241      0.0000 DICT
+   3743 N          28.0350  -35.3560   16.7340 N.am    235 GLN242      0.0000 BACKBONE|DICT|DIRECT
+   3744 CA         26.9170  -34.4560   16.5010 C.3     235 GLN242      0.0000 BACKBONE|DICT|DIRECT
+   3745 C          26.5480  -34.3710   15.0240 C.2     235 GLN242      0.0000 BACKBONE|DICT|DIRECT
+   3746 O          25.6800  -33.5720   14.6580 O.2     235 GLN242      0.0000 BACKBONE|DICT|DIRECT
+   3747 CB         27.2350  -33.0630   17.0530 C.3     235 GLN242      0.0000 DICT
+   3748 CG         27.7620  -33.0820   18.4850 C.3     235 GLN242      0.0000 DICT
+   3749 CD         27.7190  -31.7180   19.1550 C.2     235 GLN242      0.0000 DICT
+   3750 OE1        26.8860  -30.8770   18.8220 O.2     235 GLN242      0.0000 DICT
+   3751 NE2        28.6200  -31.4970   20.1060 N.am    235 GLN242      0.0000 DICT
+   3752 H          28.9610  -34.9790   16.7600 H       235 GLN242      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3753 HA         26.1250  -34.8120   16.9970 H       235 GLN242      0.0000 BACKBONE|DICT|DIRECT
+   3754 HB2        26.3990  -32.5150   17.0310 H       235 GLN242      0.0000 DICT
+   3755 HB3        27.9260  -32.6400   16.4670 H       235 GLN242      0.0000 DICT
+   3756 HG2        28.7100  -33.4000   18.4710 H       235 GLN242      0.0000 DICT
+   3757 HG3        27.2050  -33.7170   19.0200 H       235 GLN242      0.0000 DICT
+   3758 HE21       29.2800  -32.2100   20.3450 H       235 GLN242      0.0000 DICT|ESSENTIAL
+   3759 HE22       28.6390  -30.6180   20.5830 H       235 GLN242      0.0000 DICT|ESSENTIAL
+   3760 N          27.1880  -35.1870   14.1790 N.am    236 LYS243      0.0000 BACKBONE|DICT|DIRECT
+   3761 CA         26.8890  -35.2690   12.7450 C.3     236 LYS243      0.0000 BACKBONE|DICT|DIRECT
+   3762 C          26.8840  -33.8930   12.0860 C.2     236 LYS243      0.0000 BACKBONE|DICT|DIRECT
+   3763 O          26.0820  -33.6020   11.1960 O.2     236 LYS243      0.0000 BACKBONE|DICT|DIRECT
+   3764 CB         25.5700  -36.0030   12.4950 C.3     236 LYS243      0.0000 DICT
+   3765 CG         25.2790  -37.1020   13.5000 C.3     236 LYS243      0.0000 DICT
+   3766 CD         23.8290  -37.5390   13.4500 C.3     236 LYS243      0.0000 DICT
+   3767 CE         23.4340  -38.2240   14.7460 C.3     236 LYS243      0.0000 DICT
+   3768 NZ         24.4350  -39.2350   15.1780 N.4     236 LYS243      0.0000 DICT
+   3769 H          27.9100  -35.7740   14.5450 H       236 LYS243      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3770 HA         27.6170  -35.8050   12.3170 H       236 LYS243      0.0000 BACKBONE|DICT|DIRECT
+   3771 HB2        25.6050  -36.4110   11.5830 H       236 LYS243      0.0000 DICT
+   3772 HB3        24.8260  -35.3360   12.5330 H       236 LYS243      0.0000 DICT
+   3773 HG2        25.4840  -36.7640   14.4180 H       236 LYS243      0.0000 DICT
+   3774 HG3        25.8620  -37.8890   13.2970 H       236 LYS243      0.0000 DICT
+   3775 HD2        23.7040  -38.1760   12.6900 H       236 LYS243      0.0000 DICT
+   3776 HD3        23.2480  -36.7370   13.3120 H       236 LYS243      0.0000 DICT
+   3777 HE2        22.5540  -38.6790   14.6140 H       236 LYS243      0.0000 DICT
+   3778 HE3        23.3470  -37.5310   15.4620 H       236 LYS243      0.0000 DICT
+   3779 HZ1        25.1170  -38.7990   15.7650 H       236 LYS243      0.0000 DICT|ESSENTIAL
+   3780 HZ2        23.9750  -39.9630   15.6860 H       236 LYS243      0.0000 DICT|ESSENTIAL
+   3781 HZ3        24.8860  -39.6230   14.3740 H       236 LYS243      0.0000 DICT|ESSENTIAL
+   3782 N          27.7850  -33.0310   12.5450 N.am    237 ILE244      0.0000 BACKBONE|DICT|DIRECT
+   3783 CA         28.1160  -31.8100   11.8260 C.3     237 ILE244      0.0000 BACKBONE|DICT|DIRECT
+   3784 C          29.4770  -32.0450   11.1870 C.2     237 ILE244      0.0000 BACKBONE|DICT|DIRECT
+   3785 O          30.0420  -33.1390   11.2980 O.2     237 ILE244      0.0000 BACKBONE|DICT|DIRECT
+   3786 CB         28.1150  -30.5790   12.7500 C.3     237 ILE244      0.0000 DICT
+   3787 CG1        28.9620  -30.8500   13.9940 C.3     237 ILE244      0.0000 DICT
+   3788 CG2        26.6890  -30.2070   13.1370 C.3     237 ILE244      0.0000 DICT
+   3789 CD1        29.0160  -29.6870   14.9640 C.3     237 ILE244      0.0000 DICT
+   3790 H          28.2490  -33.2270   13.4090 H       237 ILE244      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3791 HA         27.4410  -31.6700   11.1020 H       237 ILE244      0.0000 BACKBONE|DICT|DIRECT
+   3792 HB         28.5190  -29.8110   12.2540 H       237 ILE244      0.0000 DICT
+   3793 HG12       29.8950  -31.0590   13.7010 H       237 ILE244      0.0000 DICT
+   3794 HG13       28.5770  -31.6400   14.4710 H       237 ILE244      0.0000 DICT
+   3795 HG21       26.7040  -29.4070   13.7360 H       237 ILE244      0.0000 DICT
+   3796 HG22       26.1640  -29.9960   12.3120 H       237 ILE244      0.0000 DICT
+   3797 HG23       26.2630  -30.9740   13.6160 H       237 ILE244      0.0000 DICT
+   3798 HD11       29.5840  -29.9340   15.7490 H       237 ILE244      0.0000 DICT
+   3799 HD12       29.4080  -28.8890   14.5060 H       237 ILE244      0.0000 DICT
+   3800 HD13       28.0910  -29.4700   15.2770 H       237 ILE244      0.0000 DICT
+   3801 N          30.0160  -31.0310   10.5190 N.am    238 TRP245      0.0000 BACKBONE|DICT|DIRECT
+   3802 CA         31.2640  -31.1900    9.7900 C.3     238 TRP245      0.0000 BACKBONE|DICT|DIRECT
+   3803 C          31.9530  -29.8390    9.6950 C.2     238 TRP245      0.0000 BACKBONE|DICT|DIRECT
+   3804 O          31.3950  -28.8040   10.0660 O.2     238 TRP245      0.0000 BACKBONE|DICT|DIRECT
+   3805 CB         31.0140  -31.7620    8.3950 C.3     238 TRP245      0.0000 DICT
+   3806 CG         30.0610  -30.9220    7.6190 C.2     238 TRP245      0.0000 DICT
+   3807 CD1        30.3700  -29.8790    6.7980 C.2     238 TRP245      0.0000 DICT
+   3808 CD2        28.6330  -31.0290    7.6130 C.ar    238 TRP245      0.0000 DICT
+   3809 NE1        29.2230  -29.3360    6.2710 N.pl3   238 TRP245      0.0000 DICT
+   3810 CE2        28.1430  -30.0250    6.7550 C.ar    238 TRP245      0.0000 DICT
+   3811 CE3        27.7210  -31.8830    8.2430 C.ar    238 TRP245      0.0000 DICT
+   3812 CZ2        26.7820  -29.8500    6.5110 C.ar    238 TRP245      0.0000 DICT
+   3813 CZ3        26.3710  -31.7070    8.0010 C.ar    238 TRP245      0.0000 DICT
+   3814 CH2        25.9140  -30.6990    7.1420 C.ar    238 TRP245      0.0000 DICT
+   3815 H          29.5560  -30.1430   10.5180 H       238 TRP245      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3816 HA         31.8550  -31.8190   10.2950 H       238 TRP245      0.0000 BACKBONE|DICT|DIRECT
+   3817 HB2        30.6350  -32.6830    8.4850 H       238 TRP245      0.0000 DICT
+   3818 HB3        31.8830  -31.8060    7.9020 H       238 TRP245      0.0000 DICT
+   3819 HD1        31.2970  -29.5560    6.6070 H       238 TRP245      0.0000 DICT
+   3820 HE1        29.1830  -28.5630    5.6370 H       238 TRP245      0.0000 DICT|ESSENTIAL
+   3821 HE3        28.0390  -32.6060    8.8560 H       238 TRP245      0.0000 DICT
+   3822 HZ2        26.4520  -29.1320    5.8980 H       238 TRP245      0.0000 DICT
+   3823 HZ3        25.7090  -32.3100    8.4470 H       238 TRP245      0.0000 DICT
+   3824 HH2        24.9310  -30.5980    6.9870 H       238 TRP245      0.0000 DICT
+   3825 N          33.1820  -29.8610    9.1870 N.am    239 TYR246      0.0000 BACKBONE|DICT|DIRECT
+   3826 CA         33.9140  -28.6460    8.8660 C.3     239 TYR246      0.0000 BACKBONE|DICT|DIRECT
+   3827 C          34.4850  -28.7560    7.4620 C.2     239 TYR246      0.0000 BACKBONE|DICT|DIRECT
+   3828 O          34.9970  -29.8110    7.0740 O.2     239 TYR246      0.0000 BACKBONE|DICT|DIRECT
+   3829 CB         35.0500  -28.3720    9.8540 C.3     239 TYR246      0.0000 DICT
+   3830 CG         36.0950  -27.4620    9.2550 C.ar    239 TYR246      0.0000 DICT
+   3831 CD1        35.8520  -26.1040    9.1090 C.ar    239 TYR246      0.0000 DICT
+   3832 CD2        37.3080  -27.9660    8.8010 C.ar    239 TYR246      0.0000 DICT
+   3833 CE1        36.7910  -25.2690    8.5450 C.ar    239 TYR246      0.0000 DICT
+   3834 CE2        38.2530  -27.1380    8.2350 C.ar    239 TYR246      0.0000 DICT
+   3835 CZ         37.9890  -25.7890    8.1100 C.ar    239 TYR246      0.0000 DICT
+   3836 OH         38.9230  -24.9520    7.5460 O.3     239 TYR246      0.0000 DICT
+   3837 H          33.6190  -30.7450    9.0200 H       239 TYR246      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3838 HA         33.2780  -27.8750    8.8910 H       239 TYR246      0.0000 BACKBONE|DICT|DIRECT
+   3839 HB2        35.4790  -29.2400   10.1040 H       239 TYR246      0.0000 DICT
+   3840 HB3        34.6720  -27.9390   10.6720 H       239 TYR246      0.0000 DICT
+   3841 HD1        34.9800  -25.7250    9.4190 H       239 TYR246      0.0000 DICT
+   3842 HD2        37.4980  -28.9440    8.8860 H       239 TYR246      0.0000 DICT
+   3843 HE1        36.6040  -24.2910    8.4520 H       239 TYR246      0.0000 DICT
+   3844 HE2        39.1240  -27.5120    7.9170 H       239 TYR246      0.0000 DICT
+   3845 HH         39.7960  -25.3200    7.2270 H       239 TYR246      0.0000 DICT|ESSENTIAL
+   3846 N          34.4050  -27.6600    6.7100 N.am    240 GLU247      0.0000 BACKBONE|DICT|DIRECT
+   3847 CA         34.9550  -27.5930    5.3640 C.3     240 GLU247      0.0000 BACKBONE|DICT|DIRECT
+   3848 C          35.5270  -26.2050    5.1130 C.2     240 GLU247      0.0000 BACKBONE|DICT|DIRECT
+   3849 O          35.1280  -25.2190    5.7390 O.2     240 GLU247      0.0000 BACKBONE|DICT|DIRECT
+   3850 CB         33.8980  -27.9080    4.2920 C.3     240 GLU247      0.0000 DICT
+   3851 CG         33.2680  -29.2830    4.4020 C.3     240 GLU247      0.0000 DICT
+   3852 CD         32.1430  -29.4830    3.4110 C.2     240 GLU247      0.0000 DICT
+   3853 OE1        32.1520  -28.8100    2.3600 O.co2   240 GLU247      0.0000 DICT
+   3854 OE2        31.2460  -30.3070    3.6850 O.co2   240 GLU247      0.0000 DICT
+   3855 H          33.9500  -26.8520    7.0840 H       240 GLU247      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3856 HA         35.6950  -28.2610    5.2880 H       240 GLU247      0.0000 BACKBONE|DICT|DIRECT
+   3857 HB2        34.3340  -27.8370    3.3950 H       240 GLU247      0.0000 DICT
+   3858 HB3        33.1700  -27.2260    4.3630 H       240 GLU247      0.0000 DICT
+   3859 HG2        32.9050  -29.3970    5.3270 H       240 GLU247      0.0000 DICT
+   3860 HG3        33.9720  -29.9730    4.2330 H       240 GLU247      0.0000 DICT
+   3861 N          36.4680  -26.1400    4.1760 N.am    241 HIS248      0.0000 BACKBONE|DICT|DIRECT
+   3862 CA         36.9920  -24.8810    3.6710 C.3     241 HIS248      0.0000 BACKBONE|DICT|DIRECT
+   3863 C          36.2560  -24.4930    2.3940 C.2     241 HIS248      0.0000 BACKBONE|DICT|DIRECT
+   3864 O          35.7820  -25.3500    1.6440 O.2     241 HIS248      0.0000 BACKBONE|DICT|DIRECT
+   3865 CB         38.4950  -24.9800    3.3990 C.3     241 HIS248      0.0000 DICT
+   3866 CG         39.0590  -23.7940    2.6800 C.2     241 HIS248      0.0000 DICT
+   3867 ND1        38.9800  -23.6480    1.3110 N.2     241 HIS248      0.0000 DICT
+   3868 CD2        39.7030  -22.6950    3.1380 C.2     241 HIS248      0.0000 DICT
+   3869 CE1        39.5520  -22.5110    0.9570 C.2     241 HIS248      0.0000 DICT
+   3870 NE2        40.0000  -21.9140    2.0470 N.pl3   241 HIS248      0.0000 DICT
+   3871 H          36.8310  -26.9940    3.8020 H       241 HIS248      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3872 HA         36.8370  -24.1710    4.3580 H       241 HIS248      0.0000 BACKBONE|DICT|DIRECT
+   3873 HB2        38.6620  -25.7940    2.8430 H       241 HIS248      0.0000 DICT
+   3874 HB3        38.9680  -25.0720    4.2750 H       241 HIS248      0.0000 DICT
+   3875 HD2        39.9220  -22.4900    4.0920 H       241 HIS248      0.0000 DICT
+   3876 HE1        39.6320  -22.1620    0.0230 H       241 HIS248      0.0000 DICT
+   3877 HE2        40.4780  -21.0360    2.0740 H       241 HIS248      0.0000 DICT|ESSENTIAL
+   3878 N          36.1550  -23.1880    2.1580 N.am    242 ARG249      0.0000 BACKBONE|DICT|DIRECT
+   3879 CA         35.5500  -22.6570    0.9460 C.3     242 ARG249      0.0000 BACKBONE|DICT|DIRECT
+   3880 C          36.3370  -21.4440    0.4790 C.2     242 ARG249      0.0000 BACKBONE|DICT|DIRECT
+   3881 O          36.7780  -20.6330    1.2970 O.2     242 ARG249      0.0000 BACKBONE|DICT|DIRECT
+   3882 CB         34.0870  -22.2480    1.1680 C.3     242 ARG249      0.0000 DICT
+   3883 CG         33.1240  -23.3890    1.4290 C.3     242 ARG249      0.0000 DICT
+   3884 CD         32.7430  -24.1050    0.1440 C.3     242 ARG249      0.0000 DICT
+   3885 NE         31.5780  -24.9630    0.3400 N.pl3   242 ARG249      0.0000 DICT
+   3886 CZ         31.6320  -26.1870    0.8530 C.cat   242 ARG249      0.0000 DICT
+   3887 NH1        30.5190  -26.8950    0.9980 N.pl3   242 ARG249      0.0000 DICT
+   3888 NH2        32.7970  -26.7030    1.2240 N.pl3   242 ARG249      0.0000 DICT
+   3889 H          36.5080  -22.5470    2.8400 H       242 ARG249      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3890 HA         35.5850  -23.3580    0.2340 H       242 ARG249      0.0000 BACKBONE|DICT|DIRECT
+   3891 HB2        33.7750  -21.7620    0.3510 H       242 ARG249      0.0000 DICT
+   3892 HB3        34.0550  -21.6320    1.9550 H       242 ARG249      0.0000 DICT
+   3893 HG2        32.2960  -23.0240    1.8550 H       242 ARG249      0.0000 DICT
+   3894 HG3        33.5570  -24.0430    2.0490 H       242 ARG249      0.0000 DICT
+   3895 HD2        33.5140  -24.6660   -0.1570 H       242 ARG249      0.0000 DICT
+   3896 HD3        32.5320  -23.4250   -0.5580 H       242 ARG249      0.0000 DICT
+   3897 HE         30.6830  -24.6070    0.0710 H       242 ARG249      0.0000 DICT|ESSENTIAL
+   3898 HH11       30.5590  -27.8170    1.3840 H       242 ARG249      0.0000 DICT|ESSENTIAL
+   3899 HH12       29.6400  -26.5070    0.7210 H       242 ARG249      0.0000 DICT|ESSENTIAL
+   3900 HH21       32.8350  -27.6250    1.6100 H       242 ARG249      0.0000 DICT|ESSENTIAL
+   3901 HH22       33.6360  -26.1700    1.1180 H       242 ARG249      0.0000 DICT|ESSENTIAL
+   3902 N          36.5150  -21.3270   -0.8330 N.am    243 LEU250      0.0000 BACKBONE|DICT|DIRECT
+   3903 CA         36.9450  -20.0580   -1.3980 C.3     243 LEU250      0.0000 BACKBONE|DICT|DIRECT
+   3904 C          35.8430  -19.0310   -1.1780 C.2     243 LEU250      0.0000 BACKBONE|DICT|DIRECT
+   3905 O          34.6570  -19.3280   -1.3480 O.2     243 LEU250      0.0000 BACKBONE|DICT|DIRECT
+   3906 CB         37.2600  -20.2060   -2.8890 C.3     243 LEU250      0.0000 DICT
+   3907 CG         37.7880  -18.9750   -3.6360 C.3     243 LEU250      0.0000 DICT
+   3908 CD1        39.1200  -18.5060   -3.0650 C.3     243 LEU250      0.0000 DICT
+   3909 CD2        37.9170  -19.2570   -5.1270 C.3     243 LEU250      0.0000 DICT
+   3910 H          36.3530  -22.1120   -1.4310 H       243 LEU250      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3911 HA         37.7700  -19.7550   -0.9210 H       243 LEU250      0.0000 BACKBONE|DICT|DIRECT
+   3912 HB2        36.4170  -20.4920   -3.3450 H       243 LEU250      0.0000 DICT
+   3913 HB3        37.9480  -20.9260   -2.9780 H       243 LEU250      0.0000 DICT
+   3914 HG         37.1250  -18.2360   -3.5190 H       243 LEU250      0.0000 DICT
+   3915 HD11       39.4360  -17.7040   -3.5720 H       243 LEU250      0.0000 DICT
+   3916 HD12       39.0040  -18.2660   -2.1010 H       243 LEU250      0.0000 DICT
+   3917 HD13       39.7950  -19.2400   -3.1470 H       243 LEU250      0.0000 DICT
+   3918 HD21       38.2620  -18.4420   -5.5920 H       243 LEU250      0.0000 DICT
+   3919 HD22       38.5530  -20.0160   -5.2690 H       243 LEU250      0.0000 DICT
+   3920 HD23       37.0210  -19.4990   -5.4990 H       243 LEU250      0.0000 DICT
+   3921 N          36.2390  -17.8220   -0.7740 N.am    244 ILE251      0.0000 BACKBONE|DICT|DIRECT
+   3922 CA         35.2660  -16.8090   -0.3700 C.3     244 ILE251      0.0000 BACKBONE|DICT|DIRECT
+   3923 C          34.2770  -16.5130   -1.4910 C.2     244 ILE251      0.0000 BACKBONE|DICT|DIRECT
+   3924 O          33.1010  -16.2240   -1.2310 O.2     244 ILE251      0.0000 BACKBONE|DICT|DIRECT
+   3925 CB         35.9990  -15.5330    0.0970 C.3     244 ILE251      0.0000 DICT
+   3926 CG1        35.0040  -14.4150    0.4220 C.3     244 ILE251      0.0000 DICT
+   3927 CG2        37.0070  -15.0810   -0.9470 C.3     244 ILE251      0.0000 DICT
+   3928 CD1        34.0510  -14.7460    1.5500 C.3     244 ILE251      0.0000 DICT
+   3929 H          37.2150  -17.6060   -0.7470 H       244 ILE251      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3930 HA         34.7510  -17.1700    0.4070 H       244 ILE251      0.0000 BACKBONE|DICT|DIRECT
+   3931 HB         36.5000  -15.7540    0.9340 H       244 ILE251      0.0000 DICT
+   3932 HG12       34.4650  -14.2250   -0.3990 H       244 ILE251      0.0000 DICT
+   3933 HG13       35.5210  -13.5980    0.6770 H       244 ILE251      0.0000 DICT
+   3934 HG21       37.4710  -14.2550   -0.6270 H       244 ILE251      0.0000 DICT
+   3935 HG22       37.6810  -15.8050   -1.0950 H       244 ILE251      0.0000 DICT
+   3936 HG23       36.5330  -14.8860   -1.8060 H       244 ILE251      0.0000 DICT
+   3937 HD11       33.4350  -13.9730    1.7040 H       244 ILE251      0.0000 DICT
+   3938 HD12       33.5160  -15.5550    1.3080 H       244 ILE251      0.0000 DICT
+   3939 HD13       34.5720  -14.9280    2.3840 H       244 ILE251      0.0000 DICT
+   3940 N          34.7190  -16.6070   -2.7470 N.am    245 ASP252      0.0000 BACKBONE|DICT|DIRECT
+   3941 CA         33.8420  -16.2900   -3.8710 C.3     245 ASP252      0.0000 BACKBONE|DICT|DIRECT
+   3942 C          32.6540  -17.2430   -3.9380 C.2     245 ASP252      0.0000 BACKBONE|DICT|DIRECT
+   3943 O          31.5220  -16.8170   -4.2020 O.2     245 ASP252      0.0000 BACKBONE|DICT|DIRECT
+   3944 CB         34.6400  -16.3270   -5.1730 C.3     245 ASP252      0.0000 DICT
+   3945 CG         35.8970  -15.4820   -5.1050 C.2     245 ASP252      0.0000 DICT
+   3946 OD1        35.8200  -14.3350   -4.6140 O.co2   245 ASP252      0.0000 DICT
+   3947 OD2        36.9670  -15.9690   -5.5280 O.co2   245 ASP252      0.0000 DICT
+   3948 H          35.6600  -16.8970   -2.9200 H       245 ASP252      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3949 HA         33.4920  -15.3620   -3.7440 H       245 ASP252      0.0000 BACKBONE|DICT|DIRECT
+   3950 HB2        34.0620  -15.9840   -5.9140 H       245 ASP252      0.0000 DICT
+   3951 HB3        34.8990  -17.2740   -5.3640 H       245 ASP252      0.0000 DICT
+   3952 N          32.8880  -18.5350   -3.6970 N.am    246 ASP253      0.0000 BACKBONE|DICT|DIRECT
+   3953 CA         31.8190  -19.5250   -3.7260 C.3     246 ASP253      0.0000 BACKBONE|DICT|DIRECT
+   3954 C          31.0980  -19.6610   -2.3940 C.2     246 ASP253      0.0000 BACKBONE|DICT|DIRECT
+   3955 O          29.9580  -20.1390   -2.3700 O.2     246 ASP253      0.0000 BACKBONE|DICT|DIRECT
+   3956 CB         32.3740  -20.8910   -4.1430 C.3     246 ASP253      0.0000 DICT
+   3957 CG         33.4120  -20.7890   -5.2440 C.2     246 ASP253      0.0000 DICT
+   3958 OD1        34.4020  -21.5440   -5.1940 O.co2   246 ASP253      0.0000 DICT
+   3959 OD2        33.2470  -19.9440   -6.1540 O.co2   246 ASP253      0.0000 DICT
+   3960 H          33.8210  -18.8310   -3.4910 H       246 ASP253      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3961 HA         31.1500  -19.2390   -4.4130 H       246 ASP253      0.0000 BACKBONE|DICT|DIRECT
+   3962 HB2        31.6170  -21.4580   -4.4680 H       246 ASP253      0.0000 DICT
+   3963 HB3        32.7950  -21.3220   -3.3450 H       246 ASP253      0.0000 DICT
+   3964 N          31.7300  -19.2570   -1.2900 N.am    247 MET254      0.0000 BACKBONE|DICT|DIRECT
+   3965 CA         31.0390  -19.2670   -0.0070 C.3     247 MET254      0.0000 BACKBONE|DICT|DIRECT
+   3966 C          29.9530  -18.2010    0.0320 C.2     247 MET254      0.0000 BACKBONE|DICT|DIRECT
+   3967 O          28.8560  -18.4420    0.5500 O.2     247 MET254      0.0000 BACKBONE|DICT|DIRECT
+   3968 CB         32.0370  -19.0650    1.1350 C.3     247 MET254      0.0000 DICT
+   3969 CG         31.4030  -19.0660    2.5220 C.3     247 MET254      0.0000 DICT
+   3970 SD         30.7740  -20.6880    3.0220 S.3     247 MET254      0.0000 DICT
+   3971 CE         29.8220  -20.2550    4.4750 C.3     247 MET254      0.0000 DICT
+   3972 H          32.6790  -18.9470   -1.3430 H       247 MET254      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3973 HA         30.6060  -20.1610    0.1090 H       247 MET254      0.0000 BACKBONE|DICT|DIRECT
+   3974 HB2        32.4960  -18.1870    1.0000 H       247 MET254      0.0000 DICT
+   3975 HB3        32.7110  -19.8030    1.0970 H       247 MET254      0.0000 DICT
+   3976 HG2        30.6430  -18.4170    2.5240 H       247 MET254      0.0000 DICT
+   3977 HG3        32.0920  -18.7740    3.1860 H       247 MET254      0.0000 DICT
+   3978 HE1        29.4090  -21.0800    4.8610 H       247 MET254      0.0000 DICT
+   3979 HE2        30.4230  -19.8340    5.1540 H       247 MET254      0.0000 DICT
+   3980 HE3        29.1020  -19.6090    4.2210 H       247 MET254      0.0000 DICT
+   3981 N          30.2400  -17.0160   -0.5160 N.am    248 VAL255      0.0000 BACKBONE|DICT|DIRECT
+   3982 CA         29.2250  -15.9710   -0.6210 C.3     248 VAL255      0.0000 BACKBONE|DICT|DIRECT
+   3983 C          28.0540  -16.4560   -1.4660 C.2     248 VAL255      0.0000 BACKBONE|DICT|DIRECT
+   3984 O          26.8870  -16.2630   -1.1050 O.2     248 VAL255      0.0000 BACKBONE|DICT|DIRECT
+   3985 CB         29.8410  -14.6800   -1.1940 C.3     248 VAL255      0.0000 DICT
+   3986 CG1        28.7510  -13.6940   -1.5830 C.3     248 VAL255      0.0000 DICT
+   3987 CG2        30.7970  -14.0480   -0.1880 C.3     248 VAL255      0.0000 DICT
+   3988 H          31.1630  -16.8420   -0.8590 H       248 VAL255      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   3989 HA         28.8850  -15.7730    0.2980 H       248 VAL255      0.0000 BACKBONE|DICT|DIRECT
+   3990 HB         30.3600  -14.9160   -2.0160 H       248 VAL255      0.0000 DICT
+   3991 HG11       29.1690  -12.8640   -1.9520 H       248 VAL255      0.0000 DICT
+   3992 HG12       28.1600  -14.1070   -2.2760 H       248 VAL255      0.0000 DICT
+   3993 HG13       28.2070  -13.4630   -0.7760 H       248 VAL255      0.0000 DICT
+   3994 HG21       31.1860  -13.2130   -0.5770 H       248 VAL255      0.0000 DICT
+   3995 HG22       30.2990  -13.8250    0.6500 H       248 VAL255      0.0000 DICT
+   3996 HG23       31.5330  -14.6920    0.0230 H       248 VAL255      0.0000 DICT
+   3997 N          28.3470  -17.1040   -2.5950 N.am    249 ALA256      0.0000 BACKBONE|DICT|DIRECT
+   3998 CA         27.2850  -17.6160   -3.4560 C.3     249 ALA256      0.0000 BACKBONE|DICT|DIRECT
+   3999 C          26.4940  -18.7160   -2.7580 C.2     249 ALA256      0.0000 BACKBONE|DICT|DIRECT
+   4000 O          25.2580  -18.7190   -2.7830 O.2     249 ALA256      0.0000 BACKBONE|DICT|DIRECT
+   4001 CB         27.8780  -18.1240   -4.7700 C.3     249 ALA256      0.0000 DICT
+   4002 H          29.3030  -17.2400   -2.8540 H       249 ALA256      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4003 HA         26.6600  -16.8640   -3.6640 H       249 ALA256      0.0000 BACKBONE|DICT|DIRECT
+   4004 HB1        27.1450  -18.4730   -5.3540 H       249 ALA256      0.0000 DICT
+   4005 HB2        28.3470  -17.3740   -5.2360 H       249 ALA256      0.0000 DICT
+   4006 HB3        28.5300  -18.8580   -4.5800 H       249 ALA256      0.0000 DICT
+   4007 N          27.1940  -19.6630   -2.1260 N.am    250 GLN257      0.0000 BACKBONE|DICT|DIRECT
+   4008 CA         26.5140  -20.7300   -1.3980 C.3     250 GLN257      0.0000 BACKBONE|DICT|DIRECT
+   4009 C          25.6830  -20.1750   -0.2470 C.2     250 GLN257      0.0000 BACKBONE|DICT|DIRECT
+   4010 O          24.5830  -20.6690    0.0290 O.2     250 GLN257      0.0000 BACKBONE|DICT|DIRECT
+   4011 CB         27.5370  -21.7440   -0.8800 C.3     250 GLN257      0.0000 DICT
+   4012 CG         26.9720  -22.7550    0.1120 C.3     250 GLN257      0.0000 DICT
+   4013 CD         28.0520  -23.4960    0.8810 C.2     250 GLN257      0.0000 DICT
+   4014 OE1        29.1490  -23.7290    0.3690 O.2     250 GLN257      0.0000 DICT
+   4015 NE2        27.7470  -23.8660    2.1210 N.am    250 GLN257      0.0000 DICT
+   4016 H          28.1930  -19.6400   -2.1520 H       250 GLN257      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4017 HA         25.8990  -21.2000   -2.0310 H       250 GLN257      0.0000 BACKBONE|DICT|DIRECT
+   4018 HB2        28.2750  -21.2420   -0.4290 H       250 GLN257      0.0000 DICT
+   4019 HB3        27.9050  -22.2460   -1.6630 H       250 GLN257      0.0000 DICT
+   4020 HG2        26.4230  -23.4230   -0.3910 H       250 GLN257      0.0000 DICT
+   4021 HG3        26.3910  -22.2700    0.7650 H       250 GLN257      0.0000 DICT
+   4022 HE21       26.8450  -23.6570    2.4980 H       250 GLN257      0.0000 DICT|ESSENTIAL
+   4023 HE22       28.4200  -24.3540    2.6770 H       250 GLN257      0.0000 DICT|ESSENTIAL
+   4024 N          26.1860  -19.1390    0.4300 N.am    251 ALA258      0.0000 BACKBONE|DICT|DIRECT
+   4025 CA         25.4830  -18.6010    1.5930 C.3     251 ALA258      0.0000 BACKBONE|DICT|DIRECT
+   4026 C          24.1570  -17.9590    1.2010 C.2     251 ALA258      0.0000 BACKBONE|DICT|DIRECT
+   4027 O          23.1680  -18.0710    1.9360 O.2     251 ALA258      0.0000 BACKBONE|DICT|DIRECT
+   4028 CB         26.3690  -17.5970    2.3280 C.3     251 ALA258      0.0000 DICT
+   4029 H          27.0500  -18.7280    0.1390 H       251 ALA258      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4030 HA         25.2890  -19.3580    2.2160 H       251 ALA258      0.0000 BACKBONE|DICT|DIRECT
+   4031 HB1        25.8770  -17.2360    3.1210 H       251 ALA258      0.0000 DICT
+   4032 HB2        27.2060  -18.0520    2.6330 H       251 ALA258      0.0000 DICT
+   4033 HB3        26.6040  -16.8460    1.7110 H       251 ALA258      0.0000 DICT
+   4034 N          24.1130  -17.2810    0.0480 N.am    252 MET259      0.0000 BACKBONE|DICT|DIRECT
+   4035 CA         22.8600  -16.6840   -0.4060 C.3     252 MET259      0.0000 BACKBONE|DICT|DIRECT
+   4036 C          21.8310  -17.7480   -0.7700 C.2     252 MET259      0.0000 BACKBONE|DICT|DIRECT
+   4037 O          20.6240  -17.5000   -0.6670 O.2     252 MET259      0.0000 BACKBONE|DICT|DIRECT
+   4038 CB         23.1070  -15.7640   -1.6030 C.3     252 MET259      0.0000 DICT
+   4039 CG         24.2130  -14.7420   -1.4010 C.3     252 MET259      0.0000 DICT
+   4040 SD         23.8310  -13.4670   -0.1880 S.3     252 MET259      0.0000 DICT
+   4041 CE         22.7950  -12.3700   -1.1520 C.3     252 MET259      0.0000 DICT
+   4042 H          24.9410  -17.1830   -0.5040 H       252 MET259      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4043 HA         22.4880  -16.1320    0.3410 H       252 MET259      0.0000 BACKBONE|DICT|DIRECT
+   4044 HB2        22.2590  -15.2710   -1.7970 H       252 MET259      0.0000 DICT
+   4045 HB3        23.3490  -16.3330   -2.3890 H       252 MET259      0.0000 DICT
+   4046 HG2        24.3920  -14.2960   -2.2780 H       252 MET259      0.0000 DICT
+   4047 HG3        25.0350  -15.2250   -1.0990 H       252 MET259      0.0000 DICT
+   4048 HE1        22.5060  -11.5990   -0.5840 H       252 MET259      0.0000 DICT
+   4049 HE2        23.3110  -12.0290   -1.9380 H       252 MET259      0.0000 DICT
+   4050 HE3        21.9890  -12.8680   -1.4730 H       252 MET259      0.0000 DICT
+   4051 N          22.2840  -18.9280   -1.1920 N.am    253 LYS260      0.0000 BACKBONE|DICT|DIRECT
+   4052 CA         21.4100  -20.0270   -1.5800 C.3     253 LYS260      0.0000 BACKBONE|DICT|DIRECT
+   4053 C          21.0810  -20.9610   -0.4240 C.2     253 LYS260      0.0000 BACKBONE|DICT|DIRECT
+   4054 O          20.3380  -21.9290   -0.6190 O.2     253 LYS260      0.0000 BACKBONE|DICT|DIRECT
+   4055 CB         22.0530  -20.8380   -2.7150 C.3     253 LYS260      0.0000 DICT
+   4056 CG         22.5720  -20.0050   -3.8820 C.3     253 LYS260      0.0000 DICT
+   4057 CD         21.9220  -20.4230   -5.1880 C.3     253 LYS260      0.0000 DICT
+   4058 CE         21.7550  -19.2310   -6.1070 C.3     253 LYS260      0.0000 DICT
+   4059 NZ         20.6390  -18.3540   -5.6540 N.4     253 LYS260      0.0000 DICT
+   4060 H          23.2730  -19.0660   -1.2450 H       253 LYS260      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4061 HA         20.5540  -19.6390   -1.9210 H       253 LYS260      0.0000 BACKBONE|DICT|DIRECT
+   4062 HB2        21.3680  -21.4760   -3.0680 H       253 LYS260      0.0000 DICT
+   4063 HB3        22.8210  -21.3520   -2.3340 H       253 LYS260      0.0000 DICT
+   4064 HG2        23.5620  -20.1290   -3.9560 H       253 LYS260      0.0000 DICT
+   4065 HG3        22.3680  -19.0410   -3.7100 H       253 LYS260      0.0000 DICT
+   4066 HD2        21.0240  -20.8180   -4.9960 H       253 LYS260      0.0000 DICT
+   4067 HD3        22.4980  -21.1060   -5.6370 H       253 LYS260      0.0000 DICT
+   4068 HE2        21.5590  -19.5570   -7.0320 H       253 LYS260      0.0000 DICT
+   4069 HE3        22.6040  -18.7020   -6.1130 H       253 LYS260      0.0000 DICT
+   4070 HZ1        20.5520  -17.5770   -6.2770 H       253 LYS260      0.0000 DICT|ESSENTIAL
+   4071 HZ2        19.7860  -18.8760   -5.6500 H       253 LYS260      0.0000 DICT|ESSENTIAL
+   4072 HZ3        20.8310  -18.0210   -4.7310 H       253 LYS260      0.0000 DICT|ESSENTIAL
+   4073 N          21.6130  -20.7060    0.7640 N.am    254 SER261      0.0000 BACKBONE|DICT|DIRECT
+   4074 CA         21.4560  -21.6350    1.8680 C.3     254 SER261      0.0000 BACKBONE|DICT|DIRECT
+   4075 C          20.2360  -21.2800    2.7130 C.2     254 SER261      0.0000 BACKBONE|DICT|DIRECT
+   4076 O          19.5960  -20.2410    2.5380 O.2     254 SER261      0.0000 BACKBONE|DICT|DIRECT
+   4077 CB         22.7170  -21.6540    2.7340 C.3     254 SER261      0.0000 DICT
+   4078 OG         23.0710  -20.3460    3.1460 O.3     254 SER261      0.0000 DICT
+   4079 H          22.1300  -19.8610    0.9010 H       254 SER261      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4080 HA         21.3210  -22.5510    1.4910 H       254 SER261      0.0000 BACKBONE|DICT|DIRECT
+   4081 HB2        23.4700  -22.0450    2.2060 H       254 SER261      0.0000 DICT
+   4082 HB3        22.5490  -22.2170    3.5430 H       254 SER261      0.0000 DICT
+   4083 HG         23.2440  -19.7780    2.3410 H       254 SER261      0.0000 DICT|ESSENTIAL
+   4084 N          19.9170  -22.1790    3.6380 N.am    255 GLU262      0.0000 BACKBONE|DICT|DIRECT
+   4085 CA         18.8510  -21.9730    4.6050 C.3     255 GLU262      0.0000 BACKBONE|DICT|DIRECT
+   4086 C          19.3430  -21.3540    5.9050 C.2     255 GLU262      0.0000 BACKBONE|DICT|DIRECT
+   4087 O          18.5310  -20.8160    6.6680 O.2     255 GLU262      0.0000 BACKBONE|DICT|DIRECT
+   4088 CB         18.1780  -23.3080    4.9210 C.3     255 GLU262      0.0000 DICT
+   4089 CG         19.1790  -24.3790    5.3260 C.3     255 GLU262      0.0000 DICT
+   4090 CD         18.5980  -25.3960    6.2830 C.2     255 GLU262      0.0000 DICT
+   4091 OE1        17.3750  -25.3450    6.5370 O.co2   255 GLU262      0.0000 DICT
+   4092 OE2        19.3710  -26.2400    6.7880 O.co2   255 GLU262      0.0000 DICT
+   4093 H          20.4330  -23.0350    3.6700 H       255 GLU262      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4094 HA         18.1700  -21.3620    4.2010 H       255 GLU262      0.0000 BACKBONE|DICT|DIRECT
+   4095 HB2        17.6850  -23.6200    4.1090 H       255 GLU262      0.0000 DICT
+   4096 HB3        17.5310  -23.1720    5.6720 H       255 GLU262      0.0000 DICT
+   4097 HG2        19.9600  -23.9360    5.7670 H       255 GLU262      0.0000 DICT
+   4098 HG3        19.4870  -24.8550    4.5030 H       255 GLU262      0.0000 DICT
+   4099 N          20.6390  -21.4260    6.1740 N.am    256 GLY263      0.0000 BACKBONE|DICT|DIRECT
+   4100 CA         21.2130  -20.9940    7.4300 C.3     256 GLY263      0.0000 BACKBONE|DICT|DIRECT
+   4101 C          21.6140  -22.1800    8.2880 C.2     256 GLY263      0.0000 BACKBONE|DICT|DIRECT
+   4102 O          21.6480  -23.3290    7.8430 O.2     256 GLY263      0.0000 BACKBONE|DICT|DIRECT
+   4103 H          21.2500  -21.7970    5.4750 H       256 GLY263      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4104 HA2        20.5390  -20.4460    7.9250 H       256 GLY263      0.0000 BACKBONE|DICT|DIRECT
+   4105 HA3        22.0230  -20.4370    7.2440 H       256 GLY263      0.0000 DICT
+   4106 N          21.9240  -21.8790    9.5450 N.am    257 GLY264      0.0000 BACKBONE|DICT|DIRECT
+   4107 CA         22.2850  -22.9130   10.4960 C.3     257 GLY264      0.0000 BACKBONE|DICT|DIRECT
+   4108 C          23.7170  -23.3930   10.3800 C.2     257 GLY264      0.0000 BACKBONE|DICT|DIRECT
+   4109 O          23.9680  -24.6000   10.3470 O.2     257 GLY264      0.0000 BACKBONE|DICT|DIRECT
+   4110 H          21.9080  -20.9240    9.8400 H       257 GLY264      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4111 HA2        21.6800  -23.6960   10.3530 H       257 GLY264      0.0000 BACKBONE|DICT|DIRECT
+   4112 HA3        22.1490  -22.5510   11.4180 H       257 GLY264      0.0000 DICT
+   4113 N          24.6670  -22.4620   10.3230 N.am    258 PHE265      0.0000 BACKBONE|DICT|DIRECT
+   4114 CA         26.0790  -22.8170   10.2590 C.3     258 PHE265      0.0000 BACKBONE|DICT|DIRECT
+   4115 C          26.9100  -21.6620   10.8010 C.2     258 PHE265      0.0000 BACKBONE|DICT|DIRECT
+   4116 O          26.4640  -20.5140   10.8360 O.2     258 PHE265      0.0000 BACKBONE|DICT|DIRECT
+   4117 CB         26.5090  -23.1680    8.8290 C.3     258 PHE265      0.0000 DICT
+   4118 CG         26.2680  -22.0650    7.8330 C.ar    258 PHE265      0.0000 DICT
+   4119 CD1        27.2170  -21.0730    7.6300 C.ar    258 PHE265      0.0000 DICT
+   4120 CD2        25.0950  -22.0240    7.0930 C.ar    258 PHE265      0.0000 DICT
+   4121 CE1        27.0000  -20.0610    6.7190 C.ar    258 PHE265      0.0000 DICT
+   4122 CE2        24.8720  -21.0130    6.1760 C.ar    258 PHE265      0.0000 DICT
+   4123 CZ         25.8270  -20.0300    5.9880 C.ar    258 PHE265      0.0000 DICT
+   4124 H          24.4060  -21.4970   10.3240 H       258 PHE265      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4125 HA         26.2310  -23.6160   10.8400 H       258 PHE265      0.0000 BACKBONE|DICT|DIRECT
+   4126 HB2        25.9970  -23.9750    8.5350 H       258 PHE265      0.0000 DICT
+   4127 HB3        27.4870  -23.3780    8.8360 H       258 PHE265      0.0000 DICT
+   4128 HD1        28.0700  -21.0920    8.1520 H       258 PHE265      0.0000 DICT
+   4129 HD2        24.4030  -22.7340    7.2240 H       258 PHE265      0.0000 DICT
+   4130 HE1        27.6910  -19.3500    6.5870 H       258 PHE265      0.0000 DICT
+   4131 HE2        24.0220  -20.9930    5.6500 H       258 PHE265      0.0000 DICT
+   4132 HZ         25.6690  -19.2980    5.3250 H       258 PHE265      0.0000 DICT
+   4133 N          28.1320  -21.9830   11.2200 N.am    259 ILE266      0.0000 BACKBONE|DICT|DIRECT
+   4134 CA         29.1010  -20.9850   11.6550 C.3     259 ILE266      0.0000 BACKBONE|DICT|DIRECT
+   4135 C          30.0320  -20.6910   10.4910 C.2     259 ILE266      0.0000 BACKBONE|DICT|DIRECT
+   4136 O          30.5460  -21.6150    9.8500 O.2     259 ILE266      0.0000 BACKBONE|DICT|DIRECT
+   4137 CB         29.8920  -21.4640   12.8830 C.3     259 ILE266      0.0000 DICT
+   4138 CG1        28.9540  -22.0470   13.9470 C.3     259 ILE266      0.0000 DICT
+   4139 CG2        30.7270  -20.3290   13.4520 C.3     259 ILE266      0.0000 DICT
+   4140 CD1        27.9120  -21.0940   14.4620 C.3     259 ILE266      0.0000 DICT
+   4141 H          28.3960  -22.9470   11.2370 H       259 ILE266      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4142 HA         28.6120  -20.1460   11.8950 H       259 ILE266      0.0000 BACKBONE|DICT|DIRECT
+   4143 HB         30.5140  -22.1890   12.5880 H       259 ILE266      0.0000 DICT
+   4144 HG12       29.5110  -22.3470   14.7220 H       259 ILE266      0.0000 DICT
+   4145 HG13       28.4850  -22.8350   13.5490 H       259 ILE266      0.0000 DICT
+   4146 HG21       31.2350  -20.6560   14.2490 H       259 ILE266      0.0000 DICT
+   4147 HG22       31.3690  -20.0070   12.7570 H       259 ILE266      0.0000 DICT
+   4148 HG23       30.1260  -19.5780   13.7250 H       259 ILE266      0.0000 DICT
+   4149 HD11       27.3480  -21.5550   15.1470 H       259 ILE266      0.0000 DICT
+   4150 HD12       28.3600  -20.3020   14.8770 H       259 ILE266      0.0000 DICT
+   4151 HD13       27.3340  -20.7910   13.7040 H       259 ILE266      0.0000 DICT
+   4152 N          30.2570  -19.4080   10.2250 N.am    260 TRP267      0.0000 BACKBONE|DICT|DIRECT
+   4153 CA         31.0420  -18.9480    9.0820 C.3     260 TRP267      0.0000 BACKBONE|DICT|DIRECT
+   4154 C          32.2640  -18.2030    9.6150 C.2     260 TRP267      0.0000 BACKBONE|DICT|DIRECT
+   4155 O          32.1730  -17.0280    9.9850 O.2     260 TRP267      0.0000 BACKBONE|DICT|DIRECT
+   4156 CB         30.1810  -18.0690    8.1730 C.3     260 TRP267      0.0000 DICT
+   4157 CG         30.8550  -17.4950    6.9500 C.2     260 TRP267      0.0000 DICT
+   4158 CD1        32.1840  -17.5330    6.6350 C.2     260 TRP267      0.0000 DICT
+   4159 CD2        30.2120  -16.7920    5.8800 C.ar    260 TRP267      0.0000 DICT
+   4160 NE1        32.4050  -16.8950    5.4390 N.pl3   260 TRP267      0.0000 DICT
+   4161 CE2        31.2110  -16.4310    4.9550 C.ar    260 TRP267      0.0000 DICT
+   4162 CE3        28.8870  -16.4330    5.6150 C.ar    260 TRP267      0.0000 DICT
+   4163 CZ2        30.9260  -15.7310    3.7860 C.ar    260 TRP267      0.0000 DICT
+   4164 CZ3        28.6070  -15.7380    4.4550 C.ar    260 TRP267      0.0000 DICT
+   4165 CH2        29.6210  -15.3960    3.5540 C.ar    260 TRP267      0.0000 DICT
+   4166 H          29.8680  -18.7220   10.8400 H       260 TRP267      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4167 HA         31.3510  -19.7440    8.5620 H       260 TRP267      0.0000 BACKBONE|DICT|DIRECT
+   4168 HB2        29.8450  -17.3030    8.7210 H       260 TRP267      0.0000 DICT
+   4169 HB3        29.4070  -18.6210    7.8620 H       260 TRP267      0.0000 DICT
+   4170 HD1        32.8930  -17.9630    7.1940 H       260 TRP267      0.0000 DICT
+   4171 HE1        33.2940  -16.7870    4.9940 H       260 TRP267      0.0000 DICT|ESSENTIAL
+   4172 HE3        28.1560  -16.6750    6.2530 H       260 TRP267      0.0000 DICT
+   4173 HZ2        31.6480  -15.4830    3.1410 H       260 TRP267      0.0000 DICT
+   4174 HZ3        27.6630  -15.4750    4.2560 H       260 TRP267      0.0000 DICT
+   4175 HH2        29.3860  -14.8950    2.7210 H       260 TRP267      0.0000 DICT
+   4176 N          33.4030  -18.8880    9.6540 N.am    261 ALA268      0.0000 BACKBONE|DICT|DIRECT
+   4177 CA         34.6650  -18.2570   10.0190 C.3     261 ALA268      0.0000 BACKBONE|DICT|DIRECT
+   4178 C          35.1990  -17.4870    8.8170 C.2     261 ALA268      0.0000 BACKBONE|DICT|DIRECT
+   4179 O          35.5290  -18.0820    7.7860 O.2     261 ALA268      0.0000 BACKBONE|DICT|DIRECT
+   4180 CB         35.6740  -19.3020   10.4890 C.3     261 ALA268      0.0000 DICT
+   4181 H          33.3930  -19.8620    9.4270 H       261 ALA268      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4182 HA         34.4980  -17.6130   10.7650 H       261 ALA268      0.0000 BACKBONE|DICT|DIRECT
+   4183 HB1        36.5320  -18.8500   10.7340 H       261 ALA268      0.0000 DICT
+   4184 HB2        35.3100  -19.7820   11.2870 H       261 ALA268      0.0000 DICT
+   4185 HB3        35.8410  -19.9580    9.7530 H       261 ALA268      0.0000 DICT
+   4186 N          35.2840  -16.1690    8.9490 N.am    262 CYS269      0.0000 BACKBONE|DICT|DIRECT
+   4187 CA         35.6250  -15.2860    7.8430 C.3     262 CYS269      0.0000 BACKBONE|DICT|DIRECT
+   4188 C          37.0330  -14.7420    8.0380 C.2     262 CYS269      0.0000 BACKBONE|DICT|DIRECT
+   4189 O          37.3600  -14.2200    9.1090 O.2     262 CYS269      0.0000 BACKBONE|DICT|DIRECT
+   4190 CB         34.6180  -14.1390    7.7380 C.3     262 CYS269      0.0000 DICT
+   4191 SG         34.2850  -13.5910    6.0520 S.3     262 CYS269      0.0000 DICT
+   4192 H          35.1060  -15.7650    9.8460 H       262 CYS269      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4193 HA         35.6000  -15.8130    6.9930 H       262 CYS269      0.0000 BACKBONE|DICT|DIRECT
+   4194 HB2        34.9750  -13.3610    8.2550 H       262 CYS269      0.0000 DICT
+   4195 HB3        33.7560  -14.4420    8.1440 H       262 CYS269      0.0000 DICT
+   4196 HG         33.6210  -12.8440    6.0690 H       262 CYS269      0.0000 DICT|ESSENTIAL
+   4197 N          37.8610  -14.8650    7.0010 N.am    263 LYS270      0.0000 BACKBONE|DICT|DIRECT
+   4198 CA         39.2310  -14.3710    7.0790 C.3     263 LYS270      0.0000 BACKBONE|DICT|DIRECT
+   4199 C          39.2870  -12.8560    6.9080 C.2     263 LYS270      0.0000 BACKBONE|DICT|DIRECT
+   4200 O          40.0770  -12.1870    7.5840 O.2     263 LYS270      0.0000 BACKBONE|DICT|DIRECT
+   4201 CB         40.0970  -15.0710    6.0290 C.3     263 LYS270      0.0000 DICT
+   4202 CG         41.5940  -15.0450    6.3150 C.3     263 LYS270      0.0000 DICT
+   4203 CD         42.2610  -13.8100    5.7320 C.3     263 LYS270      0.0000 DICT
+   4204 CE         43.7580  -13.8200    5.9810 C.3     263 LYS270      0.0000 DICT
+   4205 NZ         44.4420  -12.7630    5.1870 N.4     263 LYS270      0.0000 DICT
+   4206 H          37.5390  -15.3010    6.1600 H       263 LYS270      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4207 HA         39.5930  -14.5970    7.9830 H       263 LYS270      0.0000 BACKBONE|DICT|DIRECT
+   4208 HB2        39.9410  -14.6240    5.1480 H       263 LYS270      0.0000 DICT
+   4209 HB3        39.8070  -16.0270    5.9740 H       263 LYS270      0.0000 DICT
+   4210 HG2        42.0140  -15.8590    5.9140 H       263 LYS270      0.0000 DICT
+   4211 HG3        41.7340  -15.0510    7.3050 H       263 LYS270      0.0000 DICT
+   4212 HD2        41.8660  -12.9960    6.1570 H       263 LYS270      0.0000 DICT
+   4213 HD3        42.0950  -13.7850    4.7460 H       263 LYS270      0.0000 DICT
+   4214 HE2        44.1260  -14.7130    5.7210 H       263 LYS270      0.0000 DICT
+   4215 HE3        43.9280  -13.6590    6.9530 H       263 LYS270      0.0000 DICT
+   4216 HZ1        45.2560  -12.4520    5.6770 H       263 LYS270      0.0000 DICT|ESSENTIAL
+   4217 HZ2        44.7090  -13.1350    4.2980 H       263 LYS270      0.0000 DICT|ESSENTIAL
+   4218 HZ3        43.8200  -11.9920    5.0530 H       263 LYS270      0.0000 DICT|ESSENTIAL
+   4219 N          38.4570  -12.3060    6.0210 N.am    264 ASN271      0.0000 BACKBONE|DICT|DIRECT
+   4220 CA         38.4190  -10.8670    5.7440 C.3     264 ASN271      0.0000 BACKBONE|DICT|DIRECT
+   4221 C          38.3010  -10.0250    7.0120 C.2     264 ASN271      0.0000 BACKBONE|DICT|DIRECT
+   4222 O          37.6350   -8.9890    7.0170 O.2     264 ASN271      0.0000 BACKBONE|DICT|DIRECT
+   4223 CB         37.2510  -10.5300    4.8110 C.3     264 ASN271      0.0000 DICT
+   4224 CG         37.3770  -11.1890    3.4510 C.2     264 ASN271      0.0000 DICT
+   4225 OD1        38.4800  -11.3930    2.9440 O.2     264 ASN271      0.0000 DICT
+   4226 ND2        36.2390  -11.5260    2.8510 N.am    264 ASN271      0.0000 DICT
+   4227 H          37.8310  -12.9040    5.5210 H       264 ASN271      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4228 HA         39.2690  -10.6160    5.2820 H       264 ASN271      0.0000 BACKBONE|DICT|DIRECT
+   4229 HB2        37.2190   -9.5390    4.6840 H       264 ASN271      0.0000 DICT
+   4230 HB3        36.4010  -10.8390    5.2380 H       264 ASN271      0.0000 DICT
+   4231 HD21       35.3640  -11.3420    3.2990 H       264 ASN271      0.0000 DICT|ESSENTIAL
+   4232 HD22       36.2580  -11.9630    1.9520 H       264 ASN271      0.0000 DICT|ESSENTIAL
+   4233 N          16.9220   -4.9580   10.0810 N.am    265 SER287      0.0000 BACKBONE|DICT|DIRECT
+   4234 CA         16.9790   -4.0830   11.2470 C.3     265 SER287      0.0000 BACKBONE|DICT|DIRECT
+   4235 C          18.2000   -4.3710   12.1200 C.2     265 SER287      0.0000 BACKBONE|DICT|DIRECT
+   4236 O          18.4860   -5.5260   12.4480 O.2     265 SER287      0.0000 BACKBONE|DICT|DIRECT
+   4237 CB         15.7040   -4.2230   12.0770 C.3     265 SER287      0.0000 DICT
+   4238 OG         15.7540   -3.3990   13.2290 O.3     265 SER287      0.0000 DICT
+   4239 H          16.1190   -5.5340    9.9270 H       265 SER287      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4240 HA         17.0400   -3.1380   10.9260 H       265 SER287      0.0000 BACKBONE|DICT|DIRECT
+   4241 HB2        15.6020   -5.1760   12.3610 H       265 SER287      0.0000 DICT
+   4242 HB3        14.9190   -3.9560   11.5180 H       265 SER287      0.0000 DICT
+   4243 HG         14.9100   -3.5090   13.7540 H       265 SER287      0.0000 DICT|ESSENTIAL
+   4244 N          18.9180   -3.3070   12.4920 N.am    266 LEU288      0.0000 BACKBONE|DICT|DIRECT
+   4245 CA         20.0620   -3.4420   13.3890 C.3     266 LEU288      0.0000 BACKBONE|DICT|DIRECT
+   4246 C          19.6550   -3.8650   14.7920 C.2     266 LEU288      0.0000 BACKBONE|DICT|DIRECT
+   4247 O          20.4860   -4.4130   15.5260 O.2     266 LEU288      0.0000 BACKBONE|DICT|DIRECT
+   4248 CB         20.8390   -2.1270   13.4600 C.3     266 LEU288      0.0000 DICT
+   4249 CG         21.8190   -1.8280   12.3270 C.3     266 LEU288      0.0000 DICT
+   4250 CD1        22.2440   -0.3720   12.3830 C.3     266 LEU288      0.0000 DICT
+   4251 CD2        23.0240   -2.7460   12.4300 C.3     266 LEU288      0.0000 DICT
+   4252 H          18.6670   -2.4020   12.1500 H       266 LEU288      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4253 HA         20.6700   -4.1430   13.0160 H       266 LEU288      0.0000 BACKBONE|DICT|DIRECT
+   4254 HB2        21.3600   -2.1320   14.3140 H       266 LEU288      0.0000 DICT
+   4255 HB3        20.1700   -1.3840   13.4820 H       266 LEU288      0.0000 DICT
+   4256 HG         21.3610   -1.9960   11.4540 H       266 LEU288      0.0000 DICT
+   4257 HD11       22.8850   -0.1830   11.6390 H       266 LEU288      0.0000 DICT
+   4258 HD12       21.4390    0.2140   12.2870 H       266 LEU288      0.0000 DICT
+   4259 HD13       22.6870   -0.1880   13.2600 H       266 LEU288      0.0000 DICT
+   4260 HD21       23.6610   -2.5450   11.6860 H       266 LEU288      0.0000 DICT
+   4261 HD22       23.4800   -2.6000   13.3080 H       266 LEU288      0.0000 DICT
+   4262 HD23       22.7240   -3.6980   12.3640 H       266 LEU288      0.0000 DICT
+   4263 N          18.4040   -3.6170   15.1860 N.am    267 GLY289      0.0000 BACKBONE|DICT|DIRECT
+   4264 CA         17.9100   -4.0610   16.4740 C.3     267 GLY289      0.0000 BACKBONE|DICT|DIRECT
+   4265 C          17.7520   -5.5610   16.6220 C.2     267 GLY289      0.0000 BACKBONE|DICT|DIRECT
+   4266 O          17.2880   -6.0170   17.6720 O.2     267 GLY289      0.0000 BACKBONE|DICT|DIRECT
+   4267 H          17.7920   -3.1120   14.5770 H       267 GLY289      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4268 HA2        17.0160   -3.6390   16.6250 H       267 GLY289      0.0000 BACKBONE|DICT|DIRECT
+   4269 HA3        18.5490   -3.7460   17.1760 H       267 GLY289      0.0000 DICT
+   4270 N          18.1270   -6.3390   15.6030 N.am    268 MET290      0.0000 BACKBONE|DICT|DIRECT
+   4271 CA         18.0380   -7.7940   15.6350 C.3     268 MET290      0.0000 BACKBONE|DICT|DIRECT
+   4272 C          19.4050   -8.4520   15.4800 C.2     268 MET290      0.0000 BACKBONE|DICT|DIRECT
+   4273 O          19.4870   -9.6110   15.0640 O.2     268 MET290      0.0000 BACKBONE|DICT|DIRECT
+   4274 CB         17.0910   -8.2900   14.5410 C.3     268 MET290      0.0000 DICT
+   4275 CG         15.7430   -7.6010   14.5330 C.3     268 MET290      0.0000 DICT
+   4276 SD         14.7240   -8.1190   15.9200 S.3     268 MET290      0.0000 DICT
+   4277 CE         14.4370   -9.8370   15.5010 C.3     268 MET290      0.0000 DICT
+   4278 H          18.4860   -5.9020   14.7780 H       268 MET290      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4279 HA         17.6600   -8.0640   16.5210 H       268 MET290      0.0000 BACKBONE|DICT|DIRECT
+   4280 HB2        16.9420   -9.2700   14.6750 H       268 MET290      0.0000 DICT
+   4281 HB3        17.5270   -8.1370   13.6540 H       268 MET290      0.0000 DICT
+   4282 HG2        15.2690   -7.8250   13.6810 H       268 MET290      0.0000 DICT
+   4283 HG3        15.8840   -6.6120   14.5860 H       268 MET290      0.0000 DICT
+   4284 HE1        13.8680  -10.2610   16.2060 H       268 MET290      0.0000 DICT
+   4285 HE2        13.9700   -9.8910   14.6180 H       268 MET290      0.0000 DICT
+   4286 HE3        15.3120  -10.3170   15.4450 H       268 MET290      0.0000 DICT
+   4287 N          20.4800   -7.7420   15.8070 N.am    269 MET291      0.0000 BACKBONE|DICT|DIRECT
+   4288 CA         21.8340   -8.2170   15.5640 C.3     269 MET291      0.0000 BACKBONE|DICT|DIRECT
+   4289 C          22.6270   -8.2160   16.8640 C.2     269 MET291      0.0000 BACKBONE|DICT|DIRECT
+   4290 O          22.6900   -7.1950   17.5570 O.2     269 MET291      0.0000 BACKBONE|DICT|DIRECT
+   4291 CB         22.5220   -7.3470   14.5090 C.3     269 MET291      0.0000 DICT
+   4292 CG         22.7420   -8.0530   13.1800 C.3     269 MET291      0.0000 DICT
+   4293 SD         23.9460   -9.3830   13.3270 S.3     269 MET291      0.0000 DICT
+   4294 CE         25.4530   -8.4280   13.2730 C.3     269 MET291      0.0000 DICT
+   4295 H          20.3540   -6.8480   16.2360 H       269 MET291      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4296 HA         21.7860   -9.1550   15.2210 H       269 MET291      0.0000 BACKBONE|DICT|DIRECT
+   4297 HB2        23.4120   -7.0630   14.8660 H       269 MET291      0.0000 DICT
+   4298 HB3        21.9540   -6.5400   14.3470 H       269 MET291      0.0000 DICT
+   4299 HG2        23.0730   -7.3880   12.5100 H       269 MET291      0.0000 DICT
+   4300 HG3        21.8720   -8.4360   12.8680 H       269 MET291      0.0000 DICT
+   4301 HE1        26.2390   -9.0420   13.3460 H       269 MET291      0.0000 DICT
+   4302 HE2        25.5000   -7.9280   12.4080 H       269 MET291      0.0000 DICT
+   4303 HE3        25.4640   -7.7800   14.0340 H       269 MET291      0.0000 DICT
+   4304 N          23.2320   -9.3550   17.1870 N.am    270 THR292      0.0000 BACKBONE|DICT|DIRECT
+   4305 CA         24.0160   -9.5160   18.3990 C.3     270 THR292      0.0000 BACKBONE|DICT|DIRECT
+   4306 C          25.4900   -9.7010   18.0700 C.2     270 THR292      0.0000 BACKBONE|DICT|DIRECT
+   4307 O          25.8680  -10.0480   16.9480 O.2     270 THR292      0.0000 BACKBONE|DICT|DIRECT
+   4308 CB         23.5330  -10.7140   19.2240 C.3     270 THR292      0.0000 DICT
+   4309 OG1        23.6850  -11.9190   18.4610 O.3     270 THR292      0.0000 DICT
+   4310 CG2        22.0820  -10.5320   19.6060 C.3     270 THR292      0.0000 DICT
+   4311 H          23.1430  -10.1350   16.5680 H       270 THR292      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4312 HA         23.9160   -8.6890   18.9530 H       270 THR292      0.0000 BACKBONE|DICT|DIRECT
+   4313 HB         24.0840  -10.7820   20.0560 H       270 THR292      0.0000 DICT
+   4314 HG1        23.1430  -11.8540   17.6230 H       270 THR292      0.0000 DICT|ESSENTIAL
+   4315 HG21       21.7780  -11.3180   20.1430 H       270 THR292      0.0000 DICT
+   4316 HG22       21.9820   -9.6980   20.1490 H       270 THR292      0.0000 DICT
+   4317 HG23       21.5260  -10.4590   18.7780 H       270 THR292      0.0000 DICT
+   4318 N          26.3200   -9.4680   19.0820 N.am    271 SER293      0.0000 BACKBONE|DICT|DIRECT
+   4319 CA         27.7590   -9.6420   18.9720 C.3     271 SER293      0.0000 BACKBONE|DICT|DIRECT
+   4320 C          28.2760  -10.2260   20.2760 C.2     271 SER293      0.0000 BACKBONE|DICT|DIRECT
+   4321 O          27.8690   -9.8010   21.3610 O.2     271 SER293      0.0000 BACKBONE|DICT|DIRECT
+   4322 CB         28.4620   -8.3170   18.6650 C.3     271 SER293      0.0000 DICT
+   4323 OG         29.8600   -8.5000   18.5670 O.3     271 SER293      0.0000 DICT
+   4324 H          25.9390   -9.1610   19.9540 H       271 SER293      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4325 HA         27.9500  -10.2870   18.2320 H       271 SER293      0.0000 BACKBONE|DICT|DIRECT
+   4326 HB2        28.2670   -7.6650   19.3980 H       271 SER293      0.0000 DICT
+   4327 HB3        28.1170   -7.9560   17.7980 H       271 SER293      0.0000 DICT
+   4328 HG         30.2980   -7.6240   18.3660 H       271 SER293      0.0000 DICT|ESSENTIAL
+   4329 N          29.1580  -11.2130   20.1670 N.am    272 VAL294      0.0000 BACKBONE|DICT|DIRECT
+   4330 CA         29.7330  -11.8840   21.3240 C.3     272 VAL294      0.0000 BACKBONE|DICT|DIRECT
+   4331 C          31.2330  -12.0060   21.1090 C.2     272 VAL294      0.0000 BACKBONE|DICT|DIRECT
+   4332 O          31.6780  -12.5220   20.0770 O.2     272 VAL294      0.0000 BACKBONE|DICT|DIRECT
+   4333 CB         29.1100  -13.2740   21.5580 C.3     272 VAL294      0.0000 DICT
+   4334 CG1        29.8210  -13.9780   22.6980 C.3     272 VAL294      0.0000 DICT
+   4335 CG2        27.6170  -13.1550   21.8450 C.3     272 VAL294      0.0000 DICT
+   4336 H          29.4380  -11.5070   19.2530 H       272 VAL294      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4337 HA         29.5710  -11.3200   22.1340 H       272 VAL294      0.0000 BACKBONE|DICT|DIRECT
+   4338 HB         29.2300  -13.8180   20.7270 H       272 VAL294      0.0000 DICT
+   4339 HG11       29.4100  -14.8780   22.8420 H       272 VAL294      0.0000 DICT
+   4340 HG12       30.7890  -14.0860   22.4710 H       272 VAL294      0.0000 DICT
+   4341 HG13       29.7330  -13.4340   23.5320 H       272 VAL294      0.0000 DICT
+   4342 HG21       27.2320  -14.0660   21.9940 H       272 VAL294      0.0000 DICT
+   4343 HG22       27.4780  -12.5970   22.6630 H       272 VAL294      0.0000 DICT
+   4344 HG23       27.1610  -12.7240   21.0660 H       272 VAL294      0.0000 DICT
+   4345 N          32.0070  -11.5230   22.0740 N.am    273 LEU295      0.0000 BACKBONE|DICT|DIRECT
+   4346 CA         33.4510  -11.6920   22.0640 C.3     273 LEU295      0.0000 BACKBONE|DICT|DIRECT
+   4347 C          33.7960  -12.9170   22.9020 C.2     273 LEU295      0.0000 BACKBONE|DICT|DIRECT
+   4348 O          33.4850  -12.9660   24.0980 O.2     273 LEU295      0.0000 BACKBONE|DICT|DIRECT
+   4349 CB         34.1520  -10.4450   22.6050 C.3     273 LEU295      0.0000 DICT
+   4350 CG         35.6830  -10.4880   22.6610 C.3     273 LEU295      0.0000 DICT
+   4351 CD1        36.2820  -10.6550   21.2700 C.3     273 LEU295      0.0000 DICT
+   4352 CD2        36.2330   -9.2400   23.3310 C.3     273 LEU295      0.0000 DICT
+   4353 H          31.5830  -11.0270   22.8320 H       273 LEU295      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4354 HA         33.7510  -11.8490   21.1230 H       273 LEU295      0.0000 BACKBONE|DICT|DIRECT
+   4355 HB2        33.8190  -10.2890   23.5350 H       273 LEU295      0.0000 DICT
+   4356 HB3        33.8910   -9.6740   22.0240 H       273 LEU295      0.0000 DICT
+   4357 HG         35.9510  -11.2790   23.2110 H       273 LEU295      0.0000 DICT
+   4358 HD11       37.2790  -10.6800   21.3370 H       273 LEU295      0.0000 DICT
+   4359 HD12       35.9540  -11.5090   20.8660 H       273 LEU295      0.0000 DICT
+   4360 HD13       36.0060   -9.8860   20.6940 H       273 LEU295      0.0000 DICT
+   4361 HD21       37.2310   -9.2880   23.3570 H       273 LEU295      0.0000 DICT
+   4362 HD22       35.9520   -8.4320   22.8130 H       273 LEU295      0.0000 DICT
+   4363 HD23       35.8780   -9.1780   24.2640 H       273 LEU295      0.0000 DICT
+   4364 N          34.4120  -13.9100   22.2690 N.am    274 VAL296      0.0000 BACKBONE|DICT|DIRECT
+   4365 CA         34.8610  -15.1240   22.9380 C.3     274 VAL296      0.0000 BACKBONE|DICT|DIRECT
+   4366 C          36.3770  -15.0500   23.0400 C.2     274 VAL296      0.0000 BACKBONE|DICT|DIRECT
+   4367 O          37.0730  -14.9830   22.0190 O.2     274 VAL296      0.0000 BACKBONE|DICT|DIRECT
+   4368 CB         34.4080  -16.3880   22.1900 C.3     274 VAL296      0.0000 DICT
+   4369 CG1        34.8630  -17.6370   22.9260 C.3     274 VAL296      0.0000 DICT
+   4370 CG2        32.8960  -16.3860   22.0200 C.3     274 VAL296      0.0000 DICT
+   4371 H          34.5750  -13.8200   21.2870 H       274 VAL296      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4372 HA         34.4780  -15.1420   23.8610 H       274 VAL296      0.0000 BACKBONE|DICT|DIRECT
+   4373 HB         34.8280  -16.3860   21.2820 H       274 VAL296      0.0000 DICT
+   4374 HG11       34.5600  -18.4480   22.4260 H       274 VAL296      0.0000 DICT
+   4375 HG12       35.8610  -17.6400   22.9920 H       274 VAL296      0.0000 DICT
+   4376 HG13       34.4680  -17.6450   23.8450 H       274 VAL296      0.0000 DICT
+   4377 HG21       32.6140  -17.2120   21.5330 H       274 VAL296      0.0000 DICT
+   4378 HG22       32.4590  -16.3640   22.9190 H       274 VAL296      0.0000 DICT
+   4379 HG23       32.6210  -15.5800   21.4960 H       274 VAL296      0.0000 DICT
+   4380 N          36.8840  -15.0450   24.2640 N.am    275 CYS297      0.0000 BACKBONE|DICT|DIRECT
+   4381 CA         38.3060  -14.8810   24.5000 C.3     275 CYS297      0.0000 BACKBONE|DICT|DIRECT
+   4382 C          39.0520  -16.1910   24.2630 C.2     275 CYS297      0.0000 BACKBONE|DICT|DIRECT
+   4383 O          38.4470  -17.2670   24.2510 O.2     275 CYS297      0.0000 BACKBONE|DICT|DIRECT
+   4384 CB         38.5340  -14.3800   25.9220 C.3     275 CYS297      0.0000 DICT
+   4385 SG         37.8100  -12.7570   26.2150 S.3     275 CYS297      0.0000 DICT
+   4386 H          36.2700  -15.1570   25.0460 H       275 CYS297      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4387 HA         38.6570  -14.1960   23.8620 H       275 CYS297      0.0000 BACKBONE|DICT|DIRECT
+   4388 HB2        39.5190  -14.3250   26.0870 H       275 CYS297      0.0000 DICT
+   4389 HB3        38.1250  -15.0320   26.5600 H       275 CYS297      0.0000 DICT
+   4390 HG         37.9880  -12.4780   27.1590 H       275 CYS297      0.0000 DICT|ESSENTIAL
+   4391 N          40.3720  -16.1230   24.0530 N.am    276 PRO298      0.0000 BACKBONE|DICT|DIRECT
+   4392 CA         41.1420  -17.3590   23.8260 C.3     276 PRO298      0.0000 BACKBONE|DICT|DIRECT
+   4393 C          41.0080  -18.3910   24.9350 C.2     276 PRO298      0.0000 BACKBONE|DICT|DIRECT
+   4394 O          41.0310  -19.5930   24.6430 O.2     276 PRO298      0.0000 BACKBONE|DICT|DIRECT
+   4395 CB         42.5850  -16.8500   23.7030 C.3     276 PRO298      0.0000 DICT
+   4396 CG         42.4430  -15.4580   23.1930 C.3     276 PRO298      0.0000 DICT
+   4397 CD         41.1950  -14.9170   23.8410 C.3     276 PRO298      0.0000 DICT
+   4398 HA         40.8610  -17.7680   22.9580 H       276 PRO298      0.0000 BACKBONE|DICT|DIRECT
+   4399 HB2        43.0400  -16.8560   24.5940 H       276 PRO298      0.0000 DICT
+   4400 HB3        43.1050  -17.4120   23.0590 H       276 PRO298      0.0000 DICT
+   4401 HG2        43.2370  -14.9080   23.4520 H       276 PRO298      0.0000 DICT
+   4402 HG3        42.3480  -15.4590   22.1980 H       276 PRO298      0.0000 DICT
+   4403 HD2        41.4070  -14.4710   24.7100 H       276 PRO298      0.0000 DICT
+   4404 HD3        40.7310  -14.2680   23.2380 H       276 PRO298      0.0000 DICT
+   4405 N          40.8500  -17.9700   26.1940 N.am    277 ASP299      0.0000 BACKBONE|DICT|DIRECT
+   4406 CA         40.7570  -18.9320   27.2920 C.3     277 ASP299      0.0000 BACKBONE|DICT|DIRECT
+   4407 C          39.5010  -19.7960   27.2350 C.2     277 ASP299      0.0000 BACKBONE|DICT|DIRECT
+   4408 O          39.3490  -20.6790   28.0860 O.2     277 ASP299      0.0000 BACKBONE|DICT|DIRECT
+   4409 CB         40.8360  -18.2130   28.6470 C.3     277 ASP299      0.0000 DICT
+   4410 CG         39.7420  -17.1590   28.8390 C.2     277 ASP299      0.0000 DICT
+   4411 OD1        38.6240  -17.3160   28.3070 O.co2   277 ASP299      0.0000 DICT
+   4412 OD2        40.0030  -16.1640   29.5470 O.co2   277 ASP299      0.0000 DICT
+   4413 H          40.7950  -16.9900   26.3870 H       277 ASP299      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4414 HA         41.5470  -19.5420   27.2270 H       277 ASP299      0.0000 BACKBONE|DICT|DIRECT
+   4415 HB2        41.7260  -17.7630   28.7160 H       277 ASP299      0.0000 DICT
+   4416 HB3        40.7510  -18.8950   29.3730 H       277 ASP299      0.0000 DICT
+   4417 N          38.6010  -19.5620   26.2800 N.am    278 GLY300      0.0000 BACKBONE|DICT|DIRECT
+   4418 CA         37.4000  -20.3650   26.1370 C.3     278 GLY300      0.0000 BACKBONE|DICT|DIRECT
+   4419 C          36.3950  -20.1940   27.2590 C.2     278 GLY300      0.0000 BACKBONE|DICT|DIRECT
+   4420 O          35.3520  -20.8560   27.2720 O.2     278 GLY300      0.0000 BACKBONE|DICT|DIRECT
+   4421 H          38.7580  -18.8090   25.6410 H       278 GLY300      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4422 HA2        37.6700  -21.3270   26.1030 H       278 GLY300      0.0000 BACKBONE|DICT|DIRECT
+   4423 HA3        36.9550  -20.1120   25.2780 H       278 GLY300      0.0000 DICT
+   4424 N          36.6860  -19.2950   28.1990 N.am    279 LYS301      0.0000 BACKBONE|DICT|DIRECT
+   4425 CA         35.8790  -19.1320   29.4000 C.3     279 LYS301      0.0000 BACKBONE|DICT|DIRECT
+   4426 C          35.3300  -17.7240   29.5930 C.2     279 LYS301      0.0000 BACKBONE|DICT|DIRECT
+   4427 O          34.2750  -17.5700   30.2160 O.2     279 LYS301      0.0000 BACKBONE|DICT|DIRECT
+   4428 CB         36.7060  -19.5280   30.6360 C.3     279 LYS301      0.0000 DICT
+   4429 CG         35.9430  -19.5270   31.9520 C.3     279 LYS301      0.0000 DICT
+   4430 CD         36.8900  -19.7450   33.1230 C.3     279 LYS301      0.0000 DICT
+   4431 CE         36.1450  -20.1540   34.3860 C.3     279 LYS301      0.0000 DICT
+   4432 NZ         37.0740  -20.7530   35.3820 N.4     279 LYS301      0.0000 DICT
+   4433 H          37.4880  -18.7110   28.0750 H       279 LYS301      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4434 HA         35.1020  -19.7590   29.3360 H       279 LYS301      0.0000 BACKBONE|DICT|DIRECT
+   4435 HB2        37.4670  -18.8840   30.7190 H       279 LYS301      0.0000 DICT
+   4436 HB3        37.0640  -20.4500   30.4870 H       279 LYS301      0.0000 DICT
+   4437 HG2        35.2640  -20.2610   31.9380 H       279 LYS301      0.0000 DICT
+   4438 HG3        35.4810  -18.6470   32.0630 H       279 LYS301      0.0000 DICT
+   4439 HD2        37.3860  -18.8950   33.3010 H       279 LYS301      0.0000 DICT
+   4440 HD3        37.5400  -20.4660   32.8830 H       279 LYS301      0.0000 DICT
+   4441 HE2        35.4430  -20.8250   34.1490 H       279 LYS301      0.0000 DICT
+   4442 HE3        35.7120  -19.3460   34.7870 H       279 LYS301      0.0000 DICT
+   4443 HZ1        36.5620  -21.0130   36.2010 H       279 LYS301      0.0000 DICT|ESSENTIAL
+   4444 HZ2        37.5070  -21.5640   34.9880 H       279 LYS301      0.0000 DICT|ESSENTIAL
+   4445 HZ3        37.7770  -20.0850   35.6260 H       279 LYS301      0.0000 DICT|ESSENTIAL
+   4446 N          36.0010  -16.7000   29.0720 N.am    280 THR302      0.0000 BACKBONE|DICT|DIRECT
+   4447 CA         35.5720  -15.3150   29.2250 C.3     280 THR302      0.0000 BACKBONE|DICT|DIRECT
+   4448 C          34.7700  -14.8870   28.0020 C.2     280 THR302      0.0000 BACKBONE|DICT|DIRECT
+   4449 O          35.1750  -15.1470   26.8640 O.2     280 THR302      0.0000 BACKBONE|DICT|DIRECT
+   4450 CB         36.7750  -14.3920   29.4140 C.3     280 THR302      0.0000 DICT
+   4451 OG1        37.5310  -14.8220   30.5520 O.3     280 THR302      0.0000 DICT
+   4452 CG2        36.3180  -12.9540   29.6300 C.3     280 THR302      0.0000 DICT
+   4453 H          36.8350  -16.8880   28.5530 H       280 THR302      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4454 HA         34.9860  -15.2480   30.0330 H       280 THR302      0.0000 BACKBONE|DICT|DIRECT
+   4455 HB         37.3540  -14.4350   28.5990 H       280 THR302      0.0000 DICT
+   4456 HG1        38.2240  -15.4820   30.2620 H       280 THR302      0.0000 DICT|ESSENTIAL
+   4457 HG21       37.1170  -12.3650   29.7520 H       280 THR302      0.0000 DICT
+   4458 HG22       35.7960  -12.6470   28.8340 H       280 THR302      0.0000 DICT
+   4459 HG23       35.7420  -12.9060   30.4460 H       280 THR302      0.0000 DICT
+   4460 N          33.6390  -14.2290   28.2400 N.am    281 VAL303      0.0000 BACKBONE|DICT|DIRECT
+   4461 CA         32.7200  -13.8320   27.1780 C.3     281 VAL303      0.0000 BACKBONE|DICT|DIRECT
+   4462 C          32.1800  -12.4390   27.4850 C.2     281 VAL303      0.0000 BACKBONE|DICT|DIRECT
+   4463 O          31.9590  -12.0880   28.6490 O.2     281 VAL303      0.0000 BACKBONE|DICT|DIRECT
+   4464 CB         31.5770  -14.8610   27.0260 C.3     281 VAL303      0.0000 DICT
+   4465 CG1        30.3940  -14.2720   26.2770 C.3     281 VAL303      0.0000 DICT
+   4466 CG2        32.0830  -16.1150   26.3190 C.3     281 VAL303      0.0000 DICT
+   4467 H          33.4090  -13.9970   29.1850 H       281 VAL303      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4468 HA         33.2280  -13.7930   26.3170 H       281 VAL303      0.0000 BACKBONE|DICT|DIRECT
+   4469 HB         31.2680  -15.1220   27.9410 H       281 VAL303      0.0000 DICT
+   4470 HG11       29.6740  -14.9610   26.1960 H       281 VAL303      0.0000 DICT
+   4471 HG12       30.0430  -13.4810   26.7780 H       281 VAL303      0.0000 DICT
+   4472 HG13       30.6860  -13.9860   25.3640 H       281 VAL303      0.0000 DICT
+   4473 HG21       31.3340  -16.7710   26.2280 H       281 VAL303      0.0000 DICT
+   4474 HG22       32.4250  -15.8710   25.4120 H       281 VAL303      0.0000 DICT
+   4475 HG23       32.8220  -16.5250   26.8550 H       281 VAL303      0.0000 DICT
+   4476 N          31.9910  -11.6360   26.4360 N.am    282 GLU304      0.0000 BACKBONE|DICT|DIRECT
+   4477 CA         31.3190  -10.3460   26.5340 C.3     282 GLU304      0.0000 BACKBONE|DICT|DIRECT
+   4478 C          30.3100  -10.2290   25.4010 C.2     282 GLU304      0.0000 BACKBONE|DICT|DIRECT
+   4479 O          30.6480  -10.4740   24.2400 O.2     282 GLU304      0.0000 BACKBONE|DICT|DIRECT
+   4480 CB         32.3150   -9.1840   26.4770 C.3     282 GLU304      0.0000 DICT
+   4481 CG         31.6860   -7.8350   26.7920 C.3     282 GLU304      0.0000 DICT
+   4482 CD         32.0720   -6.7680   25.7930 C.2     282 GLU304      0.0000 DICT
+   4483 OE1        32.6120   -7.1230   24.7240 O.co2   282 GLU304      0.0000 DICT
+   4484 OE2        31.8380   -5.5750   26.0740 O.co2   282 GLU304      0.0000 DICT
+   4485 H          32.3260  -11.9330   25.5420 H       282 GLU304      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4486 HA         30.8290  -10.3050   27.4050 H       282 GLU304      0.0000 BACKBONE|DICT|DIRECT
+   4487 HB2        32.7050   -9.1450   25.5570 H       282 GLU304      0.0000 DICT
+   4488 HB3        33.0430   -9.3570   27.1400 H       282 GLU304      0.0000 DICT
+   4489 HG2        31.9850   -7.5460   27.7010 H       282 GLU304      0.0000 DICT
+   4490 HG3        30.6910   -7.9360   26.7850 H       282 GLU304      0.0000 DICT
+   4491 N          29.0800   -9.8450   25.7360 N.am    283 ALA305      0.0000 BACKBONE|DICT|DIRECT
+   4492 CA         27.9880   -9.7890   24.7780 C.3     283 ALA305      0.0000 BACKBONE|DICT|DIRECT
+   4493 C          27.4030   -8.3850   24.7210 C.2     283 ALA305      0.0000 BACKBONE|DICT|DIRECT
+   4494 O          27.3550   -7.6700   25.7270 O.2     283 ALA305      0.0000 BACKBONE|DICT|DIRECT
+   4495 CB         26.8830  -10.7940   25.1310 C.3     283 ALA305      0.0000 DICT
+   4496 H          28.9000   -9.5850   26.6850 H       283 ALA305      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4497 HA         28.3480  -10.0190   23.8740 H       283 ALA305      0.0000 BACKBONE|DICT|DIRECT
+   4498 HB1        26.1480  -10.7320   24.4560 H       283 ALA305      0.0000 DICT
+   4499 HB2        27.2610  -11.7200   25.1280 H       283 ALA305      0.0000 DICT
+   4500 HB3        26.5200  -10.5850   26.0390 H       283 ALA305      0.0000 DICT
+   4501 N          26.9490   -8.0000   23.5320 N.am    284 GLU306      0.0000 BACKBONE|DICT|DIRECT
+   4502 CA         26.3730   -6.6780   23.3380 C.3     284 GLU306      0.0000 BACKBONE|DICT|DIRECT
+   4503 C          25.5460   -6.6760   22.0630 C.2     284 GLU306      0.0000 BACKBONE|DICT|DIRECT
+   4504 O          25.6650   -7.5680   21.2170 O.2     284 GLU306      0.0000 BACKBONE|DICT|DIRECT
+   4505 CB         27.4580   -5.5980   23.2790 C.3     284 GLU306      0.0000 DICT
+   4506 CG         28.5220   -5.8430   22.2320 C.3     284 GLU306      0.0000 DICT
+   4507 CD         29.6620   -4.8460   22.3290 C.2     284 GLU306      0.0000 DICT
+   4508 OE1        29.3930   -3.6520   22.5940 O.co2   284 GLU306      0.0000 DICT
+   4509 OE2        30.8270   -5.2590   22.1510 O.co2   284 GLU306      0.0000 DICT
+   4510 H          27.0040   -8.6300   22.7570 H       284 GLU306      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4511 HA         25.7680   -6.4790   24.1090 H       284 GLU306      0.0000 BACKBONE|DICT|DIRECT
+   4512 HB2        27.9030   -5.5520   24.1730 H       284 GLU306      0.0000 DICT
+   4513 HB3        27.0180   -4.7220   23.0800 H       284 GLU306      0.0000 DICT
+   4514 HG2        28.1050   -5.7690   21.3260 H       284 GLU306      0.0000 DICT
+   4515 HG3        28.8890   -6.7650   22.3550 H       284 GLU306      0.0000 DICT
+   4516 HOE1       30.1290   -2.9790   22.6720 H       284 GLU306      0.0000 
+   4517 N          24.6930   -5.6620   21.9460 N.am    285 ALA307      0.0000 BACKBONE|DICT|DIRECT
+   4518 CA         23.9700   -5.4300   20.7070 C.3     285 ALA307      0.0000 BACKBONE|DICT|DIRECT
+   4519 C          24.9310   -4.9340   19.6360 C.2     285 ALA307      0.0000 BACKBONE|DICT|DIRECT
+   4520 O          25.8860   -4.2090   19.9250 O.2     285 ALA307      0.0000 BACKBONE|DICT|DIRECT
+   4521 CB         22.8540   -4.4140   20.9250 C.3     285 ALA307      0.0000 DICT
+   4522 H          24.5470   -5.0500   22.7230 H       285 ALA307      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4523 HA         23.5660   -6.2930   20.4030 H       285 ALA307      0.0000 BACKBONE|DICT|DIRECT
+   4524 HB1        22.3660   -4.2650   20.0650 H       285 ALA307      0.0000 DICT
+   4525 HB2        22.2170   -4.7610   21.6140 H       285 ALA307      0.0000 DICT
+   4526 HB3        23.2470   -3.5500   21.2400 H       285 ALA307      0.0000 DICT
+   4527 N          24.6800   -5.3330   18.3910 N.am    286 ALA308      0.0000 BACKBONE|DICT|DIRECT
+   4528 CA         25.5570   -4.9570   17.2900 C.3     286 ALA308      0.0000 BACKBONE|DICT|DIRECT
+   4529 C          25.2600   -3.5700   16.7350 C.2     286 ALA308      0.0000 BACKBONE|DICT|DIRECT
+   4530 O          25.8950   -3.1660   15.7560 O.2     286 ALA308      0.0000 BACKBONE|DICT|DIRECT
+   4531 CB         25.4710   -5.9940   16.1680 C.3     286 ALA308      0.0000 DICT
+   4532 H          23.8770   -5.9000   18.2090 H       286 ALA308      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4533 HA         26.4960   -4.9550   17.6340 H       286 ALA308      0.0000 BACKBONE|DICT|DIRECT
+   4534 HB1        26.0760   -5.7250   15.4190 H       286 ALA308      0.0000 DICT
+   4535 HB2        25.7500   -6.8880   16.5180 H       286 ALA308      0.0000 DICT
+   4536 HB3        24.5300   -6.0460   15.8340 H       286 ALA308      0.0000 DICT
+   4537 N          24.3310   -2.8320   17.3290 N.am    287 HIS309      0.0000 BACKBONE|DICT|DIRECT
+   4538 CA         23.9870   -1.4900   16.8880 C.3     287 HIS309      0.0000 BACKBONE|DICT|DIRECT
+   4539 C          24.5240   -0.4650   17.8830 C.2     287 HIS309      0.0000 BACKBONE|DICT|DIRECT
+   4540 O          25.1520   -0.8040   18.8890 O.2     287 HIS309      0.0000 BACKBONE|DICT|DIRECT
+   4541 CB         22.4720   -1.3530   16.7060 C.3     287 HIS309      0.0000 DICT
+   4542 CG         21.6800   -1.6540   17.9410 C.2     287 HIS309      0.0000 DICT
+   4543 ND1        21.6200   -0.7930   19.0150 N.pl3   287 HIS309      0.0000 DICT
+   4544 CD2        20.9050   -2.7150   18.2660 C.2     287 HIS309      0.0000 DICT
+   4545 CE1        20.8470   -1.3130   19.9520 C.2     287 HIS309      0.0000 DICT
+   4546 NE2        20.3980   -2.4780   19.5220 N.2     287 HIS309      0.0000 DICT
+   4547 H          23.8460   -3.2160   18.1150 H       287 HIS309      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4548 HA         24.4250   -1.3280   16.0040 H       287 HIS309      0.0000 BACKBONE|DICT|DIRECT
+   4549 HB2        22.1840   -1.9840   15.9860 H       287 HIS309      0.0000 DICT
+   4550 HB3        22.2730   -0.4140   16.4260 H       287 HIS309      0.0000 DICT
+   4551 HD1        22.0890    0.0880   19.0760 H       287 HIS309      0.0000 DICT|ESSENTIAL
+   4552 HD2        20.7330   -3.5210   17.6990 H       287 HIS309      0.0000 DICT
+   4553 HE1        20.6380   -0.8950   20.8360 H       287 HIS309      0.0000 DICT
+   4554 N          24.2670    0.8070   17.5920 N.am    288 GLY310      0.0000 BACKBONE|DICT|DIRECT
+   4555 CA         24.7280    1.9050   18.4100 C.3     288 GLY310      0.0000 BACKBONE|DICT|DIRECT
+   4556 C          23.6960    2.3620   19.4210 C.2     288 GLY310      0.0000 BACKBONE|DICT|DIRECT
+   4557 O          22.7730    1.6270   19.7910 O.2     288 GLY310      0.0000 BACKBONE|DICT|DIRECT
+   4558 H          23.7320    1.0120   16.7720 H       288 GLY310      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4559 HA2        24.9520    2.6750   17.8130 H       288 GLY310      0.0000 BACKBONE|DICT|DIRECT
+   4560 HA3        25.5490    1.6140   18.9010 H       288 GLY310      0.0000 DICT
+   4561 N          23.8540    3.6070   19.8700 N.am    289 THR311      0.0000 BACKBONE|DICT|DIRECT
+   4562 CA         23.0150    4.1670   20.9220 C.3     289 THR311      0.0000 BACKBONE|DICT|DIRECT
+   4563 C          21.6940    4.7240   20.4050 C.2     289 THR311      0.0000 BACKBONE|DICT|DIRECT
+   4564 O          20.9070    5.2380   21.2080 O.2     289 THR311      0.0000 BACKBONE|DICT|DIRECT
+   4565 CB         23.7750    5.2660   21.6710 C.3     289 THR311      0.0000 DICT
+   4566 OG1        23.9020    6.4190   20.8310 O.3     289 THR311      0.0000 DICT
+   4567 CG2        25.1640    4.7760   22.0550 C.3     289 THR311      0.0000 DICT
+   4568 H          24.5730    4.1760   19.4710 H       289 THR311      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4569 HA         22.8080    3.4370   21.5730 H       289 THR311      0.0000 BACKBONE|DICT|DIRECT
+   4570 HB         23.2700    5.5130   22.4980 H       289 THR311      0.0000 DICT
+   4571 HG1        23.4590    7.2010   21.2690 H       289 THR311      0.0000 DICT|ESSENTIAL
+   4572 HG21       25.6500    5.5010   22.5430 H       289 THR311      0.0000 DICT
+   4573 HG22       25.0830    3.9730   22.6460 H       289 THR311      0.0000 DICT
+   4574 HG23       25.6720    4.5320   21.2290 H       289 THR311      0.0000 DICT
+   4575 N          21.4350    4.6200   19.0980 N.am    290 VAL312      0.0000 BACKBONE|DICT|DIRECT
+   4576 CA         20.1890    5.0620   18.4770 C.3     290 VAL312      0.0000 BACKBONE|DICT|DIRECT
+   4577 C          19.9390    6.5230   18.8400 C.2     290 VAL312      0.0000 BACKBONE|DICT|DIRECT
+   4578 O          18.9190    6.8620   19.4530 O.2     290 VAL312      0.0000 BACKBONE|DICT|DIRECT
+   4579 CB         19.0120    4.1560   18.8880 C.3     290 VAL312      0.0000 DICT
+   4580 CG1        17.8740    4.2750   17.8900 C.3     290 VAL312      0.0000 DICT
+   4581 CG2        19.4640    2.7020   19.0000 C.3     290 VAL312      0.0000 DICT
+   4582 H          22.1360    4.2160   18.5100 H       290 VAL312      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4583 HA         20.2970    5.0020   17.4850 H       290 VAL312      0.0000 BACKBONE|DICT|DIRECT
+   4584 HB         18.6810    4.4540   19.7830 H       290 VAL312      0.0000 DICT
+   4585 HG11       17.1200    3.6810   18.1720 H       290 VAL312      0.0000 DICT
+   4586 HG12       17.5570    5.2230   17.8570 H       290 VAL312      0.0000 DICT
+   4587 HG13       18.1950    3.9990   16.9840 H       290 VAL312      0.0000 DICT
+   4588 HG21       18.6880    2.1310   19.2670 H       290 VAL312      0.0000 DICT
+   4589 HG22       19.8160    2.3930   18.1160 H       290 VAL312      0.0000 DICT
+   4590 HG23       20.1840    2.6290   19.6900 H       290 VAL312      0.0000 DICT
+   4591 N          20.8780    7.3930   18.4510 N.am    291 THR313      0.0000 BACKBONE|DICT|DIRECT
+   4592 CA         20.8620    8.7860   18.8920 C.3     291 THR313      0.0000 BACKBONE|DICT|DIRECT
+   4593 C          19.5730    9.4920   18.4910 C.2     291 THR313      0.0000 BACKBONE|DICT|DIRECT
+   4594 O          19.0100   10.2690   19.2740 O.2     291 THR313      0.0000 BACKBONE|DICT|DIRECT
+   4595 CB         22.0750    9.5260   18.3190 C.3     291 THR313      0.0000 DICT
+   4596 OG1        23.2780    8.9610   18.8520 O.3     291 THR313      0.0000 DICT
+   4597 CG2        22.0240   11.0130   18.6570 C.3     291 THR313      0.0000 DICT
+   4598 H          21.6090    7.0820   17.8430 H       291 THR313      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4599 HA         20.9290    8.8000   19.8900 H       291 THR313      0.0000 BACKBONE|DICT|DIRECT
+   4600 HB         22.0800    9.4200   17.3250 H       291 THR313      0.0000 DICT
+   4601 HG1        23.2750    9.0490   19.8480 H       291 THR313      0.0000 DICT|ESSENTIAL
+   4602 HG21       22.8260   11.4700   18.2720 H       291 THR313      0.0000 DICT
+   4603 HG22       21.1940   11.4140   18.2710 H       291 THR313      0.0000 DICT
+   4604 HG23       22.0190   11.1290   19.6500 H       291 THR313      0.0000 DICT
+   4605 N          19.0830    9.2280   17.2790 N.am    292 ARG314      0.0000 BACKBONE|DICT|DIRECT
+   4606 CA         17.9350    9.9780   16.7830 C.3     292 ARG314      0.0000 BACKBONE|DICT|DIRECT
+   4607 C          16.6550    9.6190   17.5360 C.2     292 ARG314      0.0000 BACKBONE|DICT|DIRECT
+   4608 O          15.8080   10.4940   17.7510 O.2     292 ARG314      0.0000 BACKBONE|DICT|DIRECT
+   4609 CB         17.7810    9.7640   15.2720 C.3     292 ARG314      0.0000 DICT
+   4610 CG         16.3850   10.0410   14.7110 C.3     292 ARG314      0.0000 DICT
+   4611 CD         16.1580    9.2500   13.4440 C.3     292 ARG314      0.0000 DICT
+   4612 NE         14.7430    9.1470   13.1080 N.pl3   292 ARG314      0.0000 DICT
+   4613 CZ         14.0630    8.0090   13.1520 C.cat   292 ARG314      0.0000 DICT
+   4614 NH1        12.7830    7.9870   12.8210 N.pl3   292 ARG314      0.0000 DICT
+   4615 NH2        14.6740    6.9070   13.5610 N.pl3   292 ARG314      0.0000 DICT
+   4616 H          19.5010    8.5180   16.7120 H       292 ARG314      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4617 HA         18.1160   10.9490   16.9360 H       292 ARG314      0.0000 BACKBONE|DICT|DIRECT
+   4618 HB2        18.0120    8.8120   15.0700 H       292 ARG314      0.0000 DICT
+   4619 HB3        18.4270   10.3700   14.8070 H       292 ARG314      0.0000 DICT
+   4620 HG2        16.2990   11.0170   14.5100 H       292 ARG314      0.0000 DICT
+   4621 HG3        15.6990    9.7790   15.3900 H       292 ARG314      0.0000 DICT
+   4622 HD2        16.5280    8.3290   13.5680 H       292 ARG314      0.0000 DICT
+   4623 HD3        16.6360    9.7030   12.6910 H       292 ARG314      0.0000 DICT
+   4624 HE         14.2600    9.9770   12.8300 H       292 ARG314      0.0000 DICT|ESSENTIAL
+   4625 HH11       12.2720    7.1280   12.8550 H       292 ARG314      0.0000 DICT|ESSENTIAL
+   4626 HH12       12.3260    8.8300   12.5370 H       292 ARG314      0.0000 DICT|ESSENTIAL
+   4627 HH21       14.1730    6.0420   13.5990 H       292 ARG314      0.0000 DICT|ESSENTIAL
+   4628 HH22       15.6360    6.9400   13.8320 H       292 ARG314      0.0000 DICT|ESSENTIAL
+   4629 N          16.4980    8.3610   17.9680 N.am    293 HIS315      0.0000 BACKBONE|DICT|DIRECT
+   4630 CA         15.3790    8.0410   18.8520 C.3     293 HIS315      0.0000 BACKBONE|DICT|DIRECT
+   4631 C          15.5210    8.7620   20.1860 C.2     293 HIS315      0.0000 BACKBONE|DICT|DIRECT
+   4632 O          14.5280    9.2220   20.7640 O.2     293 HIS315      0.0000 BACKBONE|DICT|DIRECT
+   4633 CB         15.2760    6.5310   19.0800 C.3     293 HIS315      0.0000 DICT
+   4634 CG         14.8860    5.7490   17.8630 C.2     293 HIS315      0.0000 DICT
+   4635 ND1        14.3460    4.4820   17.9340 N.pl3   293 HIS315      0.0000 DICT
+   4636 CD2        14.9720    6.0470   16.5450 C.2     293 HIS315      0.0000 DICT
+   4637 CE1        14.1100    4.0360   16.7130 C.2     293 HIS315      0.0000 DICT
+   4638 NE2        14.4820    4.9660   15.8520 N.pl3   293 HIS315      0.0000 DICT
+   4639 H          17.1400    7.6470   17.6880 H       293 HIS315      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4640 HA         14.5350    8.3510   18.4150 H       293 HIS315      0.0000 BACKBONE|DICT|DIRECT
+   4641 HB2        14.5910    6.3670   19.7900 H       293 HIS315      0.0000 DICT
+   4642 HB3        16.1660    6.2000   19.3930 H       293 HIS315      0.0000 DICT
+   4643 HD1        14.1620    3.9790   18.7780 H       293 HIS315      0.0000 DICT|ESSENTIAL
+   4644 HD2        15.3260    6.8950   16.1500 H       293 HIS315      0.0000 DICT
+   4645 HE1        13.7170    3.1460   16.4800 H       293 HIS315      0.0000 DICT
+   4646 HE2        14.4180    4.8950   14.8570 H       293 HIS315      0.0000 DICT|ESSENTIAL
+   4647 N          16.7520    8.8720   20.6880 N.am    294 TYR316      0.0000 BACKBONE|DICT|DIRECT
+   4648 CA         16.9840    9.6020   21.9270 C.3     294 TYR316      0.0000 BACKBONE|DICT|DIRECT
+   4649 C          16.5860   11.0670   21.7860 C.2     294 TYR316      0.0000 BACKBONE|DICT|DIRECT
+   4650 O          16.0400   11.6620   22.7220 O.2     294 TYR316      0.0000 BACKBONE|DICT|DIRECT
+   4651 CB         18.4520    9.4790   22.3360 C.3     294 TYR316      0.0000 DICT
+   4652 CG         18.7660   10.1200   23.6640 C.ar    294 TYR316      0.0000 DICT
+   4653 CD1        18.1960    9.6380   24.8330 C.ar    294 TYR316      0.0000 DICT
+   4654 CD2        19.6340   11.2030   23.7510 C.ar    294 TYR316      0.0000 DICT
+   4655 CE1        18.4770   10.2120   26.0540 C.ar    294 TYR316      0.0000 DICT
+   4656 CE2        19.9240   11.7840   24.9690 C.ar    294 TYR316      0.0000 DICT
+   4657 CZ         19.3420   11.2830   26.1170 C.ar    294 TYR316      0.0000 DICT
+   4658 OH         19.6210   11.8510   27.3360 O.3     294 TYR316      0.0000 DICT
+   4659 H          17.5220    8.4500   20.2100 H       294 TYR316      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4660 HA         16.4220    9.1910   22.6450 H       294 TYR316      0.0000 BACKBONE|DICT|DIRECT
+   4661 HB2        19.0130    9.9170   21.6340 H       294 TYR316      0.0000 DICT
+   4662 HB3        18.6840    8.5080   22.3910 H       294 TYR316      0.0000 DICT
+   4663 HD1        17.5700    8.8600   24.7890 H       294 TYR316      0.0000 DICT
+   4664 HD2        20.0540   11.5660   22.9190 H       294 TYR316      0.0000 DICT
+   4665 HE1        18.0570    9.8540   26.8880 H       294 TYR316      0.0000 DICT
+   4666 HE2        20.5510   12.5620   25.0200 H       294 TYR316      0.0000 DICT
+   4667 HH         20.2470   12.6290   27.3940 H       294 TYR316      0.0000 DICT|ESSENTIAL
+   4668 N          16.8540   11.6660   20.6220 N.am    295 ARG317      0.0000 BACKBONE|DICT|DIRECT
+   4669 CA         16.4560   13.0540   20.4040 C.3     295 ARG317      0.0000 BACKBONE|DICT|DIRECT
+   4670 C          14.9390   13.1960   20.4140 C.2     295 ARG317      0.0000 BACKBONE|DICT|DIRECT
+   4671 O          14.4060   14.1730   20.9550 O.2     295 ARG317      0.0000 BACKBONE|DICT|DIRECT
+   4672 CB         17.0420   13.5700   19.0900 C.3     295 ARG317      0.0000 DICT
+   4673 CG         18.5610   13.4980   19.0110 C.3     295 ARG317      0.0000 DICT
+   4674 CD         19.2360   14.6370   19.7700 C.3     295 ARG317      0.0000 DICT
+   4675 NE         20.6750   14.6800   19.5070 N.pl3   295 ARG317      0.0000 DICT
+   4676 CZ         21.6180   14.5090   20.4310 C.cat   295 ARG317      0.0000 DICT
+   4677 NH1        21.2840   14.3000   21.6960 N.pl3   295 ARG317      0.0000 DICT
+   4678 NH2        22.9000   14.5600   20.0910 N.pl3   295 ARG317      0.0000 DICT
+   4679 H          17.3280   11.1630   19.8990 H       295 ARG317      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4680 HA         16.8270   13.6070   21.1500 H       295 ARG317      0.0000 BACKBONE|DICT|DIRECT
+   4681 HB2        16.7670   14.5250   18.9780 H       295 ARG317      0.0000 DICT
+   4682 HB3        16.6630   13.0240   18.3420 H       295 ARG317      0.0000 DICT
+   4683 HG2        18.8350   13.5450   18.0510 H       295 ARG317      0.0000 DICT
+   4684 HG3        18.8620   12.6280   19.4020 H       295 ARG317      0.0000 DICT
+   4685 HD2        19.0890   14.5060   20.7500 H       295 ARG317      0.0000 DICT
+   4686 HD3        18.8280   15.5040   19.4850 H       295 ARG317      0.0000 DICT
+   4687 HE         20.9710   14.8500   18.5670 H       295 ARG317      0.0000 DICT|ESSENTIAL
+   4688 HH11       21.9960   14.1720   22.3870 H       295 ARG317      0.0000 DICT|ESSENTIAL
+   4689 HH12       20.3200   14.2700   21.9600 H       295 ARG317      0.0000 DICT|ESSENTIAL
+   4690 HH21       23.6070   14.4310   20.7860 H       295 ARG317      0.0000 DICT|ESSENTIAL
+   4691 HH22       23.1590   14.7270   19.1400 H       295 ARG317      0.0000 DICT|ESSENTIAL
+   4692 N          14.2270   12.2270   19.8300 N.am    296 MET318      0.0000 BACKBONE|DICT|DIRECT
+   4693 CA         12.7690   12.2370   19.9010 C.3     296 MET318      0.0000 BACKBONE|DICT|DIRECT
+   4694 C          12.2920   12.1430   21.3450 C.2     296 MET318      0.0000 BACKBONE|DICT|DIRECT
+   4695 O          11.3690   12.8590   21.7530 O.2     296 MET318      0.0000 BACKBONE|DICT|DIRECT
+   4696 CB         12.1970   11.0870   19.0720 C.3     296 MET318      0.0000 DICT
+   4697 CG         12.5220   11.1610   17.5880 C.3     296 MET318      0.0000 DICT
+   4698 SD         11.9900    9.6900   16.6830 S.3     296 MET318      0.0000 DICT
+   4699 CE         10.2320    9.6820   17.0320 C.3     296 MET318      0.0000 DICT
+   4700 H          14.6960   11.4910   19.3420 H       296 MET318      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4701 HA         12.4400   13.0990   19.5150 H       296 MET318      0.0000 BACKBONE|DICT|DIRECT
+   4702 HB2        11.2020   11.0910   19.1750 H       296 MET318      0.0000 DICT
+   4703 HB3        12.5650   10.2290   19.4310 H       296 MET318      0.0000 DICT
+   4704 HG2        13.5110   11.2620   17.4820 H       296 MET318      0.0000 DICT
+   4705 HG3        12.0620   11.9590   17.1990 H       296 MET318      0.0000 DICT
+   4706 HE1         9.8060    8.8990   16.5790 H       296 MET318      0.0000 DICT
+   4707 HE2        10.0880    9.6150   18.0190 H       296 MET318      0.0000 DICT
+   4708 HE3         9.8210   10.5280   16.6920 H       296 MET318      0.0000 DICT
+   4709 N          12.9190   11.2640   22.1320 N.am    297 TYR319      0.0000 BACKBONE|DICT|DIRECT
+   4710 CA         12.5890   11.1430   23.5490 C.3     297 TYR319      0.0000 BACKBONE|DICT|DIRECT
+   4711 C          12.8610   12.4450   24.2930 C.2     297 TYR319      0.0000 BACKBONE|DICT|DIRECT
+   4712 O          12.0940   12.8300   25.1850 O.2     297 TYR319      0.0000 BACKBONE|DICT|DIRECT
+   4713 CB         13.3890    9.9920   24.1580 C.3     297 TYR319      0.0000 DICT
+   4714 CG         13.1830    9.7630   25.6380 C.ar    297 TYR319      0.0000 DICT
+   4715 CD1        12.1320    8.9810   26.0990 C.ar    297 TYR319      0.0000 DICT
+   4716 CD2        14.0580   10.3030   26.5740 C.ar    297 TYR319      0.0000 DICT
+   4717 CE1        11.9500    8.7550   27.4510 C.ar    297 TYR319      0.0000 DICT
+   4718 CE2        13.8820   10.0840   27.9300 C.ar    297 TYR319      0.0000 DICT
+   4719 CZ         12.8290    9.3080   28.3620 C.ar    297 TYR319      0.0000 DICT
+   4720 OH         12.6480    9.0850   29.7090 O.3     297 TYR319      0.0000 DICT
+   4721 H          13.6290   10.6770   21.7430 H       297 TYR319      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4722 HA         11.6150   10.9300   23.6300 H       297 TYR319      0.0000 BACKBONE|DICT|DIRECT
+   4723 HB2        14.3600   10.1790   24.0080 H       297 TYR319      0.0000 DICT
+   4724 HB3        13.1330    9.1520   23.6790 H       297 TYR319      0.0000 DICT
+   4725 HD1        11.4960    8.5750   25.4420 H       297 TYR319      0.0000 DICT
+   4726 HD2        14.8280   10.8590   26.2620 H       297 TYR319      0.0000 DICT
+   4727 HE1        11.1850    8.1940   27.7680 H       297 TYR319      0.0000 DICT
+   4728 HE2        14.5150   10.4860   28.5910 H       297 TYR319      0.0000 DICT
+   4729 HH         13.2820    9.4840   30.3710 H       297 TYR319      0.0000 DICT|ESSENTIAL
+   4730 N          13.9460   13.1390   23.9360 N.am    298 GLN320      0.0000 BACKBONE|DICT|DIRECT
+   4731 CA         14.2860   14.3870   24.6130 C.3     298 GLN320      0.0000 BACKBONE|DICT|DIRECT
+   4732 C          13.2340   15.4620   24.3670 C.2     298 GLN320      0.0000 BACKBONE|DICT|DIRECT
+   4733 O          12.9490   16.2730   25.2550 O.2     298 GLN320      0.0000 BACKBONE|DICT|DIRECT
+   4734 CB         15.6580   14.8810   24.1550 C.3     298 GLN320      0.0000 DICT
+   4735 CG         16.8310   14.1240   24.7380 C.3     298 GLN320      0.0000 DICT
+   4736 CD         18.1600   14.6990   24.2940 C.2     298 GLN320      0.0000 DICT
+   4737 OE1        18.4390   14.8060   23.0980 O.2     298 GLN320      0.0000 DICT
+   4738 NE2        18.9850   15.0820   25.2580 N.am    298 GLN320      0.0000 DICT
+   4739 H          14.5300   12.8000   23.1980 H       298 GLN320      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4740 HA         14.3290   14.2090   25.5960 H       298 GLN320      0.0000 BACKBONE|DICT|DIRECT
+   4741 HB2        15.7460   15.8420   24.4170 H       298 GLN320      0.0000 DICT
+   4742 HB3        15.7010   14.8020   23.1590 H       298 GLN320      0.0000 DICT
+   4743 HG2        16.7780   13.1700   24.4420 H       298 GLN320      0.0000 DICT
+   4744 HG3        16.7780   14.1670   25.7360 H       298 GLN320      0.0000 DICT
+   4745 HE21       18.7180   14.9770   26.2160 H       298 GLN320      0.0000 DICT|ESSENTIAL
+   4746 HE22       19.8750   15.4760   25.0270 H       298 GLN320      0.0000 DICT|ESSENTIAL
+   4747 N          12.6520   15.4910   23.1710 N.am    299 LYS321      0.0000 BACKBONE|DICT|DIRECT
+   4748 CA         11.6450   16.4850   22.8320 C.3     299 LYS321      0.0000 BACKBONE|DICT|DIRECT
+   4749 C          10.2260   16.0100   23.1140 C.2     299 LYS321      0.0000 BACKBONE|DICT|DIRECT
+   4750 O           9.2700   16.6590   22.6770 O.2     299 LYS321      0.0000 BACKBONE|DICT|DIRECT
+   4751 CB         11.7810   16.8940   21.3650 C.3     299 LYS321      0.0000 DICT
+   4752 CG         13.2030   17.2180   20.9450 C.3     299 LYS321      0.0000 DICT
+   4753 CD         13.2480   17.6420   19.4880 C.3     299 LYS321      0.0000 DICT
+   4754 CE         14.5890   17.3120   18.8540 C.3     299 LYS321      0.0000 DICT
+   4755 NZ         14.4760   17.2120   17.3710 N.4     299 LYS321      0.0000 DICT
+   4756 H          12.9140   14.8110   22.4860 H       299 LYS321      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4757 HA         11.8140   17.2960   23.3930 H       299 LYS321      0.0000 BACKBONE|DICT|DIRECT
+   4758 HB2        11.2150   17.7040   21.2100 H       299 LYS321      0.0000 DICT
+   4759 HB3        11.4490   16.1410   20.7960 H       299 LYS321      0.0000 DICT
+   4760 HG2        13.7750   16.4070   21.0690 H       299 LYS321      0.0000 DICT
+   4761 HG3        13.5520   17.9620   21.5140 H       299 LYS321      0.0000 DICT
+   4762 HD2        13.0960   18.6290   19.4320 H       299 LYS321      0.0000 DICT
+   4763 HD3        12.5260   17.1640   18.9880 H       299 LYS321      0.0000 DICT
+   4764 HE2        14.9140   16.4380   19.2160 H       299 LYS321      0.0000 DICT
+   4765 HE3        15.2440   18.0320   19.0830 H       299 LYS321      0.0000 DICT
+   4766 HZ1        15.3710   16.9950   16.9820 H       299 LYS321      0.0000 DICT|ESSENTIAL
+   4767 HZ2        13.8260   16.4900   17.1340 H       299 LYS321      0.0000 DICT|ESSENTIAL
+   4768 HZ3        14.1550   18.0840   17.0020 H       299 LYS321      0.0000 DICT|ESSENTIAL
+   4769 N          10.0670   14.8980   23.8300 N.am    300 GLY322      0.0000 BACKBONE|DICT|DIRECT
+   4770 CA          8.7560   14.4520   24.2570 C.3     300 GLY322      0.0000 BACKBONE|DICT|DIRECT
+   4771 C           7.9720   13.6500   23.2450 C.2     300 GLY322      0.0000 BACKBONE|DICT|DIRECT
+   4772 O           6.7970   13.3580   23.4920 O.2     300 GLY322      0.0000 BACKBONE|DICT|DIRECT
+   4773 H          10.8710   14.3580   24.0790 H       300 GLY322      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4774 HA2         8.2180   15.2620   24.4900 H       300 GLY322      0.0000 BACKBONE|DICT|DIRECT
+   4775 HA3         8.8750   13.8850   25.0720 H       300 GLY322      0.0000 DICT
+   4776 N           8.5720   13.2840   22.1190 N.am    301 GLN323      0.0000 BACKBONE|DICT|DIRECT
+   4777 CA          7.8690   12.4910   21.1250 C.3     301 GLN323      0.0000 BACKBONE|DICT|DIRECT
+   4778 C           7.9050   11.0160   21.4970 C.2     301 GLN323      0.0000 BACKBONE|DICT|DIRECT
+   4779 O           8.8120   10.5470   22.1900 O.2     301 GLN323      0.0000 BACKBONE|DICT|DIRECT
+   4780 CB          8.4850   12.6900   19.7410 C.3     301 GLN323      0.0000 DICT
+   4781 CG          8.6440   14.1420   19.3390 C.3     301 GLN323      0.0000 DICT
+   4782 CD          9.4030   14.2990   18.0380 C.2     301 GLN323      0.0000 DICT
+   4783 OE1         9.6140   13.3290   17.3100 O.2     301 GLN323      0.0000 DICT
+   4784 NE2         9.8230   15.5230   17.7400 N.am    301 GLN323      0.0000 DICT
+   4785 H           9.5190   13.5570   21.9530 H       301 GLN323      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4786 HA          6.9150   12.7890   21.0950 H       301 GLN323      0.0000 BACKBONE|DICT|DIRECT
+   4787 HB2         7.8980   12.2400   19.0680 H       301 GLN323      0.0000 DICT
+   4788 HB3         9.3880   12.2610   19.7350 H       301 GLN323      0.0000 DICT
+   4789 HG2         9.1410   14.6230   20.0610 H       301 GLN323      0.0000 DICT
+   4790 HG3         7.7360   14.5470   19.2320 H       301 GLN323      0.0000 DICT
+   4791 HE21        9.6290   16.2830   18.3600 H       301 GLN323      0.0000 DICT|ESSENTIAL
+   4792 HE22       10.3330   15.6850   16.8950 H       301 GLN323      0.0000 DICT|ESSENTIAL
+   4793 N           6.8970   10.2860   21.0310 N.am    302 GLU324      0.0000 BACKBONE|DICT|DIRECT
+   4794 CA          6.8480    8.8470   21.2370 C.3     302 GLU324      0.0000 BACKBONE|DICT|DIRECT
+   4795 C           7.9600    8.1660   20.4480 C.2     302 GLU324      0.0000 BACKBONE|DICT|DIRECT
+   4796 O           8.2480    8.5350   19.3070 O.2     302 GLU324      0.0000 BACKBONE|DICT|DIRECT
+   4797 CB          5.4820    8.3110   20.8060 C.3     302 GLU324      0.0000 DICT
+   4798 CG          5.2010    6.8700   21.1820 C.3     302 GLU324      0.0000 DICT
+   4799 CD          3.8510    6.3990   20.6600 C.2     302 GLU324      0.0000 DICT
+   4800 OE1         3.5970    6.5430   19.4430 O.co2   302 GLU324      0.0000 DICT
+   4801 OE2         3.0420    5.8950   21.4690 O.co2   302 GLU324      0.0000 DICT
+   4802 H           6.1580   10.7350   20.5290 H       302 GLU324      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4803 HA          6.9780    8.6550   22.2100 H       302 GLU324      0.0000 BACKBONE|DICT|DIRECT
+   4804 HB2         5.4200    8.3880   19.8110 H       302 GLU324      0.0000 DICT
+   4805 HB3         4.7790    8.8830   21.2290 H       302 GLU324      0.0000 DICT
+   4806 HG2         5.2080    6.7890   22.1790 H       302 GLU324      0.0000 DICT
+   4807 HG3         5.9170    6.2900   20.7950 H       302 GLU324      0.0000 DICT
+   4808 N           8.6030    7.1780   21.0660 N.am    303 THR325      0.0000 BACKBONE|DICT|DIRECT
+   4809 CA          9.6410    6.4030   20.4050 C.3     303 THR325      0.0000 BACKBONE|DICT|DIRECT
+   4810 C           9.2100    4.9460   20.3030 C.2     303 THR325      0.0000 BACKBONE|DICT|DIRECT
+   4811 O           8.3740    4.4640   21.0730 O.2     303 THR325      0.0000 BACKBONE|DICT|DIRECT
+   4812 CB         10.9890    6.4910   21.1410 C.3     303 THR325      0.0000 DICT
+   4813 OG1        10.8940    5.8300   22.4100 O.3     303 THR325      0.0000 DICT
+   4814 CG2        11.3930    7.9400   21.3560 C.3     303 THR325      0.0000 DICT
+   4815 H           8.3650    6.9620   22.0130 H       303 THR325      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4816 HA          9.7620    6.7620   19.4800 H       303 THR325      0.0000 BACKBONE|DICT|DIRECT
+   4817 HB         11.6900    6.0370   20.5900 H       303 THR325      0.0000 DICT
+   4818 HG1        10.6570    4.8690   22.2680 H       303 THR325      0.0000 DICT|ESSENTIAL
+   4819 HG21       12.2700    7.9740   21.8350 H       303 THR325      0.0000 DICT
+   4820 HG22       11.4790    8.3970   20.4710 H       303 THR325      0.0000 DICT
+   4821 HG23       10.6960    8.4030   21.9040 H       303 THR325      0.0000 DICT
+   4822 N           9.7940    4.2470   19.3280 N.am    304 SER326      0.0000 BACKBONE|DICT|DIRECT
+   4823 CA          9.5580    2.8160   19.1260 C.3     304 SER326      0.0000 BACKBONE|DICT|DIRECT
+   4824 C          10.9130    2.1910   18.7950 C.2     304 SER326      0.0000 BACKBONE|DICT|DIRECT
+   4825 O          11.2690    2.0320   17.6240 O.2     304 SER326      0.0000 BACKBONE|DICT|DIRECT
+   4826 CB          8.5270    2.5710   18.0330 C.3     304 SER326      0.0000 DICT
+   4827 OG          8.1720    1.2010   17.9680 O.3     304 SER326      0.0000 DICT
+   4828 H          10.4200    4.7210   18.7080 H       304 SER326      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4829 HA          9.2210    2.4210   19.9810 H       304 SER326      0.0000 BACKBONE|DICT|DIRECT
+   4830 HB2         8.9100    2.8520   17.1530 H       304 SER326      0.0000 DICT
+   4831 HB3         7.7090    3.1120   18.2280 H       304 SER326      0.0000 DICT
+   4832 HG          7.3950    1.0290   18.5730 H       304 SER326      0.0000 DICT|ESSENTIAL
+   4833 N          11.6660    1.8410   19.8340 N.am    305 THR327      0.0000 BACKBONE|DICT|DIRECT
+   4834 CA         13.0350    1.3660   19.6910 C.3     305 THR327      0.0000 BACKBONE|DICT|DIRECT
+   4835 C          13.0920   -0.1260   19.9800 C.2     305 THR327      0.0000 BACKBONE|DICT|DIRECT
+   4836 O          12.5550   -0.5900   20.9900 O.2     305 THR327      0.0000 BACKBONE|DICT|DIRECT
+   4837 CB         13.9820    2.1210   20.6250 C.3     305 THR327      0.0000 DICT
+   4838 OG1        13.7870    3.5290   20.4610 O.3     305 THR327      0.0000 DICT
+   4839 CG2        15.4340    1.7790   20.3030 C.3     305 THR327      0.0000 DICT
+   4840 H          11.2750    1.9070   20.7520 H       305 THR327      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4841 HA         13.3290    1.5190   18.7470 H       305 THR327      0.0000 BACKBONE|DICT|DIRECT
+   4842 HB         13.7840    1.8680   21.5720 H       305 THR327      0.0000 DICT
+   4843 HG1        12.8410    3.7630   20.6840 H       305 THR327      0.0000 DICT|ESSENTIAL
+   4844 HG21       16.0390    2.2800   20.9210 H       305 THR327      0.0000 DICT
+   4845 HG22       15.5780    0.7960   20.4190 H       305 THR327      0.0000 DICT
+   4846 HG23       15.6350    2.0370   19.3580 H       305 THR327      0.0000 DICT
+   4847 N          13.7540   -0.8630   19.1000 N.am    306 ASN328      0.0000 BACKBONE|DICT|DIRECT
+   4848 CA         13.8060   -2.3120   19.2080 C.3     306 ASN328      0.0000 BACKBONE|DICT|DIRECT
+   4849 C          14.7810   -2.7210   20.3090 C.2     306 ASN328      0.0000 BACKBONE|DICT|DIRECT
+   4850 O          15.9670   -2.3840   20.2260 O.2     306 ASN328      0.0000 BACKBONE|DICT|DIRECT
+   4851 CB         14.2260   -2.9160   17.8740 C.3     306 ASN328      0.0000 DICT
+   4852 CG         14.0010   -4.4090   17.8160 C.2     306 ASN328      0.0000 DICT
+   4853 OD1        13.9010   -5.0720   18.8480 O.2     306 ASN328      0.0000 DICT
+   4854 ND2        13.9240   -4.9500   16.6040 N.am    306 ASN328      0.0000 DICT
+   4855 H          14.2290   -0.4120   18.3440 H       306 ASN328      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4856 HA         12.8950   -2.6510   19.4420 H       306 ASN328      0.0000 BACKBONE|DICT|DIRECT
+   4857 HB2        15.1990   -2.7330   17.7320 H       306 ASN328      0.0000 DICT
+   4858 HB3        13.6950   -2.4830   17.1450 H       306 ASN328      0.0000 DICT
+   4859 HD21       14.0110   -4.3730   15.7920 H       306 ASN328      0.0000 DICT|ESSENTIAL
+   4860 HD22       13.7790   -5.9340   16.5040 H       306 ASN328      0.0000 DICT|ESSENTIAL
+   4861 N          14.3340   -3.4420   21.3350 N.am    307 PRO329      0.0000 BACKBONE|DICT|DIRECT
+   4862 CA         15.2380   -3.8890   22.4110 C.3     307 PRO329      0.0000 BACKBONE|DICT|DIRECT
+   4863 C          15.7920   -5.2990   22.2500 C.2     307 PRO329      0.0000 BACKBONE|DICT|DIRECT
+   4864 O          16.4810   -5.7640   23.1640 O.2     307 PRO329      0.0000 BACKBONE|DICT|DIRECT
+   4865 CB         14.3090   -3.8340   23.6270 C.3     307 PRO329      0.0000 DICT
+   4866 CG         13.0160   -4.3150   23.0680 C.3     307 PRO329      0.0000 DICT
+   4867 CD         12.9310   -3.7600   21.6540 C.3     307 PRO329      0.0000 DICT
+   4868 HA         15.9880   -3.2370   22.5220 H       307 PRO329      0.0000 BACKBONE|DICT|DIRECT
+   4869 HB2        14.6330   -4.4360   24.3570 H       307 PRO329      0.0000 DICT
+   4870 HB3        14.2270   -2.9010   23.9770 H       307 PRO329      0.0000 DICT
+   4871 HG2        12.9970   -5.3150   23.0500 H       307 PRO329      0.0000 DICT
+   4872 HG3        12.2530   -3.9770   23.6190 H       307 PRO329      0.0000 DICT
+   4873 HD2        12.5650   -4.4430   21.0220 H       307 PRO329      0.0000 DICT
+   4874 HD3        12.3610   -2.9390   21.6240 H       307 PRO329      0.0000 DICT
+   4875 N          15.5010   -5.9800   21.1390 N.am    308 ILE330      0.0000 BACKBONE|DICT|DIRECT
+   4876 CA         15.7950   -7.4070   21.0320 C.3     308 ILE330      0.0000 BACKBONE|DICT|DIRECT
+   4877 C          17.2950   -7.6580   21.1300 C.2     308 ILE330      0.0000 BACKBONE|DICT|DIRECT
+   4878 O          17.7480   -8.5320   21.8800 O.2     308 ILE330      0.0000 BACKBONE|DICT|DIRECT
+   4879 CB         15.2100   -7.9780   19.7280 C.3     308 ILE330      0.0000 DICT
+   4880 CG1        13.6810   -8.0180   19.8040 C.3     308 ILE330      0.0000 DICT
+   4881 CG2        15.7860   -9.3590   19.4440 C.3     308 ILE330      0.0000 DICT
+   4882 CD1        13.1380   -8.7120   21.0390 C.3     308 ILE330      0.0000 DICT
+   4883 H          15.0750   -5.5060   20.3680 H       308 ILE330      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4884 HA         15.3530   -7.8720   21.7990 H       308 ILE330      0.0000 BACKBONE|DICT|DIRECT
+   4885 HB         15.4700   -7.3710   18.9770 H       308 ILE330      0.0000 DICT
+   4886 HG12       13.3390   -8.5000   18.9970 H       308 ILE330      0.0000 DICT
+   4887 HG13       13.3420   -7.0770   19.7980 H       308 ILE330      0.0000 DICT
+   4888 HG21       15.3960   -9.7150   18.5950 H       308 ILE330      0.0000 DICT
+   4889 HG22       16.7800   -9.2930   19.3530 H       308 ILE330      0.0000 DICT
+   4890 HG23       15.5610   -9.9760   20.1980 H       308 ILE330      0.0000 DICT
+   4891 HD11       12.1380   -8.6980   21.0170 H       308 ILE330      0.0000 DICT
+   4892 HD12       13.4580   -9.6590   21.0570 H       308 ILE330      0.0000 DICT
+   4893 HD13       13.4600   -8.2360   21.8570 H       308 ILE330      0.0000 DICT
+   4894 N          18.0890   -6.8960   20.3730 N.am    309 ALA331      0.0000 BACKBONE|DICT|DIRECT
+   4895 CA         19.5300   -7.1170   20.3800 C.3     309 ALA331      0.0000 BACKBONE|DICT|DIRECT
+   4896 C          20.1250   -6.8710   21.7590 C.2     309 ALA331      0.0000 BACKBONE|DICT|DIRECT
+   4897 O          21.0530   -7.5770   22.1690 O.2     309 ALA331      0.0000 BACKBONE|DICT|DIRECT
+   4898 CB         20.2040   -6.2340   19.3320 C.3     309 ALA331      0.0000 DICT
+   4899 H          17.6960   -6.1750   19.8020 H       309 ALA331      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4900 HA         19.6980   -8.0720   20.1360 H       309 ALA331      0.0000 BACKBONE|DICT|DIRECT
+   4901 HB1        21.1910   -6.3940   19.3460 H       309 ALA331      0.0000 DICT
+   4902 HB2        19.8430   -6.4570   18.4260 H       309 ALA331      0.0000 DICT
+   4903 HB3        20.0190   -5.2730   19.5370 H       309 ALA331      0.0000 DICT
+   4904 N          19.5920   -5.8940   22.4980 N.am    310 SER332      0.0000 BACKBONE|DICT|DIRECT
+   4905 CA         20.0670   -5.6550   23.8580 C.3     310 SER332      0.0000 BACKBONE|DICT|DIRECT
+   4906 C          19.6320   -6.7710   24.7980 C.2     310 SER332      0.0000 BACKBONE|DICT|DIRECT
+   4907 O          20.3940   -7.1760   25.6860 O.2     310 SER332      0.0000 BACKBONE|DICT|DIRECT
+   4908 CB         19.5590   -4.3040   24.3640 C.3     310 SER332      0.0000 DICT
+   4909 OG         19.9800   -3.2560   23.5140 O.3     310 SER332      0.0000 DICT
+   4910 H          18.8640   -5.3230   22.1180 H       310 SER332      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4911 HA         21.0670   -5.6290   23.8420 H       310 SER332      0.0000 BACKBONE|DICT|DIRECT
+   4912 HB2        19.9170   -4.1430   25.2840 H       310 SER332      0.0000 DICT
+   4913 HB3        18.5600   -4.3200   24.3930 H       310 SER332      0.0000 DICT
+   4914 HG         19.6220   -3.4100   22.5930 H       310 SER332      0.0000 DICT|ESSENTIAL
+   4915 N          18.4050   -7.2710   24.6270 N.am    311 ILE333      0.0000 BACKBONE|DICT|DIRECT
+   4916 CA         17.9310   -8.3770   25.4560 C.3     311 ILE333      0.0000 BACKBONE|DICT|DIRECT
+   4917 C          18.8080   -9.6060   25.2500 C.2     311 ILE333      0.0000 BACKBONE|DICT|DIRECT
+   4918 O          19.2610  -10.2370   26.2130 O.2     311 ILE333      0.0000 BACKBONE|DICT|DIRECT
+   4919 CB         16.4520   -8.6780   25.1540 C.3     311 ILE333      0.0000 DICT
+   4920 CG1        15.5610   -7.5820   25.7410 C.3     311 ILE333      0.0000 DICT
+   4921 CG2        16.0580  -10.0410   25.7010 C.3     311 ILE333      0.0000 DICT
+   4922 CD1        14.2470   -7.4260   25.0280 C.3     311 ILE333      0.0000 DICT
+   4923 H          17.8060   -6.8850   23.9260 H       311 ILE333      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4924 HA         18.0030   -8.1010   26.4140 H       311 ILE333      0.0000 BACKBONE|DICT|DIRECT
+   4925 HB         16.3280   -8.6880   24.1620 H       311 ILE333      0.0000 DICT
+   4926 HG12       16.0530   -6.7130   25.6890 H       311 ILE333      0.0000 DICT
+   4927 HG13       15.3760   -7.8040   26.6980 H       311 ILE333      0.0000 DICT
+   4928 HG21       15.0950  -10.2170   25.4950 H       311 ILE333      0.0000 DICT
+   4929 HG22       16.6250  -10.7470   25.2760 H       311 ILE333      0.0000 DICT
+   4930 HG23       16.1950  -10.0550   26.6920 H       311 ILE333      0.0000 DICT
+   4931 HD11       13.7170   -6.6970   25.4610 H       311 ILE333      0.0000 DICT
+   4932 HD12       14.4130   -7.1930   24.0700 H       311 ILE333      0.0000 DICT
+   4933 HD13       13.7360   -8.2840   25.0790 H       311 ILE333      0.0000 DICT
+   4934 N          19.0790   -9.9540   23.9880 N.am    312 PHE334      0.0000 BACKBONE|DICT|DIRECT
+   4935 CA         19.8960  -11.1290   23.7150 C.3     312 PHE334      0.0000 BACKBONE|DICT|DIRECT
+   4936 C          21.3260  -10.9680   24.2120 C.2     312 PHE334      0.0000 BACKBONE|DICT|DIRECT
+   4937 O          21.9940  -11.9750   24.4670 O.2     312 PHE334      0.0000 BACKBONE|DICT|DIRECT
+   4938 CB         19.8780  -11.4560   22.2220 C.3     312 PHE334      0.0000 DICT
+   4939 CG         18.7210  -12.3290   21.8090 C.ar    312 PHE334      0.0000 DICT
+   4940 CD1        17.4190  -11.8540   21.8700 C.ar    312 PHE334      0.0000 DICT
+   4941 CD2        18.9360  -13.6250   21.3640 C.ar    312 PHE334      0.0000 DICT
+   4942 CE1        16.3520  -12.6550   21.4920 C.ar    312 PHE334      0.0000 DICT
+   4943 CE2        17.8750  -14.4290   20.9830 C.ar    312 PHE334      0.0000 DICT
+   4944 CZ         16.5800  -13.9430   21.0490 C.ar    312 PHE334      0.0000 DICT
+   4945 H          18.7210   -9.4080   23.2310 H       312 PHE334      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4946 HA         19.4900  -11.9020   24.2010 H       312 PHE334      0.0000 BACKBONE|DICT|DIRECT
+   4947 HB2        20.7290  -11.9290   21.9920 H       312 PHE334      0.0000 DICT
+   4948 HB3        19.8250  -10.5980   21.7110 H       312 PHE334      0.0000 DICT
+   4949 HD1        17.2480  -10.9220   22.1910 H       312 PHE334      0.0000 DICT
+   4950 HD2        19.8690  -13.9830   21.3180 H       312 PHE334      0.0000 DICT
+   4951 HE1        15.4180  -12.3000   21.5400 H       312 PHE334      0.0000 DICT
+   4952 HE2        18.0440  -15.3600   20.6600 H       312 PHE334      0.0000 DICT
+   4953 HZ         15.8120  -14.5230   20.7770 H       312 PHE334      0.0000 DICT
+   4954 N          21.8090   -9.7340   24.3680 N.am    313 ALA335      0.0000 BACKBONE|DICT|DIRECT
+   4955 CA         23.0920   -9.5400   25.0310 C.3     313 ALA335      0.0000 BACKBONE|DICT|DIRECT
+   4956 C          23.0440  -10.0580   26.4640 C.2     313 ALA335      0.0000 BACKBONE|DICT|DIRECT
+   4957 O          23.9960  -10.6910   26.9370 O.2     313 ALA335      0.0000 BACKBONE|DICT|DIRECT
+   4958 CB         23.4850   -8.0620   24.9990 C.3     313 ALA335      0.0000 DICT
+   4959 H          21.2930   -8.9460   24.0320 H       313 ALA335      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4960 HA         23.7850  -10.0600   24.5320 H       313 ALA335      0.0000 BACKBONE|DICT|DIRECT
+   4961 HB1        24.3660   -7.9410   25.4560 H       313 ALA335      0.0000 DICT
+   4962 HB2        23.5580   -7.7570   24.0490 H       313 ALA335      0.0000 DICT
+   4963 HB3        22.7880   -7.5210   25.4700 H       313 ALA335      0.0000 DICT
+   4964 N          21.9320   -9.8120   27.1650 N.am    314 TRP336      0.0000 BACKBONE|DICT|DIRECT
+   4965 CA         21.7750  -10.3310   28.5210 C.3     314 TRP336      0.0000 BACKBONE|DICT|DIRECT
+   4966 C          21.6440  -11.8520   28.5210 C.2     314 TRP336      0.0000 BACKBONE|DICT|DIRECT
+   4967 O          22.2970  -12.5390   29.3150 O.2     314 TRP336      0.0000 BACKBONE|DICT|DIRECT
+   4968 CB         20.5620   -9.6860   29.2000 C.3     314 TRP336      0.0000 DICT
+   4969 CG         20.8430   -8.3280   29.7790 C.2     314 TRP336      0.0000 DICT
+   4970 CD1        20.7020   -7.1200   29.1510 C.2     314 TRP336      0.0000 DICT
+   4971 CD2        21.3220   -8.0410   31.1000 C.ar    314 TRP336      0.0000 DICT
+   4972 NE1        21.0640   -6.1020   30.0020 N.pl3   314 TRP336      0.0000 DICT
+   4973 CE2        21.4490   -6.6410   31.2030 C.ar    314 TRP336      0.0000 DICT
+   4974 CE3        21.6590   -8.8320   32.2030 C.ar    314 TRP336      0.0000 DICT
+   4975 CZ2        21.8960   -6.0160   32.3650 C.ar    314 TRP336      0.0000 DICT
+   4976 CZ3        22.1020   -8.2080   33.3580 C.ar    314 TRP336      0.0000 DICT
+   4977 CH2        22.2150   -6.8140   33.4300 C.ar    314 TRP336      0.0000 DICT
+   4978 H          21.2000   -9.2670   26.7560 H       314 TRP336      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4979 HA         22.5920  -10.0880   29.0450 H       314 TRP336      0.0000 BACKBONE|DICT|DIRECT
+   4980 HB2        20.2570  -10.2870   29.9390 H       314 TRP336      0.0000 DICT
+   4981 HB3        19.8320   -9.5950   28.5220 H       314 TRP336      0.0000 DICT
+   4982 HD1        20.3830   -6.9960   28.2120 H       314 TRP336      0.0000 DICT
+   4983 HE1        21.0490   -5.1270   29.7810 H       314 TRP336      0.0000 DICT|ESSENTIAL
+   4984 HE3        21.5820   -9.8280   32.1590 H       314 TRP336      0.0000 DICT
+   4985 HZ2        21.9810   -5.0210   32.4190 H       314 TRP336      0.0000 DICT
+   4986 HZ3        22.3450   -8.7630   34.1540 H       314 TRP336      0.0000 DICT
+   4987 HH2        22.5360   -6.3920   34.2780 H       314 TRP336      0.0000 DICT
+   4988 N          20.8080  -12.3970   27.6300 N.am    315 THR337      0.0000 BACKBONE|DICT|DIRECT
+   4989 CA         20.5600  -13.8370   27.6410 C.3     315 THR337      0.0000 BACKBONE|DICT|DIRECT
+   4990 C          21.8170  -14.6260   27.2930 C.2     315 THR337      0.0000 BACKBONE|DICT|DIRECT
+   4991 O          22.1040  -15.6500   27.9260 O.2     315 THR337      0.0000 BACKBONE|DICT|DIRECT
+   4992 CB         19.4280  -14.1980   26.6780 C.3     315 THR337      0.0000 DICT
+   4993 OG1        19.7690  -13.7710   25.3550 O.3     315 THR337      0.0000 DICT
+   4994 CG2        18.1250  -13.5410   27.1020 C.3     315 THR337      0.0000 DICT
+   4995 H          20.3520  -11.8170   26.9550 H       315 THR337      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   4996 HA         20.2770  -14.0960   28.5640 H       315 THR337      0.0000 BACKBONE|DICT|DIRECT
+   4997 HB         19.3060  -15.1910   26.6780 H       315 THR337      0.0000 DICT
+   4998 HG1        19.7900  -14.5630   24.7440 H       315 THR337      0.0000 DICT|ESSENTIAL
+   4999 HG21       17.4010  -13.7910   26.4590 H       315 THR337      0.0000 DICT
+   5000 HG22       17.8780  -13.8520   28.0200 H       315 THR337      0.0000 DICT
+   5001 HG23       18.2390  -12.5470   27.1060 H       315 THR337      0.0000 DICT
+   5002 N          22.5760  -14.1780   26.2890 N.am    316 ARG338      0.0000 BACKBONE|DICT|DIRECT
+   5003 CA         23.8380  -14.8440   25.9750 C.3     316 ARG338      0.0000 BACKBONE|DICT|DIRECT
+   5004 C          24.7870  -14.7890   27.1640 C.2     316 ARG338      0.0000 BACKBONE|DICT|DIRECT
+   5005 O          25.4180  -15.7920   27.5160 O.2     316 ARG338      0.0000 BACKBONE|DICT|DIRECT
+   5006 CB         24.4910  -14.2140   24.7440 C.3     316 ARG338      0.0000 DICT
+   5007 CG         24.1320  -14.8860   23.4330 C.3     316 ARG338      0.0000 DICT
+   5008 CD         22.7080  -14.5820   23.0340 C.3     316 ARG338      0.0000 DICT
+   5009 NE         22.2720  -15.3650   21.8840 N.pl3   316 ARG338      0.0000 DICT
+   5010 CZ         22.5340  -15.0480   20.6210 C.cat   316 ARG338      0.0000 DICT
+   5011 NH1        23.2450  -13.9640   20.3390 N.pl3   316 ARG338      0.0000 DICT
+   5012 NH2        22.0890  -15.8210   19.6410 N.pl3   316 ARG338      0.0000 DICT
+   5013 H          22.2810  -13.3870   25.7530 H       316 ARG338      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5014 HA         23.6450  -15.8040   25.7720 H       316 ARG338      0.0000 BACKBONE|DICT|DIRECT
+   5015 HB2        25.4830  -14.2600   24.8580 H       316 ARG338      0.0000 DICT
+   5016 HB3        24.2060  -13.2570   24.6940 H       316 ARG338      0.0000 DICT
+   5017 HG2        24.2380  -15.8750   23.5340 H       316 ARG338      0.0000 DICT
+   5018 HG3        24.7480  -14.5560   22.7180 H       316 ARG338      0.0000 DICT
+   5019 HD2        22.6390  -13.6110   22.8060 H       316 ARG338      0.0000 DICT
+   5020 HD3        22.1080  -14.7860   23.8070 H       316 ARG338      0.0000 DICT
+   5021 HE         21.7410  -16.1950   22.0570 H       316 ARG338      0.0000 DICT|ESSENTIAL
+   5022 HH11       23.4410  -13.7280   19.3870 H       316 ARG338      0.0000 DICT|ESSENTIAL
+   5023 HH12       23.5850  -13.3830   21.0780 H       316 ARG338      0.0000 DICT|ESSENTIAL
+   5024 HH21       22.2850  -15.5840   18.6890 H       316 ARG338      0.0000 DICT|ESSENTIAL
+   5025 HH22       21.5570  -16.6410   19.8530 H       316 ARG338      0.0000 DICT|ESSENTIAL
+   5026 N          24.8970  -13.6200   27.7980 N.am    317 GLY339      0.0000 BACKBONE|DICT|DIRECT
+   5027 CA         25.7390  -13.5100   28.9760 C.3     317 GLY339      0.0000 BACKBONE|DICT|DIRECT
+   5028 C          25.2580  -14.3860   30.1170 C.2     317 GLY339      0.0000 BACKBONE|DICT|DIRECT
+   5029 O          26.0570  -15.0450   30.7860 O.2     317 GLY339      0.0000 BACKBONE|DICT|DIRECT
+   5030 H          24.4000  -12.8200   27.4620 H       317 GLY339      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5031 HA2        25.7410  -12.5580   29.2810 H       317 GLY339      0.0000 BACKBONE|DICT|DIRECT
+   5032 HA3        26.6690  -13.7830   28.7320 H       317 GLY339      0.0000 DICT
+   5033 N          23.9440  -14.4100   30.3510 N.am    318 LEU340      0.0000 BACKBONE|DICT|DIRECT
+   5034 CA         23.4020  -15.2490   31.4150 C.3     318 LEU340      0.0000 BACKBONE|DICT|DIRECT
+   5035 C          23.5310  -16.7290   31.0690 C.2     318 LEU340      0.0000 BACKBONE|DICT|DIRECT
+   5036 O          23.7940  -17.5550   31.9510 O.2     318 LEU340      0.0000 BACKBONE|DICT|DIRECT
+   5037 CB         21.9440  -14.8770   31.6870 C.3     318 LEU340      0.0000 DICT
+   5038 CG         21.7220  -13.5210   32.3620 C.3     318 LEU340      0.0000 DICT
+   5039 CD1        20.2370  -13.2190   32.5320 C.3     318 LEU340      0.0000 DICT
+   5040 CD2        22.4380  -13.4740   33.7010 C.3     318 LEU340      0.0000 DICT
+   5041 H          23.3290  -13.8510   29.7950 H       318 LEU340      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5042 HA         23.9290  -15.0760   32.2470 H       318 LEU340      0.0000 BACKBONE|DICT|DIRECT
+   5043 HB2        21.5520  -15.5820   32.2770 H       318 LEU340      0.0000 DICT
+   5044 HB3        21.4600  -14.8680   30.8120 H       318 LEU340      0.0000 DICT
+   5045 HG         22.1170  -12.8140   31.7750 H       318 LEU340      0.0000 DICT
+   5046 HD11       20.1260  -12.3290   32.9750 H       318 LEU340      0.0000 DICT
+   5047 HD12       19.7950  -13.2020   31.6350 H       318 LEU340      0.0000 DICT
+   5048 HD13       19.8150  -13.9270   33.0980 H       318 LEU340      0.0000 DICT
+   5049 HD21       22.2850  -12.5840   34.1300 H       318 LEU340      0.0000 DICT
+   5050 HD22       22.0820  -14.1960   34.2950 H       318 LEU340      0.0000 DICT
+   5051 HD23       23.4180  -13.6110   33.5600 H       318 LEU340      0.0000 DICT
+   5052 N          23.3610  -17.0810   29.7920 N.am    319 ALA341      0.0000 BACKBONE|DICT|DIRECT
+   5053 CA         23.5270  -18.4720   29.3810 C.3     319 ALA341      0.0000 BACKBONE|DICT|DIRECT
+   5054 C          24.9560  -18.9460   29.6100 C.2     319 ALA341      0.0000 BACKBONE|DICT|DIRECT
+   5055 O          25.1780  -20.0450   30.1310 O.2     319 ALA341      0.0000 BACKBONE|DICT|DIRECT
+   5056 CB         23.1350  -18.6410   27.9140 C.3     319 ALA341      0.0000 DICT
+   5057 H          23.1190  -16.3880   29.1130 H       319 ALA341      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5058 HA         22.9170  -19.0380   29.9360 H       319 ALA341      0.0000 BACKBONE|DICT|DIRECT
+   5059 HB1        23.2530  -19.5970   27.6450 H       319 ALA341      0.0000 DICT
+   5060 HB2        22.1780  -18.3760   27.7920 H       319 ALA341      0.0000 DICT
+   5061 HB3        23.7170  -18.0600   27.3440 H       319 ALA341      0.0000 DICT
+   5062 N          25.9400  -18.1310   29.2300 N.am    320 HIS342      0.0000 BACKBONE|DICT|DIRECT
+   5063 CA         27.3300  -18.4960   29.4790 C.3     320 HIS342      0.0000 BACKBONE|DICT|DIRECT
+   5064 C          27.6300  -18.5290   30.9710 C.2     320 HIS342      0.0000 BACKBONE|DICT|DIRECT
+   5065 O          28.3770  -19.3960   31.4390 O.2     320 HIS342      0.0000 BACKBONE|DICT|DIRECT
+   5066 CB         28.2700  -17.5240   28.7680 C.3     320 HIS342      0.0000 DICT
+   5067 CG         29.7130  -17.9040   28.8730 C.2     320 HIS342      0.0000 DICT
+   5068 ND1        30.2900  -18.8610   28.0670 N.2     320 HIS342      0.0000 DICT
+   5069 CD2        30.6920  -17.4670   29.7000 C.2     320 HIS342      0.0000 DICT
+   5070 CE1        31.5650  -18.9920   28.3870 C.2     320 HIS342      0.0000 DICT
+   5071 NE2        31.8350  -18.1550   29.3740 N.pl3   320 HIS342      0.0000 DICT
+   5072 H          25.7250  -17.2680   28.7730 H       320 HIS342      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5073 HA         27.4850  -19.4110   29.1070 H       320 HIS342      0.0000 BACKBONE|DICT|DIRECT
+   5074 HB2        28.1520  -16.6170   29.1720 H       320 HIS342      0.0000 DICT
+   5075 HB3        28.0200  -17.4930   27.8000 H       320 HIS342      0.0000 DICT
+   5076 HD2        30.6000  -16.7730   30.4140 H       320 HIS342      0.0000 DICT
+   5077 HE1        32.2150  -19.6180   27.9560 H       320 HIS342      0.0000 DICT
+   5078 HE2        32.7270  -18.0410   29.8120 H       320 HIS342      0.0000 DICT|ESSENTIAL
+   5079 N          27.0650  -17.5860   31.7290 N.am    321 ARG343      0.0000 BACKBONE|DICT|DIRECT
+   5080 CA         27.2110  -17.6060   33.1800 C.3     321 ARG343      0.0000 BACKBONE|DICT|DIRECT
+   5081 C          26.6820  -18.9100   33.7600 C.2     321 ARG343      0.0000 BACKBONE|DICT|DIRECT
+   5082 O          27.3230  -19.5300   34.6160 O.2     321 ARG343      0.0000 BACKBONE|DICT|DIRECT
+   5083 CB         26.4800  -16.4080   33.7920 C.3     321 ARG343      0.0000 DICT
+   5084 CG         26.3760  -16.4260   35.3130 C.3     321 ARG343      0.0000 DICT
+   5085 CD         27.6520  -15.9450   35.9790 C.3     321 ARG343      0.0000 DICT
+   5086 NE         28.6860  -16.9740   36.0250 N.pl3   321 ARG343      0.0000 DICT
+   5087 CZ         29.9790  -16.7280   36.2110 C.cat   321 ARG343      0.0000 DICT
+   5088 NH1        30.4120  -15.4820   36.3560 N.pl3   321 ARG343      0.0000 DICT
+   5089 NH2        30.8440  -17.7310   36.2420 N.pl3   321 ARG343      0.0000 DICT
+   5090 H          26.5350  -16.8570   31.2960 H       321 ARG343      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5091 HA         28.1830  -17.5310   33.4020 H       321 ARG343      0.0000 BACKBONE|DICT|DIRECT
+   5092 HB2        25.5530  -16.3860   33.4180 H       321 ARG343      0.0000 DICT
+   5093 HB3        26.9680  -15.5770   33.5240 H       321 ARG343      0.0000 DICT
+   5094 HG2        26.1890  -17.3620   35.6120 H       321 ARG343      0.0000 DICT
+   5095 HG3        25.6230  -15.8300   35.5920 H       321 ARG343      0.0000 DICT
+   5096 HD2        27.4380  -15.6640   36.9150 H       321 ARG343      0.0000 DICT
+   5097 HD3        28.0040  -15.1610   35.4680 H       321 ARG343      0.0000 DICT
+   5098 HE         28.4030  -17.9260   35.9090 H       321 ARG343      0.0000 DICT|ESSENTIAL
+   5099 HH11       31.3860  -15.3040   36.4960 H       321 ARG343      0.0000 DICT|ESSENTIAL
+   5100 HH12       29.7640  -14.7210   36.3260 H       321 ARG343      0.0000 DICT|ESSENTIAL
+   5101 HH21       31.8170  -17.5480   36.3820 H       321 ARG343      0.0000 DICT|ESSENTIAL
+   5102 HH22       30.5240  -18.6710   36.1260 H       321 ARG343      0.0000 DICT|ESSENTIAL
+   5103 N          25.5070  -19.3420   33.2960 N.am    322 ALA344      0.0000 BACKBONE|DICT|DIRECT
+   5104 CA         24.9200  -20.5890   33.7710 C.3     322 ALA344      0.0000 BACKBONE|DICT|DIRECT
+   5105 C          25.7370  -21.7990   33.3390 C.2     322 ALA344      0.0000 BACKBONE|DICT|DIRECT
+   5106 O          25.7610  -22.8120   34.0450 O.2     322 ALA344      0.0000 BACKBONE|DICT|DIRECT
+   5107 CB         23.4820  -20.7130   33.2670 C.3     322 ALA344      0.0000 DICT
+   5108 H          25.0210  -18.8000   32.6100 H       322 ALA344      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5109 HA         24.9000  -20.5650   34.7710 H       322 ALA344      0.0000 BACKBONE|DICT|DIRECT
+   5110 HB1        23.0860  -21.5700   33.5960 H       322 ALA344      0.0000 DICT
+   5111 HB2        22.9420  -19.9440   33.6080 H       322 ALA344      0.0000 DICT
+   5112 HB3        23.4780  -20.7060   32.2670 H       322 ALA344      0.0000 DICT
+   5113 N          26.4060  -21.7170   32.1870 N.am    323 LYS345      0.0000 BACKBONE|DICT|DIRECT
+   5114 CA         27.2260  -22.8350   31.7340 C.3     323 LYS345      0.0000 BACKBONE|DICT|DIRECT
+   5115 C          28.4660  -22.9940   32.6040 C.2     323 LYS345      0.0000 BACKBONE|DICT|DIRECT
+   5116 O          28.8920  -24.1190   32.8870 O.2     323 LYS345      0.0000 BACKBONE|DICT|DIRECT
+   5117 CB         27.6210  -22.6370   30.2710 C.3     323 LYS345      0.0000 DICT
+   5118 CG         28.1900  -23.8830   29.6090 C.3     323 LYS345      0.0000 DICT
+   5119 CD         28.7160  -23.5890   28.2120 C.3     323 LYS345      0.0000 DICT
+   5120 CE         29.9910  -22.7620   28.2650 C.3     323 LYS345      0.0000 DICT
+   5121 NZ         30.5200  -22.4580   26.9040 N.4     323 LYS345      0.0000 DICT
+   5122 H          26.3450  -20.8870   31.6330 H       323 LYS345      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5123 HA         26.6830  -23.6720   31.8030 H       323 LYS345      0.0000 BACKBONE|DICT|DIRECT
+   5124 HB2        28.3110  -21.9150   30.2270 H       323 LYS345      0.0000 DICT
+   5125 HB3        26.8080  -22.3540   29.7620 H       323 LYS345      0.0000 DICT
+   5126 HG2        27.4700  -24.5740   29.5450 H       323 LYS345      0.0000 DICT
+   5127 HG3        28.9400  -24.2340   30.1700 H       323 LYS345      0.0000 DICT
+   5128 HD2        28.0200  -23.0830   27.7020 H       323 LYS345      0.0000 DICT
+   5129 HD3        28.9070  -24.4540   27.7470 H       323 LYS345      0.0000 DICT
+   5130 HE2        30.6850  -23.2710   28.7740 H       323 LYS345      0.0000 DICT
+   5131 HE3        29.7970  -21.9010   28.7350 H       323 LYS345      0.0000 DICT
+   5132 HZ1        31.3560  -21.9150   26.9850 H       323 LYS345      0.0000 DICT|ESSENTIAL
+   5133 HZ2        30.7230  -23.3130   26.4270 H       323 LYS345      0.0000 DICT|ESSENTIAL
+   5134 HZ3        29.8360  -21.9430   26.3880 H       323 LYS345      0.0000 DICT|ESSENTIAL
+   5135 N          29.0550  -21.8800   33.0420 N.am    324 LEU346      0.0000 BACKBONE|DICT|DIRECT
+   5136 CA         30.2550  -21.9560   33.8670 C.3     324 LEU346      0.0000 BACKBONE|DICT|DIRECT
+   5137 C          29.9420  -22.4400   35.2760 C.2     324 LEU346      0.0000 BACKBONE|DICT|DIRECT
+   5138 O          30.7930  -23.0670   35.9170 O.2     324 LEU346      0.0000 BACKBONE|DICT|DIRECT
+   5139 CB         30.9430  -20.5910   33.9220 C.3     324 LEU346      0.0000 DICT
+   5140 CG         31.4030  -19.9890   32.5910 C.3     324 LEU346      0.0000 DICT
+   5141 CD1        32.0850  -18.6450   32.8120 C.3     324 LEU346      0.0000 DICT
+   5142 CD2        32.3230  -20.9470   31.8540 C.3     324 LEU346      0.0000 DICT
+   5143 H          28.6710  -20.9880   32.8030 H       324 LEU346      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5144 HA         30.8850  -22.6080   33.4450 H       324 LEU346      0.0000 BACKBONE|DICT|DIRECT
+   5145 HB2        31.7500  -20.6830   34.5060 H       324 LEU346      0.0000 DICT
+   5146 HB3        30.3020  -19.9470   34.3390 H       324 LEU346      0.0000 DICT
+   5147 HG         30.5940  -19.8370   32.0230 H       324 LEU346      0.0000 DICT
+   5148 HD11       32.3770  -18.2710   31.9320 H       324 LEU346      0.0000 DICT
+   5149 HD12       31.4430  -18.0130   33.2470 H       324 LEU346      0.0000 DICT
+   5150 HD13       32.8830  -18.7690   33.4020 H       324 LEU346      0.0000 DICT
+   5151 HD21       32.6110  -20.5340   30.9900 H       324 LEU346      0.0000 DICT
+   5152 HD22       33.1270  -21.1360   32.4170 H       324 LEU346      0.0000 DICT
+   5153 HD23       31.8370  -21.8010   31.6700 H       324 LEU346      0.0000 DICT
+   5154 N          28.7400  -22.1620   35.7760 N.am    325 ASP347      0.0000 BACKBONE|DICT|DIRECT
+   5155 CA         28.3580  -22.5230   37.1330 C.3     325 ASP347      0.0000 BACKBONE|DICT|DIRECT
+   5156 C          27.5380  -23.8040   37.2030 C.2     325 ASP347      0.0000 BACKBONE|DICT|DIRECT
+   5157 O          27.1700  -24.2230   38.3050 O.2     325 ASP347      0.0000 BACKBONE|DICT|DIRECT
+   5158 CB         27.5660  -21.3790   37.7810 C.3     325 ASP347      0.0000 DICT
+   5159 CG         28.3160  -20.0610   37.7610 C.2     325 ASP347      0.0000 DICT
+   5160 OD1        29.5490  -20.0780   37.5670 O.co2   325 ASP347      0.0000 DICT
+   5161 OD2        27.6690  -19.0070   37.9420 O.co2   325 ASP347      0.0000 DICT
+   5162 H          28.0760  -21.6880   35.1980 H       325 ASP347      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5163 HA         29.1940  -22.6610   37.6640 H       325 ASP347      0.0000 BACKBONE|DICT|DIRECT
+   5164 HB2        27.3730  -21.6220   38.7310 H       325 ASP347      0.0000 DICT
+   5165 HB3        26.7050  -21.2650   37.2850 H       325 ASP347      0.0000 DICT
+   5166 N          27.2560  -24.4380   36.0640 N.am    326 ASN348      0.0000 BACKBONE|DICT|DIRECT
+   5167 CA         26.3160  -25.5570   35.9960 C.3     326 ASN348      0.0000 BACKBONE|DICT|DIRECT
+   5168 C          25.0060  -25.1840   36.6880 C.2     326 ASN348      0.0000 BACKBONE|DICT|DIRECT
+   5169 O          24.5220  -25.8700   37.5900 O.2     326 ASN348      0.0000 BACKBONE|DICT|DIRECT
+   5170 CB         26.9230  -26.8300   36.5910 C.3     326 ASN348      0.0000 DICT
+   5171 CG         26.1340  -28.0770   36.2320 C.2     326 ASN348      0.0000 DICT
+   5172 OD1        25.3470  -28.0750   35.2850 O.2     326 ASN348      0.0000 DICT
+   5173 ND2        26.3440  -29.1510   36.9860 N.am    326 ASN348      0.0000 DICT
+   5174 H          27.7050  -24.1360   35.2230 H       326 ASN348      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5175 HA         26.1160  -25.7330   35.0320 H       326 ASN348      0.0000 BACKBONE|DICT|DIRECT
+   5176 HB2        26.9440  -26.7400   37.5870 H       326 ASN348      0.0000 DICT
+   5177 HB3        27.8560  -26.9310   36.2460 H       326 ASN348      0.0000 DICT
+   5178 HD21       26.9920  -29.1090   37.7460 H       326 ASN348      0.0000 DICT|ESSENTIAL
+   5179 HD22       25.8540  -30.0010   36.7930 H       326 ASN348      0.0000 DICT|ESSENTIAL
+   5180 N          24.4400  -24.0630   36.2550 N.am    327 ASN349      0.0000 BACKBONE|DICT|DIRECT
+   5181 CA         23.2690  -23.4490   36.8760 C.3     327 ASN349      0.0000 BACKBONE|DICT|DIRECT
+   5182 C          22.0700  -23.7150   35.9720 C.2     327 ASN349      0.0000 BACKBONE|DICT|DIRECT
+   5183 O          21.8200  -22.9670   35.0240 O.2     327 ASN349      0.0000 BACKBONE|DICT|DIRECT
+   5184 CB         23.5110  -21.9550   37.0830 C.3     327 ASN349      0.0000 DICT
+   5185 CG         22.4510  -21.2990   37.9430 C.2     327 ASN349      0.0000 DICT
+   5186 OD1        21.2730  -21.6570   37.8910 O.2     327 ASN349      0.0000 DICT
+   5187 ND2        22.8670  -20.3230   38.7390 N.am    327 ASN349      0.0000 DICT
+   5188 H          24.8390  -23.6130   35.4560 H       327 ASN349      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5189 HA         23.1090  -23.8790   37.7640 H       327 ASN349      0.0000 BACKBONE|DICT|DIRECT
+   5190 HB2        23.5190  -21.5060   36.1890 H       327 ASN349      0.0000 DICT
+   5191 HB3        24.4000  -21.8340   37.5250 H       327 ASN349      0.0000 DICT
+   5192 HD21       23.8330  -20.0640   38.7500 H       327 ASN349      0.0000 DICT|ESSENTIAL
+   5193 HD22       22.2150  -19.8460   39.3280 H       327 ASN349      0.0000 DICT|ESSENTIAL
+   5194 N          21.3220  -24.7810   36.2740 N.am    328 LYS350      0.0000 BACKBONE|DICT|DIRECT
+   5195 CA         20.2480  -25.1980   35.3780 C.3     328 LYS350      0.0000 BACKBONE|DICT|DIRECT
+   5196 C          19.0660  -24.2360   35.4160 C.2     328 LYS350      0.0000 BACKBONE|DICT|DIRECT
+   5197 O          18.3560  -24.0920   34.4130 O.2     328 LYS350      0.0000 BACKBONE|DICT|DIRECT
+   5198 CB         19.8020  -26.6250   35.7140 C.3     328 LYS350      0.0000 DICT
+   5199 CG         19.1760  -26.8100   37.0920 C.3     328 LYS350      0.0000 DICT
+   5200 CD         19.0940  -28.2910   37.4620 C.3     328 LYS350      0.0000 DICT
+   5201 CE         18.1910  -28.5330   38.6690 C.3     328 LYS350      0.0000 DICT
+   5202 NZ         18.8130  -28.1040   39.9540 N.4     328 LYS350      0.0000 DICT
+   5203 H          21.4980  -25.2930   37.1150 H       328 LYS350      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5204 HA         20.6100  -25.2020   34.4460 H       328 LYS350      0.0000 BACKBONE|DICT|DIRECT
+   5205 HB2        20.6040  -27.2200   35.6580 H       328 LYS350      0.0000 DICT
+   5206 HB3        19.1290  -26.9070   35.0300 H       328 LYS350      0.0000 DICT
+   5207 HG2        18.2540  -26.4230   37.0870 H       328 LYS350      0.0000 DICT
+   5208 HG3        19.7340  -26.3340   37.7710 H       328 LYS350      0.0000 DICT
+   5209 HD2        20.0130  -28.6210   37.6760 H       328 LYS350      0.0000 DICT
+   5210 HD3        18.7310  -28.7990   36.6810 H       328 LYS350      0.0000 DICT
+   5211 HE2        17.9870  -29.5100   38.7240 H       328 LYS350      0.0000 DICT
+   5212 HE3        17.3410  -28.0220   38.5390 H       328 LYS350      0.0000 DICT
+   5213 HZ1        18.5790  -27.1490   40.1350 H       328 LYS350      0.0000 DICT|ESSENTIAL
+   5214 HZ2        18.4700  -28.6780   40.6980 H       328 LYS350      0.0000 DICT|ESSENTIAL
+   5215 HZ3        19.8070  -28.1980   39.8910 H       328 LYS350      0.0000 DICT|ESSENTIAL
+   5216 N          18.8410  -23.5630   36.5460 N.am    329 GLU351      0.0000 BACKBONE|DICT|DIRECT
+   5217 CA         17.7430  -22.6040   36.6200 C.3     329 GLU351      0.0000 BACKBONE|DICT|DIRECT
+   5218 C          18.0460  -21.3540   35.8020 C.2     329 GLU351      0.0000 BACKBONE|DICT|DIRECT
+   5219 O          17.1810  -20.8600   35.0680 O.2     329 GLU351      0.0000 BACKBONE|DICT|DIRECT
+   5220 CB         17.4590  -22.2320   38.0760 C.3     329 GLU351      0.0000 DICT
+   5221 CG         16.8780  -23.3580   38.9230 C.3     329 GLU351      0.0000 DICT
+   5222 CD         17.9030  -24.4210   39.2780 C.2     329 GLU351      0.0000 DICT
+   5223 OE1        17.4950  -25.5650   39.5720 O.co2   329 GLU351      0.0000 DICT
+   5224 OE2        19.1150  -24.1130   39.2590 O.co2   329 GLU351      0.0000 DICT
+   5225 H          19.4250  -23.7160   37.3430 H       329 GLU351      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5226 HA         16.9240  -23.0350   36.2410 H       329 GLU351      0.0000 BACKBONE|DICT|DIRECT
+   5227 HB2        16.8090  -21.4720   38.0820 H       329 GLU351      0.0000 DICT
+   5228 HB3        18.3180  -21.9390   38.4950 H       329 GLU351      0.0000 DICT
+   5229 HG2        16.1340  -23.7900   38.4130 H       329 GLU351      0.0000 DICT
+   5230 HG3        16.5180  -22.9670   39.7700 H       329 GLU351      0.0000 DICT
+   5231 N          19.2690  -20.8280   35.9170 N.am    330 LEU352      0.0000 BACKBONE|DICT|DIRECT
+   5232 CA         19.6400  -19.6490   35.1430 C.3     330 LEU352      0.0000 BACKBONE|DICT|DIRECT
+   5233 C          19.6580  -19.9540   33.6510 C.2     330 LEU352      0.0000 BACKBONE|DICT|DIRECT
+   5234 O          19.2050  -19.1360   32.8400 O.2     330 LEU352      0.0000 BACKBONE|DICT|DIRECT
+   5235 CB         20.9990  -19.1220   35.6060 C.3     330 LEU352      0.0000 DICT
+   5236 CG         21.5270  -17.8740   34.8960 C.3     330 LEU352      0.0000 DICT
+   5237 CD1        20.4920  -16.7570   34.9290 C.3     330 LEU352      0.0000 DICT
+   5238 CD2        22.8440  -17.4150   35.5210 C.3     330 LEU352      0.0000 DICT
+   5239 H          19.9330  -21.2450   36.5370 H       330 LEU352      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5240 HA         18.9560  -18.9380   35.3090 H       330 LEU352      0.0000 BACKBONE|DICT|DIRECT
+   5241 HB2        21.6690  -19.8530   35.4740 H       330 LEU352      0.0000 DICT
+   5242 HB3        20.9260  -18.9090   36.5800 H       330 LEU352      0.0000 DICT
+   5243 HG         21.7010  -18.1100   33.9400 H       330 LEU352      0.0000 DICT
+   5244 HD11       20.8560  -15.9520   34.4610 H       330 LEU352      0.0000 DICT
+   5245 HD12       19.6580  -17.0620   34.4690 H       330 LEU352      0.0000 DICT
+   5246 HD13       20.2830  -16.5240   35.8790 H       330 LEU352      0.0000 DICT
+   5247 HD21       23.1730  -16.6000   35.0440 H       330 LEU352      0.0000 DICT
+   5248 HD22       22.6980  -17.2000   36.4870 H       330 LEU352      0.0000 DICT
+   5249 HD23       23.5230  -18.1450   35.4410 H       330 LEU352      0.0000 DICT
+   5250 N          20.1670  -21.1290   33.2680 N.am    331 ALA353      0.0000 BACKBONE|DICT|DIRECT
+   5251 CA         20.1590  -21.5090   31.8590 C.3     331 ALA353      0.0000 BACKBONE|DICT|DIRECT
+   5252 C          18.7400  -21.6180   31.3220 C.2     331 ALA353      0.0000 BACKBONE|DICT|DIRECT
+   5253 O          18.4900  -21.2940   30.1540 O.2     331 ALA353      0.0000 BACKBONE|DICT|DIRECT
+   5254 CB         20.9050  -22.8280   31.6610 C.3     331 ALA353      0.0000 DICT
+   5255 H          20.5550  -21.7500   33.9490 H       331 ALA353      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5256 HA         20.6360  -20.7990   31.3410 H       331 ALA353      0.0000 BACKBONE|DICT|DIRECT
+   5257 HB1        20.8920  -23.0760   30.6920 H       331 ALA353      0.0000 DICT
+   5258 HB2        21.8520  -22.7240   31.9660 H       331 ALA353      0.0000 DICT
+   5259 HB3        20.4600  -23.5460   32.1950 H       331 ALA353      0.0000 DICT
+   5260 N          17.7990  -22.0630   32.1570 N.am    332 PHE354      0.0000 BACKBONE|DICT|DIRECT
+   5261 CA         16.4100  -22.1490   31.7250 C.3     332 PHE354      0.0000 BACKBONE|DICT|DIRECT
+   5262 C          15.8010  -20.7620   31.5490 C.2     332 PHE354      0.0000 BACKBONE|DICT|DIRECT
+   5263 O          15.0410  -20.5270   30.6010 O.2     332 PHE354      0.0000 BACKBONE|DICT|DIRECT
+   5264 CB         15.6020  -22.9690   32.7310 C.3     332 PHE354      0.0000 DICT
+   5265 CG         14.1590  -23.1210   32.3620 C.ar    332 PHE354      0.0000 DICT
+   5266 CD1        13.7620  -24.0890   31.4540 C.ar    332 PHE354      0.0000 DICT
+   5267 CD2        13.1980  -22.2930   32.9180 C.ar    332 PHE354      0.0000 DICT
+   5268 CE1        12.4330  -24.2300   31.1080 C.ar    332 PHE354      0.0000 DICT
+   5269 CE2        11.8670  -22.4280   32.5770 C.ar    332 PHE354      0.0000 DICT
+   5270 CZ         11.4840  -23.3970   31.6700 C.ar    332 PHE354      0.0000 DICT
+   5271 H          18.0490  -22.3390   33.0850 H       332 PHE354      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5272 HA         16.3830  -22.6190   30.8430 H       332 PHE354      0.0000 BACKBONE|DICT|DIRECT
+   5273 HB2        15.6540  -22.5170   33.6210 H       332 PHE354      0.0000 DICT
+   5274 HB3        16.0090  -23.8800   32.7950 H       332 PHE354      0.0000 DICT
+   5275 HD1        14.4460  -24.6930   31.0440 H       332 PHE354      0.0000 DICT
+   5276 HD2        13.4710  -21.5890   33.5740 H       332 PHE354      0.0000 DICT
+   5277 HE1        12.1580  -24.9330   30.4520 H       332 PHE354      0.0000 DICT
+   5278 HE2        11.1820  -21.8250   32.9860 H       332 PHE354      0.0000 DICT
+   5279 HZ         10.5210  -23.4960   31.4200 H       332 PHE354      0.0000 DICT
+   5280 N          16.1190  -19.8340   32.4550 N.am    333 PHE355      0.0000 BACKBONE|DICT|DIRECT
+   5281 CA         15.6040  -18.4740   32.3320 C.3     333 PHE355      0.0000 BACKBONE|DICT|DIRECT
+   5282 C          16.1180  -17.8060   31.0610 C.2     333 PHE355      0.0000 BACKBONE|DICT|DIRECT
+   5283 O          15.3410  -17.2320   30.2890 O.2     333 PHE355      0.0000 BACKBONE|DICT|DIRECT
+   5284 CB         15.9830  -17.6530   33.5640 C.3     333 PHE355      0.0000 DICT
+   5285 CG         15.6170  -16.2030   33.4570 C.ar    333 PHE355      0.0000 DICT
+   5286 CD1        14.3300  -15.7810   33.7330 C.ar    333 PHE355      0.0000 DICT
+   5287 CD2        16.5590  -15.2620   33.0730 C.ar    333 PHE355      0.0000 DICT
+   5288 CE1        13.9860  -14.4490   33.6310 C.ar    333 PHE355      0.0000 DICT
+   5289 CE2        16.2200  -13.9280   32.9670 C.ar    333 PHE355      0.0000 DICT
+   5290 CZ         14.9320  -13.5210   33.2480 C.ar    333 PHE355      0.0000 DICT
+   5291 H          16.7140  -20.0720   33.2230 H       333 PHE355      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5292 HA         14.6060  -18.5200   32.2810 H       333 PHE355      0.0000 BACKBONE|DICT|DIRECT
+   5293 HB2        16.9720  -17.7200   33.6960 H       333 PHE355      0.0000 DICT
+   5294 HB3        15.5130  -18.0400   34.3580 H       333 PHE355      0.0000 DICT
+   5295 HD1        13.6400  -16.4490   34.0100 H       333 PHE355      0.0000 DICT
+   5296 HD2        17.4940  -15.5520   32.8710 H       333 PHE355      0.0000 DICT
+   5297 HE1        13.0520  -14.1560   33.8350 H       333 PHE355      0.0000 DICT
+   5298 HE2        16.9070  -13.2580   32.6870 H       333 PHE355      0.0000 DICT
+   5299 HZ         14.6850  -12.5550   33.1740 H       333 PHE355      0.0000 DICT
+   5300 N          17.4320  -17.8800   30.8260 N.am    334 ALA356      0.0000 BACKBONE|DICT|DIRECT
+   5301 CA         18.0220  -17.2450   29.6510 C.3     334 ALA356      0.0000 BACKBONE|DICT|DIRECT
+   5302 C          17.3390  -17.7110   28.3710 C.2     334 ALA356      0.0000 BACKBONE|DICT|DIRECT
+   5303 O          16.9520  -16.8970   27.5250 O.2     334 ALA356      0.0000 BACKBONE|DICT|DIRECT
+   5304 CB         19.5240  -17.5350   29.5980 C.3     334 ALA356      0.0000 DICT
+   5305 H          18.0190  -18.3780   31.4640 H       334 ALA356      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5306 HA         17.8960  -16.2560   29.7320 H       334 ALA356      0.0000 BACKBONE|DICT|DIRECT
+   5307 HB1        19.9200  -17.0970   28.7910 H       334 ALA356      0.0000 DICT
+   5308 HB2        19.9620  -17.1750   30.4220 H       334 ALA356      0.0000 DICT
+   5309 HB3        19.6710  -18.5230   29.5470 H       334 ALA356      0.0000 DICT
+   5310 N          17.1620  -19.0260   28.2250 N.am    335 ASN357      0.0000 BACKBONE|DICT|DIRECT
+   5311 CA         16.5060  -19.5500   27.0320 C.3     335 ASN357      0.0000 BACKBONE|DICT|DIRECT
+   5312 C          15.0280  -19.1890   26.9920 C.2     335 ASN357      0.0000 BACKBONE|DICT|DIRECT
+   5313 O          14.4780  -18.9670   25.9080 O.2     335 ASN357      0.0000 BACKBONE|DICT|DIRECT
+   5314 CB         16.6790  -21.0650   26.9530 C.3     335 ASN357      0.0000 DICT
+   5315 CG         16.0760  -21.6470   25.6940 C.2     335 ASN357      0.0000 DICT
+   5316 OD1        16.7190  -21.6790   24.6450 O.2     335 ASN357      0.0000 DICT
+   5317 ND2        14.8300  -22.0990   25.7860 N.am    335 ASN357      0.0000 DICT
+   5318 H          17.4800  -19.6540   28.9350 H       335 ASN357      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5319 HA         16.9470  -19.1450   26.2310 H       335 ASN357      0.0000 BACKBONE|DICT|DIRECT
+   5320 HB2        16.2330  -21.4810   27.7450 H       335 ASN357      0.0000 DICT
+   5321 HB3        17.6560  -21.2780   26.9700 H       335 ASN357      0.0000 DICT
+   5322 HD21       14.3450  -22.0530   26.6590 H       335 ASN357      0.0000 DICT|ESSENTIAL
+   5323 HD22       14.3770  -22.4850   24.9820 H       335 ASN357      0.0000 DICT|ESSENTIAL
+   5324 N          14.3660  -19.1310   28.1500 N.am    336 ALA358      0.0000 BACKBONE|DICT|DIRECT
+   5325 CA         12.9620  -18.7320   28.1700 C.3     336 ALA358      0.0000 BACKBONE|DICT|DIRECT
+   5326 C          12.7870  -17.3040   27.6640 C.2     336 ALA358      0.0000 BACKBONE|DICT|DIRECT
+   5327 O          11.8600  -17.0200   26.8950 O.2     336 ALA358      0.0000 BACKBONE|DICT|DIRECT
+   5328 CB         12.3950  -18.8750   29.5830 C.3     336 ALA358      0.0000 DICT
+   5329 H          14.8320  -19.3610   29.0040 H       336 ALA358      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5330 HA         12.4530  -19.3440   27.5640 H       336 ALA358      0.0000 BACKBONE|DICT|DIRECT
+   5331 HB1        11.4340  -18.5990   29.5860 H       336 ALA358      0.0000 DICT
+   5332 HB2        12.4700  -19.8280   29.8770 H       336 ALA358      0.0000 DICT
+   5333 HB3        12.9110  -18.2910   30.2100 H       336 ALA358      0.0000 DICT
+   5334 N          13.6770  -16.3950   28.0770 N.am    337 LEU359      0.0000 BACKBONE|DICT|DIRECT
+   5335 CA         13.5640  -14.9970   27.6690 C.3     337 LEU359      0.0000 BACKBONE|DICT|DIRECT
+   5336 C          13.7750  -14.8350   26.1680 C.2     337 LEU359      0.0000 BACKBONE|DICT|DIRECT
+   5337 O          13.0960  -14.0240   25.5260 O.2     337 LEU359      0.0000 BACKBONE|DICT|DIRECT
+   5338 CB         14.5590  -14.1410   28.4560 C.3     337 LEU359      0.0000 DICT
+   5339 CG         14.5530  -12.6340   28.1940 C.3     337 LEU359      0.0000 DICT
+   5340 CD1        13.1400  -12.0820   28.2350 C.3     337 LEU359      0.0000 DICT
+   5341 CD2        15.4360  -11.9120   29.2040 C.3     337 LEU359      0.0000 DICT
+   5342 H          14.4290  -16.6760   28.6730 H       337 LEU359      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5343 HA         12.6410  -14.6820   27.8890 H       337 LEU359      0.0000 BACKBONE|DICT|DIRECT
+   5344 HB2        15.4770  -14.4780   28.2460 H       337 LEU359      0.0000 DICT
+   5345 HB3        14.3680  -14.2770   29.4280 H       337 LEU359      0.0000 DICT
+   5346 HG         14.9260  -12.4730   27.2800 H       337 LEU359      0.0000 DICT
+   5347 HD11       13.1620  -11.0970   28.0610 H       337 LEU359      0.0000 DICT
+   5348 HD12       12.5860  -12.5320   27.5350 H       337 LEU359      0.0000 DICT
+   5349 HD13       12.7410  -12.2530   29.1360 H       337 LEU359      0.0000 DICT
+   5350 HD21       15.4200  -10.9300   29.0180 H       337 LEU359      0.0000 DICT
+   5351 HD22       15.0930  -12.0820   30.1280 H       337 LEU359      0.0000 DICT
+   5352 HD23       16.3740  -12.2510   29.1290 H       337 LEU359      0.0000 DICT
+   5353 N          14.7060  -15.5980   25.5880 N.am    338 GLU360      0.0000 BACKBONE|DICT|DIRECT
+   5354 CA         14.8800  -15.5680   24.1380 C.3     338 GLU360      0.0000 BACKBONE|DICT|DIRECT
+   5355 C          13.6290  -16.0600   23.4240 C.2     338 GLU360      0.0000 BACKBONE|DICT|DIRECT
+   5356 O          13.2190  -15.4870   22.4080 O.2     338 GLU360      0.0000 BACKBONE|DICT|DIRECT
+   5357 CB         16.0920  -16.4070   23.7270 C.3     338 GLU360      0.0000 DICT
+   5358 CG         17.4080  -15.8990   24.2840 C.3     338 GLU360      0.0000 DICT
+   5359 CD         18.6180  -16.5550   23.6480 C.2     338 GLU360      0.0000 DICT
+   5360 OE1        18.4380  -17.4330   22.7790 O.co2   338 GLU360      0.0000 DICT
+   5361 OE2        19.7530  -16.1870   24.0170 O.co2   338 GLU360      0.0000 DICT
+   5362 H          15.2850  -16.1910   26.1480 H       338 GLU360      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5363 HA         15.0460  -14.6210   23.8620 H       338 GLU360      0.0000 BACKBONE|DICT|DIRECT
+   5364 HB2        16.1510  -16.4070   22.7290 H       338 GLU360      0.0000 DICT
+   5365 HB3        15.9520  -17.3420   24.0520 H       338 GLU360      0.0000 DICT
+   5366 HG2        17.4280  -16.0800   25.2670 H       338 GLU360      0.0000 DICT
+   5367 HG3        17.4610  -14.9130   24.1260 H       338 GLU360      0.0000 DICT
+   5368 N          13.0090  -17.1250   23.9410 N.am    339 GLU361      0.0000 BACKBONE|DICT|DIRECT
+   5369 CA         11.7940  -17.6510   23.3250 C.3     339 GLU361      0.0000 BACKBONE|DICT|DIRECT
+   5370 C          10.6640  -16.6330   23.3880 C.2     339 GLU361      0.0000 BACKBONE|DICT|DIRECT
+   5371 O           9.9620  -16.4050   22.3950 O.2     339 GLU361      0.0000 BACKBONE|DICT|DIRECT
+   5372 CB         11.3870  -18.9570   24.0080 C.3     339 GLU361      0.0000 DICT
+   5373 CG         12.3530  -20.1010   23.7650 C.3     339 GLU361      0.0000 DICT
+   5374 CD         11.9710  -21.3630   24.5140 C.2     339 GLU361      0.0000 DICT
+   5375 OE1        11.1810  -21.2710   25.4760 O.co2   339 GLU361      0.0000 DICT
+   5376 OE2        12.4630  -22.4490   24.1430 O.co2   339 GLU361      0.0000 DICT
+   5377 H          13.3810  -17.5660   24.7580 H       339 GLU361      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5378 HA         11.9880  -17.8460   22.3640 H       339 GLU361      0.0000 BACKBONE|DICT|DIRECT
+   5379 HB2        10.4870  -19.2260   23.6640 H       339 GLU361      0.0000 DICT
+   5380 HB3        11.3320  -18.7940   24.9930 H       339 GLU361      0.0000 DICT
+   5381 HG2        13.2650  -19.8170   24.0610 H       339 GLU361      0.0000 DICT
+   5382 HG3        12.3690  -20.3030   22.7860 H       339 GLU361      0.0000 DICT
+   5383 N          10.4800  -16.0030   24.5520 N.am    340 VAL362      0.0000 BACKBONE|DICT|DIRECT
+   5384 CA          9.4340  -14.9950   24.7040 C.3     340 VAL362      0.0000 BACKBONE|DICT|DIRECT
+   5385 C           9.6350  -13.8580   23.7110 C.2     340 VAL362      0.0000 BACKBONE|DICT|DIRECT
+   5386 O           8.6750  -13.3710   23.1010 O.2     340 VAL362      0.0000 BACKBONE|DICT|DIRECT
+   5387 CB          9.4030  -14.4800   26.1550 C.3     340 VAL362      0.0000 DICT
+   5388 CG1         8.4930  -13.2720   26.2730 C.3     340 VAL362      0.0000 DICT
+   5389 CG2         8.9510  -15.5820   27.0990 C.3     340 VAL362      0.0000 DICT
+   5390 H          11.0670  -16.2250   25.3300 H       340 VAL362      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5391 HA          8.5540  -15.4280   24.5080 H       340 VAL362      0.0000 BACKBONE|DICT|DIRECT
+   5392 HB         10.3290  -14.2040   26.4120 H       340 VAL362      0.0000 DICT
+   5393 HG11        8.4850  -12.9520   27.2200 H       340 VAL362      0.0000 DICT
+   5394 HG12        8.8290  -12.5420   25.6770 H       340 VAL362      0.0000 DICT
+   5395 HG13        7.5650  -13.5260   25.9990 H       340 VAL362      0.0000 DICT
+   5396 HG21        8.9360  -15.2330   28.0360 H       340 VAL362      0.0000 DICT
+   5397 HG22        8.0340  -15.8860   26.8420 H       340 VAL362      0.0000 DICT
+   5398 HG23        9.5860  -16.3520   27.0400 H       340 VAL362      0.0000 DICT
+   5399 N          10.8830  -13.4250   23.5230 N.am    341 SER363      0.0000 BACKBONE|DICT|DIRECT
+   5400 CA         11.1580  -12.3070   22.6240 C.3     341 SER363      0.0000 BACKBONE|DICT|DIRECT
+   5401 C          10.7650  -12.6450   21.1930 C.2     341 SER363      0.0000 BACKBONE|DICT|DIRECT
+   5402 O          10.1430  -11.8340   20.4980 O.2     341 SER363      0.0000 BACKBONE|DICT|DIRECT
+   5403 CB         12.6380  -11.9280   22.6980 C.3     341 SER363      0.0000 DICT
+   5404 OG         13.0440  -11.6930   24.0370 O.3     341 SER363      0.0000 DICT
+   5405 H          11.6390  -13.8710   24.0030 H       341 SER363      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5406 HA         10.6160  -11.5210   22.9230 H       341 SER363      0.0000 BACKBONE|DICT|DIRECT
+   5407 HB2        12.7890  -11.0980   22.1610 H       341 SER363      0.0000 DICT
+   5408 HB3        13.1850  -12.6740   22.3180 H       341 SER363      0.0000 DICT
+   5409 HG         12.9000  -12.5210   24.5790 H       341 SER363      0.0000 DICT|ESSENTIAL
+   5410 N          11.1170  -13.8480   20.7360 N.am    342 ILE364      0.0000 BACKBONE|DICT|DIRECT
+   5411 CA         10.7980  -14.2470   19.3690 C.3     342 ILE364      0.0000 BACKBONE|DICT|DIRECT
+   5412 C           9.3060  -14.5190   19.2220 C.2     342 ILE364      0.0000 BACKBONE|DICT|DIRECT
+   5413 O           8.6770  -14.0940   18.2450 O.2     342 ILE364      0.0000 BACKBONE|DICT|DIRECT
+   5414 CB         11.6470  -15.4670   18.9680 C.3     342 ILE364      0.0000 DICT
+   5415 CG1        13.1290  -15.0840   18.9420 C.3     342 ILE364      0.0000 DICT
+   5416 CG2        11.1930  -16.0200   17.6220 C.3     342 ILE364      0.0000 DICT
+   5417 CD1        14.0680  -16.2630   18.9260 C.3     342 ILE364      0.0000 DICT
+   5418 H          11.6040  -14.4820   21.3360 H       342 ILE364      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5419 HA         11.0370  -13.4900   18.7610 H       342 ILE364      0.0000 BACKBONE|DICT|DIRECT
+   5420 HB         11.5190  -16.1790   19.6590 H       342 ILE364      0.0000 DICT
+   5421 HG12       13.3260  -14.5360   19.7550 H       342 ILE364      0.0000 DICT
+   5422 HG13       13.2980  -14.5370   18.1220 H       342 ILE364      0.0000 DICT
+   5423 HG21       11.7560  -16.8100   17.3800 H       342 ILE364      0.0000 DICT
+   5424 HG22       10.2350  -16.2990   17.6820 H       342 ILE364      0.0000 DICT
+   5425 HG23       11.2910  -15.3130   16.9210 H       342 ILE364      0.0000 DICT
+   5426 HD11       15.0130  -15.9360   18.9090 H       342 ILE364      0.0000 DICT
+   5427 HD12       13.9210  -16.8170   19.7450 H       342 ILE364      0.0000 DICT
+   5428 HD13       13.8930  -16.8180   18.1130 H       342 ILE364      0.0000 DICT
+   5429 N           8.7140  -15.2240   20.1920 N.am    343 GLU365      0.0000 BACKBONE|DICT|DIRECT
+   5430 CA          7.2900  -15.5390   20.1190 C.3     343 GLU365      0.0000 BACKBONE|DICT|DIRECT
+   5431 C           6.4410  -14.2750   20.1010 C.2     343 GLU365      0.0000 BACKBONE|DICT|DIRECT
+   5432 O           5.4510  -14.1940   19.3640 O.2     343 GLU365      0.0000 BACKBONE|DICT|DIRECT
+   5433 CB          6.8900  -16.4340   21.2930 C.3     343 GLU365      0.0000 DICT
+   5434 CG          7.4590  -17.8440   21.2240 C.3     343 GLU365      0.0000 DICT
+   5435 CD          7.4450  -18.5460   22.5690 C.2     343 GLU365      0.0000 DICT
+   5436 OE1         6.7630  -18.0540   23.4950 O.co2   343 GLU365      0.0000 DICT
+   5437 OE2         8.1280  -19.5850   22.7030 O.co2   343 GLU365      0.0000 DICT
+   5438 H           9.2510  -15.5380   20.9750 H       343 GLU365      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5439 HA          7.1230  -16.0410   19.2710 H       343 GLU365      0.0000 BACKBONE|DICT|DIRECT
+   5440 HB2         5.8920  -16.4990   21.3120 H       343 GLU365      0.0000 DICT
+   5441 HB3         7.2130  -16.0070   22.1380 H       343 GLU365      0.0000 DICT
+   5442 HG2         8.4030  -17.7930   20.9000 H       343 GLU365      0.0000 DICT
+   5443 HG3         6.9130  -18.3780   20.5780 H       343 GLU365      0.0000 DICT
+   5444 N           6.8120  -13.2750   20.9050 N.am    344 THR366      0.0000 BACKBONE|DICT|DIRECT
+   5445 CA          6.0380  -12.0380   20.9470 C.3     344 THR366      0.0000 BACKBONE|DICT|DIRECT
+   5446 C           6.0050  -11.3730   19.5780 C.2     344 THR366      0.0000 BACKBONE|DICT|DIRECT
+   5447 O           4.9440  -10.9480   19.1050 O.2     344 THR366      0.0000 BACKBONE|DICT|DIRECT
+   5448 CB          6.6170  -11.0890   21.9980 C.3     344 THR366      0.0000 DICT
+   5449 OG1         6.6150  -11.7310   23.2790 O.3     344 THR366      0.0000 DICT
+   5450 CG2         5.7950   -9.8010   22.0750 C.3     344 THR366      0.0000 DICT
+   5451 H           7.6240  -13.3740   21.4810 H       344 THR366      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5452 HA          5.1000  -12.2630   21.2100 H       344 THR366      0.0000 BACKBONE|DICT|DIRECT
+   5453 HB          7.5580  -10.8610   21.7490 H       344 THR366      0.0000 DICT
+   5454 HG1         7.1720  -12.5600   23.2370 H       344 THR366      0.0000 DICT|ESSENTIAL
+   5455 HG21        6.1890   -9.1950   22.7660 H       344 THR366      0.0000 DICT
+   5456 HG22        5.8070   -9.3440   21.1860 H       344 THR366      0.0000 DICT
+   5457 HG23        4.8520  -10.0220   22.3240 H       344 THR366      0.0000 DICT
+   5458 N           7.1620  -11.2940   18.9170 N.am    345 ILE367      0.0000 BACKBONE|DICT|DIRECT
+   5459 CA          7.2180  -10.7150   17.5770 C.3     345 ILE367      0.0000 BACKBONE|DICT|DIRECT
+   5460 C           6.4090  -11.5610   16.6010 C.2     345 ILE367      0.0000 BACKBONE|DICT|DIRECT
+   5461 O           5.5910  -11.0420   15.8310 O.2     345 ILE367      0.0000 BACKBONE|DICT|DIRECT
+   5462 CB          8.6810  -10.5610   17.1210 C.3     345 ILE367      0.0000 DICT
+   5463 CG1         9.3990   -9.5110   17.9760 C.3     345 ILE367      0.0000 DICT
+   5464 CG2         8.7490  -10.1950   15.6440 C.3     345 ILE367      0.0000 DICT
+   5465 CD1        10.8970   -9.4670   17.7590 C.3     345 ILE367      0.0000 DICT
+   5466 H           8.0000  -11.6350   19.3440 H       345 ILE367      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5467 HA          6.8060   -9.8040   17.6140 H       345 ILE367      0.0000 BACKBONE|DICT|DIRECT
+   5468 HB          9.1430  -11.4390   17.2480 H       345 ILE367      0.0000 DICT
+   5469 HG12        9.2260   -9.7170   18.9390 H       345 ILE367      0.0000 DICT
+   5470 HG13        9.0220   -8.6120   17.7540 H       345 ILE367      0.0000 DICT
+   5471 HG21        9.7050  -10.1000   15.3680 H       345 ILE367      0.0000 DICT
+   5472 HG22        8.3160  -10.9150   15.1020 H       345 ILE367      0.0000 DICT
+   5473 HG23        8.2710   -9.3300   15.4930 H       345 ILE367      0.0000 DICT
+   5474 HD11       11.2980   -8.7640   18.3460 H       345 ILE367      0.0000 DICT
+   5475 HD12       11.2930  -10.3570   17.9870 H       345 ILE367      0.0000 DICT
+   5476 HD13       11.0890   -9.2520   16.8010 H       345 ILE367      0.0000 DICT
+   5477 N           6.6160  -12.8800   16.6260 N.am    346 GLU368      0.0000 BACKBONE|DICT|DIRECT
+   5478 CA          5.9100  -13.7580   15.6990 C.3     346 GLU368      0.0000 BACKBONE|DICT|DIRECT
+   5479 C           4.4050  -13.7620   15.9370 C.2     346 GLU368      0.0000 BACKBONE|DICT|DIRECT
+   5480 O           3.6440  -14.0890   15.0190 O.2     346 GLU368      0.0000 BACKBONE|DICT|DIRECT
+   5481 CB          6.4740  -15.1770   15.7910 C.3     346 GLU368      0.0000 DICT
+   5482 CG          7.9010  -15.2960   15.2700 C.3     346 GLU368      0.0000 DICT
+   5483 CD          8.4620  -16.7030   15.3830 C.2     346 GLU368      0.0000 DICT
+   5484 OE1         7.9290  -17.4980   16.1870 O.co2   346 GLU368      0.0000 DICT
+   5485 OE2         9.4370  -17.0130   14.6660 O.co2   346 GLU368      0.0000 DICT
+   5486 H           7.2600  -13.2690   17.2850 H       346 GLU368      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5487 HA          6.0740  -13.4220   14.7720 H       346 GLU368      0.0000 BACKBONE|DICT|DIRECT
+   5488 HB2         5.8890  -15.7860   15.2550 H       346 GLU368      0.0000 DICT
+   5489 HB3         6.4620  -15.4610   16.7500 H       346 GLU368      0.0000 DICT
+   5490 HG2         8.4840  -14.6780   15.7960 H       346 GLU368      0.0000 DICT
+   5491 HG3         7.9120  -15.0260   14.3070 H       346 GLU368      0.0000 DICT
+   5492 N           3.9580  -13.3950   17.1380 N.am    347 ALA369      0.0000 BACKBONE|DICT|DIRECT
+   5493 CA          2.5390  -13.2090   17.4100 C.3     347 ALA369      0.0000 BACKBONE|DICT|DIRECT
+   5494 C           2.0010  -11.8860   16.8810 C.2     347 ALA369      0.0000 BACKBONE|DICT|DIRECT
+   5495 O           0.8100  -11.6100   17.0550 O.2     347 ALA369      0.0000 BACKBONE|DICT|DIRECT
+   5496 CB          2.2730  -13.3010   18.9150 C.3     347 ALA369      0.0000 DICT
+   5497 H           4.6170  -13.2430   17.8750 H       347 ALA369      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5498 HA          2.0380  -13.9490   16.9610 H       347 ALA369      0.0000 BACKBONE|DICT|DIRECT
+   5499 HB1         1.2970  -13.1720   19.0890 H       347 ALA369      0.0000 DICT
+   5500 HB2         2.5550  -14.2000   19.2490 H       347 ALA369      0.0000 DICT
+   5501 HB3         2.7930  -12.5910   19.3890 H       347 ALA369      0.0000 DICT
+   5502 N           2.8390  -11.0640   16.2550 N.am    348 GLY370      0.0000 BACKBONE|DICT|DIRECT
+   5503 CA          2.4060   -9.8050   15.6890 C.3     348 GLY370      0.0000 BACKBONE|DICT|DIRECT
+   5504 C           2.6180   -8.5780   16.5510 C.2     348 GLY370      0.0000 BACKBONE|DICT|DIRECT
+   5505 O           2.0870   -7.5150   16.2150 O.2     348 GLY370      0.0000 BACKBONE|DICT|DIRECT
+   5506 H           3.8010  -11.3250   16.1730 H       348 GLY370      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5507 HA2         1.4270   -9.8770   15.4960 H       348 GLY370      0.0000 BACKBONE|DICT|DIRECT
+   5508 HA3         2.9050   -9.6670   14.8330 H       348 GLY370      0.0000 DICT
+   5509 N           3.3680   -8.6870   17.6460 N.am    349 PHE371      0.0000 BACKBONE|DICT|DIRECT
+   5510 CA          3.6770   -7.5550   18.5130 C.3     349 PHE371      0.0000 BACKBONE|DICT|DIRECT
+   5511 C           5.1330   -7.1620   18.2990 C.2     349 PHE371      0.0000 BACKBONE|DICT|DIRECT
+   5512 O           6.0390   -7.9570   18.5690 O.2     349 PHE371      0.0000 BACKBONE|DICT|DIRECT
+   5513 CB          3.4180   -7.8980   19.9790 C.3     349 PHE371      0.0000 DICT
+   5514 CG          1.9930   -8.2860   20.2680 C.ar    349 PHE371      0.0000 DICT
+   5515 CD1         1.0300   -7.3160   20.5040 C.ar    349 PHE371      0.0000 DICT
+   5516 CD2         1.6170   -9.6190   20.3010 C.ar    349 PHE371      0.0000 DICT
+   5517 CE1        -0.2800   -7.6700   20.7680 C.ar    349 PHE371      0.0000 DICT
+   5518 CE2         0.3100   -9.9770   20.5610 C.ar    349 PHE371      0.0000 DICT
+   5519 CZ         -0.6400   -9.0010   20.7970 C.ar    349 PHE371      0.0000 DICT
+   5520 H           3.7360   -9.5860   17.8850 H       349 PHE371      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5521 HA          3.0950   -6.7840   18.2550 H       349 PHE371      0.0000 BACKBONE|DICT|DIRECT
+   5522 HB2         3.6460   -7.0990   20.5350 H       349 PHE371      0.0000 DICT
+   5523 HB3         4.0110   -8.6620   20.2340 H       349 PHE371      0.0000 DICT
+   5524 HD1         1.2860   -6.3500   20.4830 H       349 PHE371      0.0000 DICT
+   5525 HD2         2.3000  -10.3300   20.1350 H       349 PHE371      0.0000 DICT
+   5526 HE1        -0.9660   -6.9620   20.9380 H       349 PHE371      0.0000 DICT
+   5527 HE2         0.0500  -10.9420   20.5790 H       349 PHE371      0.0000 DICT
+   5528 HZ         -1.5870   -9.2600   20.9880 H       349 PHE371      0.0000 DICT
+   5529 N           5.3550   -5.9410   17.8250 N.am    350 MET372      0.0000 BACKBONE|DICT|DIRECT
+   5530 CA          6.6910   -5.5360   17.4190 C.3     350 MET372      0.0000 BACKBONE|DICT|DIRECT
+   5531 C           6.7880   -4.0190   17.4620 C.2     350 MET372      0.0000 BACKBONE|DICT|DIRECT
+   5532 O           5.7760   -3.3140   17.5010 O.2     350 MET372      0.0000 BACKBONE|DICT|DIRECT
+   5533 CB          7.0210   -6.0610   16.0170 C.3     350 MET372      0.0000 DICT
+   5534 CG          6.0920   -5.5340   14.9280 C.3     350 MET372      0.0000 DICT
+   5535 SD          6.1710   -6.4830   13.3910 S.3     350 MET372      0.0000 DICT
+   5536 CE          5.3860   -8.0080   13.9080 C.3     350 MET372      0.0000 DICT
+   5537 H           4.5960   -5.2940   17.7470 H       350 MET372      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5538 HA          7.3510   -5.9170   18.0660 H       350 MET372      0.0000 BACKBONE|DICT|DIRECT
+   5539 HB2         6.9570   -7.0590   16.0310 H       350 MET372      0.0000 DICT
+   5540 HB3         7.9570   -5.7900   15.7910 H       350 MET372      0.0000 DICT
+   5541 HG2         6.3430   -4.5870   14.7280 H       350 MET372      0.0000 DICT
+   5542 HG3         5.1530   -5.5640   15.2710 H       350 MET372      0.0000 DICT
+   5543 HE1         5.3580   -8.6460   13.1390 H       350 MET372      0.0000 DICT
+   5544 HE2         5.9070   -8.4130   14.6590 H       350 MET372      0.0000 DICT
+   5545 HE3         4.4540   -7.8160   14.2150 H       350 MET372      0.0000 DICT
+   5546 N           8.0270   -3.5280   17.4640 N.am    351 THR373      0.0000 BACKBONE|DICT|DIRECT
+   5547 CA          8.2820   -2.1020   17.3500 C.3     351 THR373      0.0000 BACKBONE|DICT|DIRECT
+   5548 C           8.2460   -1.6800   15.8830 C.2     351 THR373      0.0000 BACKBONE|DICT|DIRECT
+   5549 O           8.1960   -2.5080   14.9700 O.2     351 THR373      0.0000 BACKBONE|DICT|DIRECT
+   5550 CB          9.6230   -1.7340   17.9860 C.3     351 THR373      0.0000 DICT
+   5551 OG1        10.6620   -2.5550   17.4400 O.3     351 THR373      0.0000 DICT
+   5552 CG2         9.5670   -1.9260   19.4950 C.3     351 THR373      0.0000 DICT
+   5553 H           8.8000   -4.1570   17.5460 H       351 THR373      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5554 HA          7.5580   -1.6130   17.8360 H       351 THR373      0.0000 BACKBONE|DICT|DIRECT
+   5555 HB          9.8260   -0.7750   17.7870 H       351 THR373      0.0000 DICT
+   5556 HG1        11.0510   -2.1090   16.6340 H       351 THR373      0.0000 DICT|ESSENTIAL
+   5557 HG21       10.4500   -1.6810   19.8950 H       351 THR373      0.0000 DICT
+   5558 HG22        8.8530   -1.3400   19.8790 H       351 THR373      0.0000 DICT
+   5559 HG23        9.3610   -2.8820   19.7020 H       351 THR373      0.0000 DICT
+   5560 N           8.2840   -0.3620   15.6660 N.am    352 LYS374      0.0000 BACKBONE|DICT|DIRECT
+   5561 CA          8.0090    0.1890   14.3410 C.3     352 LYS374      0.0000 BACKBONE|DICT|DIRECT
+   5562 C           9.0270   -0.2620   13.2990 C.2     352 LYS374      0.0000 BACKBONE|DICT|DIRECT
+   5563 O           8.6770   -0.4310   12.1250 O.2     352 LYS374      0.0000 BACKBONE|DICT|DIRECT
+   5564 CB          7.9650    1.7170   14.4140 C.3     352 LYS374      0.0000 DICT
+   5565 CG          7.5080    2.3880   13.1300 C.3     352 LYS374      0.0000 DICT
+   5566 CD          7.5310    3.8990   13.2630 C.3     352 LYS374      0.0000 DICT
+   5567 CE          7.0450    4.5690   11.9900 C.3     352 LYS374      0.0000 DICT
+   5568 NZ          7.1870    6.0480   12.0720 N.4     352 LYS374      0.0000 DICT
+   5569 H           8.5040    0.2560   16.4210 H       352 LYS374      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5570 HA          7.1070   -0.1330   14.0530 H       352 LYS374      0.0000 BACKBONE|DICT|DIRECT
+   5571 HB2         8.8840    2.0470   14.6310 H       352 LYS374      0.0000 DICT
+   5572 HB3         7.3350    1.9780   15.1460 H       352 LYS374      0.0000 DICT
+   5573 HG2         6.5750    2.0930   12.9220 H       352 LYS374      0.0000 DICT
+   5574 HG3         8.1180    2.1170   12.3850 H       352 LYS374      0.0000 DICT
+   5575 HD2         8.4670    4.1960   13.4510 H       352 LYS374      0.0000 DICT
+   5576 HD3         6.9370    4.1690   14.0210 H       352 LYS374      0.0000 DICT
+   5577 HE2         6.0820    4.3410   11.8490 H       352 LYS374      0.0000 DICT
+   5578 HE3         7.5840    4.2320   11.2180 H       352 LYS374      0.0000 DICT
+   5579 HZ1         6.8600    6.4620   11.2220 H       352 LYS374      0.0000 DICT|ESSENTIAL
+   5580 HZ2         6.6470    6.3930   12.8400 H       352 LYS374      0.0000 DICT|ESSENTIAL
+   5581 HZ3         8.1490    6.2830   12.2090 H       352 LYS374      0.0000 DICT|ESSENTIAL
+   5582 N          10.2830   -0.4630   13.7000 N.am    353 ASP375      0.0000 BACKBONE|DICT|DIRECT
+   5583 CA         11.3040   -0.8590   12.7330 C.3     353 ASP375      0.0000 BACKBONE|DICT|DIRECT
+   5584 C          10.9700   -2.2020   12.0920 C.2     353 ASP375      0.0000 BACKBONE|DICT|DIRECT
+   5585 O          11.1610   -2.3860   10.8850 O.2     353 ASP375      0.0000 BACKBONE|DICT|DIRECT
+   5586 CB         12.6770   -0.9070   13.4060 C.3     353 ASP375      0.0000 DICT
+   5587 CG         12.7200   -1.8720   14.5750 C.2     353 ASP375      0.0000 DICT
+   5588 OD1        11.7170   -1.9550   15.3170 O.co2   353 ASP375      0.0000 DICT
+   5589 OD2        13.7540   -2.5540   14.7460 O.co2   353 ASP375      0.0000 DICT
+   5590 H          10.5260   -0.3430   14.6630 H       353 ASP375      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5591 HA         11.3350   -0.1680   12.0110 H       353 ASP375      0.0000 BACKBONE|DICT|DIRECT
+   5592 HB2        12.9030    0.0090   13.7380 H       353 ASP375      0.0000 DICT
+   5593 HB3        13.3560   -1.1930   12.7290 H       353 ASP375      0.0000 DICT
+   5594 N          10.4590   -3.1510   12.8800 N.am    354 LEU376      0.0000 BACKBONE|DICT|DIRECT
+   5595 CA         10.1120   -4.4540   12.3230 C.3     354 LEU376      0.0000 BACKBONE|DICT|DIRECT
+   5596 C           8.8520   -4.3750   11.4660 C.2     354 LEU376      0.0000 BACKBONE|DICT|DIRECT
+   5597 O           8.7600   -5.0390   10.4270 O.2     354 LEU376      0.0000 BACKBONE|DICT|DIRECT
+   5598 CB          9.9460   -5.4740   13.4480 C.3     354 LEU376      0.0000 DICT
+   5599 CG         11.1900   -5.6530   14.3230 C.3     354 LEU376      0.0000 DICT
+   5600 CD1        10.9910   -6.7760   15.3250 C.3     354 LEU376      0.0000 DICT
+   5601 CD2        12.4270   -5.9020   13.4680 C.3     354 LEU376      0.0000 DICT
+   5602 H          10.3140   -2.9690   13.8520 H       354 LEU376      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5603 HA         10.8670   -4.7540   11.7400 H       354 LEU376      0.0000 BACKBONE|DICT|DIRECT
+   5604 HB2         9.7210   -6.3580   13.0390 H       354 LEU376      0.0000 DICT
+   5605 HB3         9.1920   -5.1760   14.0330 H       354 LEU376      0.0000 DICT
+   5606 HG         11.3330   -4.8050   14.8340 H       354 LEU376      0.0000 DICT
+   5607 HD11       11.8140   -6.8740   15.8840 H       354 LEU376      0.0000 DICT
+   5608 HD12       10.2120   -6.5630   15.9140 H       354 LEU376      0.0000 DICT
+   5609 HD13       10.8160   -7.6310   14.8370 H       354 LEU376      0.0000 DICT
+   5610 HD21       13.2240   -6.0150   14.0610 H       354 LEU376      0.0000 DICT
+   5611 HD22       12.2950   -6.7310   12.9240 H       354 LEU376      0.0000 DICT
+   5612 HD23       12.5730   -5.1230   12.8580 H       354 LEU376      0.0000 DICT
+   5613 N           7.8730   -3.5670   11.8820 N.am    355 ALA377      0.0000 BACKBONE|DICT|DIRECT
+   5614 CA          6.6740   -3.3890   11.0710 C.3     355 ALA377      0.0000 BACKBONE|DICT|DIRECT
+   5615 C           7.0130   -2.7700    9.7200 C.2     355 ALA377      0.0000 BACKBONE|DICT|DIRECT
+   5616 O           6.4170   -3.1290    8.6970 O.2     355 ALA377      0.0000 BACKBONE|DICT|DIRECT
+   5617 CB          5.6540   -2.5290   11.8180 C.3     355 ALA377      0.0000 DICT
+   5618 H           7.9630   -3.0830   12.7520 H       355 ALA377      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5619 HA          6.2680   -4.2890   10.9100 H       355 ALA377      0.0000 BACKBONE|DICT|DIRECT
+   5620 HB1         4.8370   -2.4140   11.2530 H       355 ALA377      0.0000 DICT
+   5621 HB2         5.4050   -2.9770   12.6760 H       355 ALA377      0.0000 DICT
+   5622 HB3         6.0530   -1.6330   12.0130 H       355 ALA377      0.0000 DICT
+   5623 N           7.9780   -1.8460    9.6950 N.am    356 ALA378      0.0000 BACKBONE|DICT|DIRECT
+   5624 CA          8.3900   -1.2420    8.4310 C.3     356 ALA378      0.0000 BACKBONE|DICT|DIRECT
+   5625 C           9.0770   -2.2600    7.5290 C.2     356 ALA378      0.0000 BACKBONE|DICT|DIRECT
+   5626 O           8.9100   -2.2190    6.3050 O.2     356 ALA378      0.0000 BACKBONE|DICT|DIRECT
+   5627 CB          9.3060   -0.0450    8.6880 C.3     356 ALA378      0.0000 DICT
+   5628 H           8.4210   -1.5660   10.5470 H       356 ALA378      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5629 HA          7.5710   -0.9120    7.9620 H       356 ALA378      0.0000 BACKBONE|DICT|DIRECT
+   5630 HB1         9.5800    0.3580    7.8150 H       356 ALA378      0.0000 DICT
+   5631 HB2         8.8180    0.6380    9.2320 H       356 ALA378      0.0000 DICT
+   5632 HB3        10.1190   -0.3480    9.1850 H       356 ALA378      0.0000 DICT
+   5633 N           9.8610   -3.1740    8.1100 N.am    357 CYS379      0.0000 BACKBONE|DICT|DIRECT
+   5634 CA         10.4540   -4.2460    7.3170 C.3     357 CYS379      0.0000 BACKBONE|DICT|DIRECT
+   5635 C           9.3860   -5.0310    6.5650 C.2     357 CYS379      0.0000 BACKBONE|DICT|DIRECT
+   5636 O           9.5410   -5.3260    5.3740 O.2     357 CYS379      0.0000 BACKBONE|DICT|DIRECT
+   5637 CB         11.2670   -5.1840    8.2130 C.3     357 CYS379      0.0000 DICT
+   5638 SG         12.8560   -4.5280    8.7690 S.3     357 CYS379      0.0000 DICT
+   5639 H          10.0420   -3.1230    9.0920 H       357 CYS379      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5640 HA         11.0730   -3.8360    6.6470 H       357 CYS379      0.0000 BACKBONE|DICT|DIRECT
+   5641 HB2        11.4410   -6.0260    7.7030 H       357 CYS379      0.0000 DICT
+   5642 HB3        10.7180   -5.3920    9.0220 H       357 CYS379      0.0000 DICT
+   5643 HG         12.7050   -3.6910    9.2950 H       357 CYS379      0.0000 DICT|ESSENTIAL
+   5644 N           8.2860   -5.3620    7.2400 N.am    358 ILE380      0.0000 BACKBONE|DICT|DIRECT
+   5645 CA          7.2190   -6.1330    6.6060 C.3     358 ILE380      0.0000 BACKBONE|DICT|DIRECT
+   5646 C           6.5150   -5.3000    5.5400 C.2     358 ILE380      0.0000 BACKBONE|DICT|DIRECT
+   5647 O           6.4460   -5.6870    4.3690 O.2     358 ILE380      0.0000 BACKBONE|DICT|DIRECT
+   5648 CB          6.2160   -6.6360    7.6570 C.3     358 ILE380      0.0000 DICT
+   5649 CG1         6.8950   -7.5750    8.6540 C.3     358 ILE380      0.0000 DICT
+   5650 CG2         5.0460   -7.3250    6.9750 C.3     358 ILE380      0.0000 DICT
+   5651 CD1         6.0010   -7.9590    9.8160 C.3     358 ILE380      0.0000 DICT
+   5652 H           8.1890   -5.0790    8.1940 H       358 ILE380      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5653 HA          7.6300   -6.9280    6.1600 H       358 ILE380      0.0000 BACKBONE|DICT|DIRECT
+   5654 HB          5.8650   -5.8460    8.1590 H       358 ILE380      0.0000 DICT
+   5655 HG12        7.7090   -7.1200    9.0160 H       358 ILE380      0.0000 DICT
+   5656 HG13        7.1660   -8.4080    8.1720 H       358 ILE380      0.0000 DICT
+   5657 HG21        4.4000   -7.6480    7.6670 H       358 ILE380      0.0000 DICT
+   5658 HG22        4.5870   -6.6780    6.3670 H       358 ILE380      0.0000 DICT
+   5659 HG23        5.3810   -8.1030    6.4430 H       358 ILE380      0.0000 DICT
+   5660 HD11        6.4980   -8.5710   10.4310 H       358 ILE380      0.0000 DICT
+   5661 HD12        5.7290   -7.1350   10.3140 H       358 ILE380      0.0000 DICT
+   5662 HD13        5.1860   -8.4240    9.4700 H       358 ILE380      0.0000 DICT
+   5663 N           5.9840   -4.1420    5.9330 N.am    359 LYS381      0.0000 BACKBONE|DICT|DIRECT
+   5664 CA          5.0350   -3.4060    5.1090 C.3     359 LYS381      0.0000 BACKBONE|DICT|DIRECT
+   5665 C           5.6480   -2.2450    4.3360 C.2     359 LYS381      0.0000 BACKBONE|DICT|DIRECT
+   5666 O           4.9630   -1.6630    3.4870 O.2     359 LYS381      0.0000 BACKBONE|DICT|DIRECT
+   5667 CB          3.8950   -2.8720    5.9830 C.3     359 LYS381      0.0000 DICT
+   5668 CG          3.1540   -3.9400    6.7630 C.3     359 LYS381      0.0000 DICT
+   5669 CD          2.0480   -3.3270    7.6030 C.3     359 LYS381      0.0000 DICT
+   5670 CE          1.1110   -2.4850    6.7490 C.3     359 LYS381      0.0000 DICT
+   5671 NZ          0.0730   -1.7930    7.5680 N.4     359 LYS381      0.0000 DICT
+   5672 H           6.2460   -3.7670    6.8220 H       359 LYS381      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5673 HA          4.6420   -4.0440    4.4470 H       359 LYS381      0.0000 BACKBONE|DICT|DIRECT
+   5674 HB2         3.2390   -2.4050    5.3910 H       359 LYS381      0.0000 DICT
+   5675 HB3         4.2800   -2.2180    6.6350 H       359 LYS381      0.0000 DICT
+   5676 HG2         3.7980   -4.4130    7.3640 H       359 LYS381      0.0000 DICT
+   5677 HG3         2.7540   -4.5950    6.1220 H       359 LYS381      0.0000 DICT
+   5678 HD2         2.4570   -2.7470    8.3080 H       359 LYS381      0.0000 DICT
+   5679 HD3         1.5240   -4.0600    8.0370 H       359 LYS381      0.0000 DICT
+   5680 HE2         0.6550   -3.0810    6.0870 H       359 LYS381      0.0000 DICT
+   5681 HE3         1.6490   -1.7970    6.2630 H       359 LYS381      0.0000 DICT
+   5682 HZ1        -0.1840   -0.9340    7.1250 H       359 LYS381      0.0000 DICT|ESSENTIAL
+   5683 HZ2        -0.7330   -2.3800    7.6500 H       359 LYS381      0.0000 DICT|ESSENTIAL
+   5684 HZ3         0.4400   -1.6010    8.4780 H       359 LYS381      0.0000 DICT|ESSENTIAL
+   5685 N           6.9030   -1.8900    4.5960 N.am    360 GLY382      0.0000 BACKBONE|DICT|DIRECT
+   5686 CA          7.4570   -0.6810    4.0170 C.3     360 GLY382      0.0000 BACKBONE|DICT|DIRECT
+   5687 C           7.0430    0.5360    4.8180 C.2     360 GLY382      0.0000 BACKBONE|DICT|DIRECT
+   5688 O           5.8830    0.6450    5.2290 O.2     360 GLY382      0.0000 BACKBONE|DICT|DIRECT
+   5689 H           7.4670   -2.4590    5.1940 H       360 GLY382      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5690 HA2         7.1250   -0.5850    3.0790 H       360 GLY382      0.0000 BACKBONE|DICT|DIRECT
+   5691 HA3         8.4550   -0.7470    4.0120 H       360 GLY382      0.0000 DICT
+   5692 N           7.9820    1.4520    5.0520 N.am    361 LEU383      0.0000 BACKBONE|DICT|DIRECT
+   5693 CA          7.7050    2.5870    5.9290 C.3     361 LEU383      0.0000 BACKBONE|DICT|DIRECT
+   5694 C           6.5340    3.4530    5.4710 C.2     361 LEU383      0.0000 BACKBONE|DICT|DIRECT
+   5695 O           5.7400    3.8630    6.3350 O.2     361 LEU383      0.0000 BACKBONE|DICT|DIRECT
+   5696 CB          8.9740    3.4350    6.0950 C.3     361 LEU383      0.0000 DICT
+   5697 CG          8.8910    4.5580    7.1330 C.3     361 LEU383      0.0000 DICT
+   5698 CD1         8.6010    3.9890    8.5160 C.3     361 LEU383      0.0000 DICT
+   5699 CD2        10.1640    5.3920    7.1470 C.3     361 LEU383      0.0000 DICT
+   5700 H           8.8820    1.3620    4.6250 H       361 LEU383      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5701 HA          7.4710    2.2190    6.8290 H       361 LEU383      0.0000 BACKBONE|DICT|DIRECT
+   5702 HB2         9.1840    3.8500    5.2100 H       361 LEU383      0.0000 DICT
+   5703 HB3         9.7190    2.8240    6.3620 H       361 LEU383      0.0000 DICT
+   5704 HG          8.1320    5.1570    6.8800 H       361 LEU383      0.0000 DICT
+   5705 HD11        8.5500    4.7350    9.1800 H       361 LEU383      0.0000 DICT
+   5706 HD12        7.7300    3.4990    8.4990 H       361 LEU383      0.0000 DICT
+   5707 HD13        9.3330    3.3590    8.7780 H       361 LEU383      0.0000 DICT
+   5708 HD21       10.0810    6.1150    7.8320 H       361 LEU383      0.0000 DICT
+   5709 HD22       10.9430    4.8070    7.3720 H       361 LEU383      0.0000 DICT
+   5710 HD23       10.3040    5.8010    6.2450 H       361 LEU383      0.0000 DICT
+   5711 N           6.3610    3.7740    4.1820 N.am    362 PRO384      0.0000 BACKBONE|DICT|DIRECT
+   5712 CA          5.2110    4.6100    3.7930 C.3     362 PRO384      0.0000 BACKBONE|DICT|DIRECT
+   5713 C           3.8570    4.0070    4.1250 C.2     362 PRO384      0.0000 BACKBONE|DICT|DIRECT
+   5714 O           2.8690    4.7490    4.1880 O.2     362 PRO384      0.0000 BACKBONE|DICT|DIRECT
+   5715 CB          5.3920    4.7670    2.2770 C.3     362 PRO384      0.0000 DICT
+   5716 CG          6.8480    4.6160    2.0660 C.3     362 PRO384      0.0000 DICT
+   5717 CD          7.2810    3.5730    3.0460 C.3     362 PRO384      0.0000 DICT
+   5718 HA          5.2900    5.5060    4.2300 H       362 PRO384      0.0000 BACKBONE|DICT|DIRECT
+   5719 HB2         4.8870    4.0580    1.7850 H       362 PRO384      0.0000 DICT
+   5720 HB3         5.0820    5.6680    1.9750 H       362 PRO384      0.0000 DICT
+   5721 HG2         7.0380    4.3180    1.1300 H       362 PRO384      0.0000 DICT
+   5722 HG3         7.3190    5.4800    2.2430 H       362 PRO384      0.0000 DICT
+   5723 HD2         7.1800    2.6560    2.6610 H       362 PRO384      0.0000 DICT
+   5724 HD3         8.2310    3.7150    3.3240 H       362 PRO384      0.0000 DICT
+   5725 N           3.7710    2.6950    4.3420 N.am    363 ASN385      0.0000 BACKBONE|DICT|DIRECT
+   5726 CA          2.5010    2.0290    4.5980 C.3     363 ASN385      0.0000 BACKBONE|DICT|DIRECT
+   5727 C           2.3200    1.6290    6.0570 C.2     363 ASN385      0.0000 BACKBONE|DICT|DIRECT
+   5728 O           1.3850    0.8850    6.3730 O.2     363 ASN385      0.0000 BACKBONE|DICT|DIRECT
+   5729 CB          2.3640    0.8000    3.6970 C.3     363 ASN385      0.0000 DICT
+   5730 CG          2.1220    1.1670    2.2470 C.2     363 ASN385      0.0000 DICT
+   5731 OD1         2.9900    1.7330    1.5860 O.2     363 ASN385      0.0000 DICT
+   5732 ND2         0.9360    0.8430    1.7450 N.am    363 ASN385      0.0000 DICT
+   5733 H           4.6080    2.1480    4.3290 H       363 ASN385      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5734 HA          1.7670    2.6660    4.3610 H       363 ASN385      0.0000 BACKBONE|DICT|DIRECT
+   5735 HB2         1.5950    0.2490    4.0210 H       363 ASN385      0.0000 DICT
+   5736 HB3         3.2060    0.2640    3.7560 H       363 ASN385      0.0000 DICT
+   5737 HD21        0.2590    0.3830    2.3190 H       363 ASN385      0.0000 DICT|ESSENTIAL
+   5738 HD22        0.7200    1.0590    0.7930 H       363 ASN385      0.0000 DICT|ESSENTIAL
+   5739 N           3.1810    2.1010    6.9520 N.am    364 VAL386      0.0000 BACKBONE|DICT|DIRECT
+   5740 CA          3.0710    1.7530    8.3630 C.3     364 VAL386      0.0000 BACKBONE|DICT|DIRECT
+   5741 C           2.0570    2.6690    9.0300 C.2     364 VAL386      0.0000 BACKBONE|DICT|DIRECT
+   5742 O           2.0410    3.8830    8.7980 O.2     364 VAL386      0.0000 BACKBONE|DICT|DIRECT
+   5743 CB          4.4440    1.8400    9.0560 C.3     364 VAL386      0.0000 DICT
+   5744 CG1         4.3020    1.6250   10.5610 C.3     364 VAL386      0.0000 DICT
+   5745 CG2         5.4000    0.8210    8.4670 C.3     364 VAL386      0.0000 DICT
+   5746 H           3.9180    2.7060    6.6520 H       364 VAL386      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5747 HA          2.7410    0.8120    8.4320 H       364 VAL386      0.0000 BACKBONE|DICT|DIRECT
+   5748 HB          4.8200    2.7540    8.9010 H       364 VAL386      0.0000 DICT
+   5749 HG11        5.2020    1.6850   10.9930 H       364 VAL386      0.0000 DICT
+   5750 HG12        3.7020    2.3280   10.9430 H       364 VAL386      0.0000 DICT
+   5751 HG13        3.9090    0.7220   10.7330 H       364 VAL386      0.0000 DICT
+   5752 HG21        6.2850    0.8900    8.9270 H       364 VAL386      0.0000 DICT
+   5753 HG22        5.0280   -0.0980    8.5960 H       364 VAL386      0.0000 DICT
+   5754 HG23        5.5170    0.9990    7.4900 H       364 VAL386      0.0000 DICT
+   5755 N           1.2000    2.0850    9.8560 N.am    365 GLN387      0.0000 BACKBONE|DICT|DIRECT
+   5756 CA          0.2600    2.8360   10.6650 C.3     365 GLN387      0.0000 BACKBONE|DICT|DIRECT
+   5757 C           0.5280    2.5440   12.1330 C.2     365 GLN387      0.0000 BACKBONE|DICT|DIRECT
+   5758 O           1.1720    1.5500   12.4810 O.2     365 GLN387      0.0000 BACKBONE|DICT|DIRECT
+   5759 CB         -1.1910    2.4970   10.2980 C.3     365 GLN387      0.0000 DICT
+   5760 CG         -1.5720    2.9270    8.8890 C.3     365 GLN387      0.0000 DICT
+   5761 CD         -3.0320    2.6700    8.5690 C.2     365 GLN387      0.0000 DICT
+   5762 OE1        -3.7880    2.1800    9.4080 O.2     365 GLN387      0.0000 DICT
+   5763 NE2        -3.4360    3.0020    7.3480 N.am    365 GLN387      0.0000 DICT
+   5764 H           1.2020    1.0870    9.9240 H       365 GLN387      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5765 HA          0.4090    3.8110   10.5030 H       365 GLN387      0.0000 BACKBONE|DICT|DIRECT
+   5766 HB2        -1.7980    2.9580   10.9450 H       365 GLN387      0.0000 DICT
+   5767 HB3        -1.3140    1.5070   10.3720 H       365 GLN387      0.0000 DICT
+   5768 HG2        -1.0080    2.4200    8.2370 H       365 GLN387      0.0000 DICT
+   5769 HG3        -1.3920    3.9060    8.7940 H       365 GLN387      0.0000 DICT
+   5770 HE21       -2.7880    3.3980    6.6970 H       365 GLN387      0.0000 DICT|ESSENTIAL
+   5771 HE22       -4.3880    2.8560    7.0800 H       365 GLN387      0.0000 DICT|ESSENTIAL
+   5772 N           0.0280    3.4360   12.9920 N.am    366 ARG388      0.0000 BACKBONE|DICT|DIRECT
+   5773 CA          0.3040    3.3250   14.4200 C.3     366 ARG388      0.0000 BACKBONE|DICT|DIRECT
+   5774 C          -0.1580    1.9870   14.9840 C.2     366 ARG388      0.0000 BACKBONE|DICT|DIRECT
+   5775 O           0.4890    1.4370   15.8830 O.2     366 ARG388      0.0000 BACKBONE|DICT|DIRECT
+   5776 CB         -0.3570    4.4840   15.1680 C.3     366 ARG388      0.0000 DICT
+   5777 CG         -0.0690    4.5050   16.6580 C.3     366 ARG388      0.0000 DICT
+   5778 CD          1.4310    4.5510   16.9370 C.3     366 ARG388      0.0000 DICT
+   5779 NE          1.7010    4.4390   18.3670 N.pl3   366 ARG388      0.0000 DICT
+   5780 CZ          1.8010    3.2850   19.0200 C.cat   366 ARG388      0.0000 DICT
+   5781 NH1         2.0400    3.2770   20.3260 N.pl3   366 ARG388      0.0000 DICT
+   5782 NH2         1.6630    2.1380   18.3660 N.pl3   366 ARG388      0.0000 DICT
+   5783 H          -0.5400    4.1860   12.6530 H       366 ARG388      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5784 HA          1.2930    3.3930   14.5520 H       366 ARG388      0.0000 BACKBONE|DICT|DIRECT
+   5785 HB2        -1.3470    4.4160   15.0400 H       366 ARG388      0.0000 DICT
+   5786 HB3        -0.0280    5.3410   14.7720 H       366 ARG388      0.0000 DICT
+   5787 HG2        -0.4520    3.6810   17.0750 H       366 ARG388      0.0000 DICT
+   5788 HG3        -0.4990    5.3130   17.0610 H       366 ARG388      0.0000 DICT
+   5789 HD2         1.8000    5.4180   16.6020 H       366 ARG388      0.0000 DICT
+   5790 HD3         1.8760    3.7930   16.4600 H       366 ARG388      0.0000 DICT
+   5791 HE          1.8180    5.2840   18.8890 H       366 ARG388      0.0000 DICT|ESSENTIAL
+   5792 HH11        2.1150    2.4080   20.8150 H       366 ARG388      0.0000 DICT|ESSENTIAL
+   5793 HH12        2.1450    4.1400   20.8200 H       366 ARG388      0.0000 DICT|ESSENTIAL
+   5794 HH21        1.7380    1.2700   18.8570 H       366 ARG388      0.0000 DICT|ESSENTIAL
+   5795 HH22        1.4840    2.1420   17.3820 H       366 ARG388      0.0000 DICT|ESSENTIAL
+   5796 N          -1.2510    1.4340   14.4570 N.am    367 SER389      0.0000 BACKBONE|DICT|DIRECT
+   5797 CA         -1.7610    0.1600   14.9550 C.3     367 SER389      0.0000 BACKBONE|DICT|DIRECT
+   5798 C          -0.9280   -1.0350   14.5110 C.2     367 SER389      0.0000 BACKBONE|DICT|DIRECT
+   5799 O          -1.2280   -2.1590   14.9250 O.2     367 SER389      0.0000 BACKBONE|DICT|DIRECT
+   5800 CB         -3.2150   -0.0350   14.5160 C.3     367 SER389      0.0000 DICT
+   5801 OG         -3.3360   -0.0030   13.1040 O.3     367 SER389      0.0000 DICT
+   5802 H          -1.7280    1.8980   13.7110 H       367 SER389      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5803 HA         -1.7440    0.1920   15.9540 H       367 SER389      0.0000 BACKBONE|DICT|DIRECT
+   5804 HB2        -3.7740    0.6960   14.9070 H       367 SER389      0.0000 DICT
+   5805 HB3        -3.5400   -0.9190   14.8510 H       367 SER389      0.0000 DICT
+   5806 HG         -4.2940   -0.1330   12.8490 H       367 SER389      0.0000 DICT|ESSENTIAL
+   5807 N           0.1010   -0.8300   13.6900 N.am    368 ASP390      0.0000 BACKBONE|DICT|DIRECT
+   5808 CA          0.9450   -1.9260   13.2380 C.3     368 ASP390      0.0000 BACKBONE|DICT|DIRECT
+   5809 C           2.1050   -2.2220   14.1790 C.2     368 ASP390      0.0000 BACKBONE|DICT|DIRECT
+   5810 O           2.8230   -3.2030   13.9540 O.2     368 ASP390      0.0000 BACKBONE|DICT|DIRECT
+   5811 CB          1.4930   -1.6310   11.8390 C.3     368 ASP390      0.0000 DICT
+   5812 CG          0.4140   -1.6620   10.7750 C.2     368 ASP390      0.0000 DICT
+   5813 OD1        -0.5650   -2.4170   10.9450 O.co2   368 ASP390      0.0000 DICT
+   5814 OD2         0.5430   -0.9340    9.7680 O.co2   368 ASP390      0.0000 DICT
+   5815 H           0.2980    0.0990   13.3770 H       368 ASP390      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5816 HA          0.3780   -2.7480   13.1800 H       368 ASP390      0.0000 BACKBONE|DICT|DIRECT
+   5817 HB2         2.1850   -2.3170   11.6140 H       368 ASP390      0.0000 DICT
+   5818 HB3         1.9130   -0.7230   11.8440 H       368 ASP390      0.0000 DICT
+   5819 N           2.3070   -1.4190   15.2230 N.am    369 TYR391      0.0000 BACKBONE|DICT|DIRECT
+   5820 CA          3.4480   -1.6280   16.1030 C.3     369 TYR391      0.0000 BACKBONE|DICT|DIRECT
+   5821 C           3.1350   -1.1030   17.4970 C.2     369 TYR391      0.0000 BACKBONE|DICT|DIRECT
+   5822 O           2.1220   -0.4370   17.7250 O.2     369 TYR391      0.0000 BACKBONE|DICT|DIRECT
+   5823 CB          4.7120   -0.9620   15.5430 C.3     369 TYR391      0.0000 DICT
+   5824 CG          4.6220    0.5430   15.4020 C.ar    369 TYR391      0.0000 DICT
+   5825 CD1         4.9810    1.3810   16.4500 C.ar    369 TYR391      0.0000 DICT
+   5826 CD2         4.1920    1.1240   14.2170 C.ar    369 TYR391      0.0000 DICT
+   5827 CE1         4.9070    2.7520   16.3250 C.ar    369 TYR391      0.0000 DICT
+   5828 CE2         4.1130    2.4970   14.0820 C.ar    369 TYR391      0.0000 DICT
+   5829 CZ          4.4750    3.3060   15.1400 C.ar    369 TYR391      0.0000 DICT
+   5830 OH          4.4040    4.6740   15.0170 O.3     369 TYR391      0.0000 DICT
+   5831 H           1.6710   -0.6680   15.4030 H       369 TYR391      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5832 HA          3.6160   -2.6120   16.1690 H       369 TYR391      0.0000 BACKBONE|DICT|DIRECT
+   5833 HB2         4.8950   -1.3500   14.6390 H       369 TYR391      0.0000 DICT
+   5834 HB3         5.4730   -1.1730   16.1560 H       369 TYR391      0.0000 DICT
+   5835 HD1         5.2990    0.9830   17.3100 H       369 TYR391      0.0000 DICT
+   5836 HD2         3.9350    0.5390   13.4480 H       369 TYR391      0.0000 DICT
+   5837 HE1         5.1660    3.3410   17.0910 H       369 TYR391      0.0000 DICT
+   5838 HE2         3.7960    2.9010   13.2240 H       369 TYR391      0.0000 DICT
+   5839 HH          4.0910    5.0830   14.1600 H       369 TYR391      0.0000 DICT|ESSENTIAL
+   5840 N           4.0280   -1.4220   18.4310 N.am    370 LEU392      0.0000 BACKBONE|DICT|DIRECT
+   5841 CA          3.9910   -0.9190   19.7950 C.3     370 LEU392      0.0000 BACKBONE|DICT|DIRECT
+   5842 C           5.1470    0.0480   20.0150 C.2     370 LEU392      0.0000 BACKBONE|DICT|DIRECT
+   5843 O           6.2140   -0.0940   19.4100 O.2     370 LEU392      0.0000 BACKBONE|DICT|DIRECT
+   5844 CB          4.0840   -2.0630   20.8080 C.3     370 LEU392      0.0000 DICT
+   5845 CG          3.0860   -3.2110   20.6590 C.3     370 LEU392      0.0000 DICT
+   5846 CD1         3.2870   -4.2320   21.7650 C.3     370 LEU392      0.0000 DICT
+   5847 CD2         1.6650   -2.6810   20.6660 C.3     370 LEU392      0.0000 DICT
+   5848 H           4.7690   -2.0450   18.1800 H       370 LEU392      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5849 HA          3.1300   -0.4310   19.9360 H       370 LEU392      0.0000 BACKBONE|DICT|DIRECT
+   5850 HB2         3.9560   -1.6700   21.7180 H       370 LEU392      0.0000 DICT
+   5851 HB3         5.0030   -2.4520   20.7390 H       370 LEU392      0.0000 DICT
+   5852 HG          3.2510   -3.6600   19.7810 H       370 LEU392      0.0000 DICT
+   5853 HD11        2.6280   -4.9760   21.6550 H       370 LEU392      0.0000 DICT
+   5854 HD12        4.2160   -4.5990   21.7150 H       370 LEU392      0.0000 DICT
+   5855 HD13        3.1490   -3.7930   22.6530 H       370 LEU392      0.0000 DICT
+   5856 HD21        1.0250   -3.4430   20.5680 H       370 LEU392      0.0000 DICT
+   5857 HD22        1.4900   -2.2080   21.5290 H       370 LEU392      0.0000 DICT
+   5858 HD23        1.5430   -2.0430   19.9050 H       370 LEU392      0.0000 DICT
+   5859 N           4.9380    1.0340   20.8890 N.am    371 ASN393      0.0000 BACKBONE|DICT|DIRECT
+   5860 CA          6.0270    1.9410   21.2160 C.3     371 ASN393      0.0000 BACKBONE|DICT|DIRECT
+   5861 C           6.9990    1.2490   22.1700 C.2     371 ASN393      0.0000 BACKBONE|DICT|DIRECT
+   5862 O           6.7920    0.1050   22.5880 O.2     371 ASN393      0.0000 BACKBONE|DICT|DIRECT
+   5863 CB          5.4960    3.2670   21.7750 C.3     371 ASN393      0.0000 DICT
+   5864 CG          4.7940    3.1310   23.1270 C.2     371 ASN393      0.0000 DICT
+   5865 OD1         5.1650    2.3210   23.9770 O.2     371 ASN393      0.0000 DICT
+   5866 ND2         3.7750    3.9590   23.3300 N.am    371 ASN393      0.0000 DICT
+   5867 H           4.0410    1.1480   21.3150 H       371 ASN393      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5868 HA          6.5210    2.1420   20.3700 H       371 ASN393      0.0000 BACKBONE|DICT|DIRECT
+   5869 HB2         4.8450    3.6470   21.1190 H       371 ASN393      0.0000 DICT
+   5870 HB3         6.2670    3.8950   21.8820 H       371 ASN393      0.0000 DICT
+   5871 HD21        3.5040    4.6030   22.6150 H       371 ASN393      0.0000 DICT|ESSENTIAL
+   5872 HD22        3.2790    3.9380   24.1980 H       371 ASN393      0.0000 DICT|ESSENTIAL
+   5873 N           8.0720    1.9630   22.5220 N.am    372 THR394      0.0000 BACKBONE|DICT|DIRECT
+   5874 CA          9.1600    1.3650   23.2920 C.3     372 THR394      0.0000 BACKBONE|DICT|DIRECT
+   5875 C           8.6570    0.7680   24.6010 C.2     372 THR394      0.0000 BACKBONE|DICT|DIRECT
+   5876 O           9.0310   -0.3520   24.9710 O.2     372 THR394      0.0000 BACKBONE|DICT|DIRECT
+   5877 CB         10.2390    2.4120   23.5640 C.3     372 THR394      0.0000 DICT
+   5878 OG1        10.7990    2.8550   22.3220 O.3     372 THR394      0.0000 DICT
+   5879 CG2        11.3360    1.8290   24.4300 C.3     372 THR394      0.0000 DICT
+   5880 H           8.1310    2.9240   22.2530 H       372 THR394      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5881 HA          9.5650    0.6310   22.7470 H       372 THR394      0.0000 BACKBONE|DICT|DIRECT
+   5882 HB          9.8280    3.1920   24.0360 H       372 THR394      0.0000 DICT
+   5883 HG1        11.7530    3.1210   22.4620 H       372 THR394      0.0000 DICT|ESSENTIAL
+   5884 HG21       12.0330    2.5260   24.5990 H       372 THR394      0.0000 DICT
+   5885 HG22       10.9480    1.5280   25.3010 H       372 THR394      0.0000 DICT
+   5886 HG23       11.7510    1.0490   23.9620 H       372 THR394      0.0000 DICT
+   5887 N           7.8010    1.5000   25.3120 N.am    373 PHE395      0.0000 BACKBONE|DICT|DIRECT
+   5888 CA          7.3230    1.0280   26.6060 C.3     373 PHE395      0.0000 BACKBONE|DICT|DIRECT
+   5889 C           6.2450   -0.0360   26.4560 C.2     373 PHE395      0.0000 BACKBONE|DICT|DIRECT
+   5890 O           6.1820   -0.9740   27.2600 O.2     373 PHE395      0.0000 BACKBONE|DICT|DIRECT
+   5891 CB          6.8160    2.2090   27.4300 C.3     373 PHE395      0.0000 DICT
+   5892 CG          7.8830    3.2100   27.7550 C.ar    373 PHE395      0.0000 DICT
+   5893 CD1         8.1990    4.2230   26.8610 C.ar    373 PHE395      0.0000 DICT
+   5894 CD2         8.5880    3.1270   28.9430 C.ar    373 PHE395      0.0000 DICT
+   5895 CE1         9.1910    5.1430   27.1510 C.ar    373 PHE395      0.0000 DICT
+   5896 CE2         9.5820    4.0450   29.2400 C.ar    373 PHE395      0.0000 DICT
+   5897 CZ          9.8830    5.0530   28.3410 C.ar    373 PHE395      0.0000 DICT
+   5898 H           7.4840    2.3790   24.9560 H       373 PHE395      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5899 HA          8.0960    0.6200   27.0920 H       373 PHE395      0.0000 BACKBONE|DICT|DIRECT
+   5900 HB2         6.4380    1.8590   28.2870 H       373 PHE395      0.0000 DICT
+   5901 HB3         6.0950    2.6710   26.9120 H       373 PHE395      0.0000 DICT
+   5902 HD1         7.7030    4.2890   25.9950 H       373 PHE395      0.0000 DICT
+   5903 HD2         8.3780    2.3970   29.5930 H       373 PHE395      0.0000 DICT
+   5904 HE1         9.4060    5.8710   26.5000 H       373 PHE395      0.0000 DICT
+   5905 HE2        10.0820    3.9790   30.1040 H       373 PHE395      0.0000 DICT
+   5906 HZ         10.6010    5.7150   28.5540 H       373 PHE395      0.0000 DICT
+   5907 N           5.3960    0.0870   25.4340 N.am    374 GLU396      0.0000 BACKBONE|DICT|DIRECT
+   5908 CA          4.3750   -0.9290   25.1980 C.3     374 GLU396      0.0000 BACKBONE|DICT|DIRECT
+   5909 C           5.0050   -2.2750   24.8710 C.2     374 GLU396      0.0000 BACKBONE|DICT|DIRECT
+   5910 O           4.5740   -3.3130   25.3890 O.2     374 GLU396      0.0000 BACKBONE|DICT|DIRECT
+   5911 CB          3.4420   -0.4900   24.0710 C.3     374 GLU396      0.0000 DICT
+   5912 CG          2.5140    0.6510   24.4390 C.3     374 GLU396      0.0000 DICT
+   5913 CD          1.7970    1.2160   23.2360 C.2     374 GLU396      0.0000 DICT
+   5914 OE1         2.4000    1.2360   22.1380 O.co2   374 GLU396      0.0000 DICT
+   5915 OE2         0.6310    1.6370   23.3890 O.co2   374 GLU396      0.0000 DICT
+   5916 H           5.4600    0.8790   24.8270 H       374 GLU396      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5917 HA          3.8340   -1.0300   26.0330 H       374 GLU396      0.0000 BACKBONE|DICT|DIRECT
+   5918 HB2         2.8830   -1.2750   23.8040 H       374 GLU396      0.0000 DICT
+   5919 HB3         4.0030   -0.2000   23.2950 H       374 GLU396      0.0000 DICT
+   5920 HG2         3.0520    1.3790   24.8640 H       374 GLU396      0.0000 DICT
+   5921 HG3         1.8340    0.3150   25.0910 H       374 GLU396      0.0000 DICT
+   5922 N           6.0320   -2.2800   24.0180 N.am    375 PHE397      0.0000 BACKBONE|DICT|DIRECT
+   5923 CA          6.6760   -3.5380   23.6570 C.3     375 PHE397      0.0000 BACKBONE|DICT|DIRECT
+   5924 C           7.3470   -4.1760   24.8690 C.2     375 PHE397      0.0000 BACKBONE|DICT|DIRECT
+   5925 O           7.1940   -5.3780   25.1120 O.2     375 PHE397      0.0000 BACKBONE|DICT|DIRECT
+   5926 CB          7.6830   -3.3160   22.5280 C.3     375 PHE397      0.0000 DICT
+   5927 CG          8.2610   -4.5890   21.9840 C.ar    375 PHE397      0.0000 DICT
+   5928 CD1         7.4740   -5.4590   21.2440 C.ar    375 PHE397      0.0000 DICT
+   5929 CD2         9.5830   -4.9250   22.2200 C.ar    375 PHE397      0.0000 DICT
+   5930 CE1         7.9970   -6.6360   20.7460 C.ar    375 PHE397      0.0000 DICT
+   5931 CE2        10.1130   -6.1000   21.7230 C.ar    375 PHE397      0.0000 DICT
+   5932 CZ          9.3180   -6.9590   20.9840 C.ar    375 PHE397      0.0000 DICT
+   5933 H           6.3600   -1.4200   23.6260 H       375 PHE397      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5934 HA          5.9710   -4.1650   23.3260 H       375 PHE397      0.0000 BACKBONE|DICT|DIRECT
+   5935 HB2         8.4310   -2.7520   22.8770 H       375 PHE397      0.0000 DICT
+   5936 HB3         7.2220   -2.8340   21.7830 H       375 PHE397      0.0000 DICT
+   5937 HD1         6.5160   -5.2310   21.0690 H       375 PHE397      0.0000 DICT
+   5938 HD2        10.1610   -4.3100   22.7560 H       375 PHE397      0.0000 DICT
+   5939 HE1         7.4190   -7.2540   20.2130 H       375 PHE397      0.0000 DICT
+   5940 HE2        11.0710   -6.3300   21.8970 H       375 PHE397      0.0000 DICT
+   5941 HZ          9.6990   -7.8100   20.6240 H       375 PHE397      0.0000 DICT
+   5942 N           8.0910   -3.3800   25.6480 N.am    376 MET398      0.0000 BACKBONE|DICT|DIRECT
+   5943 CA          8.7180   -3.9070   26.8580 C.3     376 MET398      0.0000 BACKBONE|DICT|DIRECT
+   5944 C           7.6780   -4.4630   27.8230 C.2     376 MET398      0.0000 BACKBONE|DICT|DIRECT
+   5945 O           7.9070   -5.4930   28.4690 O.2     376 MET398      0.0000 BACKBONE|DICT|DIRECT
+   5946 CB          9.5560   -2.8250   27.5450 C.3     376 MET398      0.0000 DICT
+   5947 CG         10.9030   -2.5440   26.8840 C.3     376 MET398      0.0000 DICT
+   5948 SD         12.0000   -3.9810   26.8600 S.3     376 MET398      0.0000 DICT
+   5949 CE         12.0840   -4.3710   28.6080 C.3     376 MET398      0.0000 DICT
+   5950 H           8.2180   -2.4200   25.4000 H       376 MET398      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5951 HA          9.3290   -4.6530   26.5930 H       376 MET398      0.0000 BACKBONE|DICT|DIRECT
+   5952 HB2         9.7260   -3.1140   28.4870 H       376 MET398      0.0000 DICT
+   5953 HB3         9.0270   -1.9760   27.5470 H       376 MET398      0.0000 DICT
+   5954 HG2        11.3560   -1.8070   27.3860 H       376 MET398      0.0000 DICT
+   5955 HG3        10.7400   -2.2530   25.9410 H       376 MET398      0.0000 DICT
+   5956 HE1        12.6740   -5.1670   28.7440 H       376 MET398      0.0000 DICT
+   5957 HE2        12.4590   -3.5890   29.1060 H       376 MET398      0.0000 DICT
+   5958 HE3        11.1660   -4.5740   28.9490 H       376 MET398      0.0000 DICT
+   5959 N           6.5250   -3.7980   27.9320 N.am    377 ASP399      0.0000 BACKBONE|DICT|DIRECT
+   5960 CA          5.4640   -4.3240   28.7840 C.3     377 ASP399      0.0000 BACKBONE|DICT|DIRECT
+   5961 C           4.9090   -5.6290   28.2280 C.2     377 ASP399      0.0000 BACKBONE|DICT|DIRECT
+   5962 O           4.6190   -6.5580   28.9910 O.2     377 ASP399      0.0000 BACKBONE|DICT|DIRECT
+   5963 CB          4.3530   -3.2880   28.9500 C.3     377 ASP399      0.0000 DICT
+   5964 CG          4.6730   -2.2580   30.0190 C.2     377 ASP399      0.0000 DICT
+   5965 OD1         5.5370   -2.5410   30.8760 O.co2   377 ASP399      0.0000 DICT
+   5966 OD2         4.0590   -1.1710   30.0100 O.co2   377 ASP399      0.0000 DICT
+   5967 H           6.3890   -2.9430   27.4320 H       377 ASP399      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5968 HA          5.8530   -4.5110   29.6860 H       377 ASP399      0.0000 BACKBONE|DICT|DIRECT
+   5969 HB2         3.5090   -3.7610   29.2030 H       377 ASP399      0.0000 DICT
+   5970 HB3         4.2220   -2.8160   28.0780 H       377 ASP399      0.0000 DICT
+   5971 N           4.7730   -5.7270   26.9020 N.am    378 LYS400      0.0000 BACKBONE|DICT|DIRECT
+   5972 CA          4.2590   -6.9570   26.3040 C.3     378 LYS400      0.0000 BACKBONE|DICT|DIRECT
+   5973 C           5.2010   -8.1280   26.5570 C.2     378 LYS400      0.0000 BACKBONE|DICT|DIRECT
+   5974 O           4.7540   -9.2340   26.8840 O.2     378 LYS400      0.0000 BACKBONE|DICT|DIRECT
+   5975 CB          4.0320   -6.7640   24.8050 C.3     378 LYS400      0.0000 DICT
+   5976 CG          3.2820   -7.9100   24.1460 C.3     378 LYS400      0.0000 DICT
+   5977 CD          1.8870   -8.0480   24.7270 C.3     378 LYS400      0.0000 DICT
+   5978 CE          1.0810   -9.1100   23.9990 C.3     378 LYS400      0.0000 DICT
+   5979 NZ         -0.3160   -9.1840   24.5110 N.4     378 LYS400      0.0000 DICT
+   5980 H           5.0240   -4.9560   26.3170 H       378 LYS400      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   5981 HA          3.3780   -7.1670   26.7290 H       378 LYS400      0.0000 BACKBONE|DICT|DIRECT
+   5982 HB2         4.9230   -6.6730   24.3600 H       378 LYS400      0.0000 DICT
+   5983 HB3         3.5060   -5.9240   24.6710 H       378 LYS400      0.0000 DICT
+   5984 HG2         3.7850   -8.7610   24.2970 H       378 LYS400      0.0000 DICT
+   5985 HG3         3.2120   -7.7340   23.1640 H       378 LYS400      0.0000 DICT
+   5986 HD2         1.4140   -7.1700   24.6480 H       378 LYS400      0.0000 DICT
+   5987 HD3         1.9610   -8.3010   25.6920 H       378 LYS400      0.0000 DICT
+   5988 HE2         1.5220   -9.9980   24.1290 H       378 LYS400      0.0000 DICT
+   5989 HE3         1.0580   -8.8890   23.0240 H       378 LYS400      0.0000 DICT
+   5990 HZ1        -0.8170   -9.8910   24.0120 H       378 LYS400      0.0000 DICT|ESSENTIAL
+   5991 HZ2        -0.3030   -9.4100   25.4850 H       378 LYS400      0.0000 DICT|ESSENTIAL
+   5992 HZ3        -0.7660   -8.3010   24.3800 H       378 LYS400      0.0000 DICT|ESSENTIAL
+   5993 N           6.5100   -7.9060   26.4070 N.am    379 LEU401      0.0000 BACKBONE|DICT|DIRECT
+   5994 CA          7.4770   -8.9390   26.7630 C.3     379 LEU401      0.0000 BACKBONE|DICT|DIRECT
+   5995 C           7.3800   -9.2880   28.2400 C.2     379 LEU401      0.0000 BACKBONE|DICT|DIRECT
+   5996 O           7.5030  -10.4590   28.6190 O.2     379 LEU401      0.0000 BACKBONE|DICT|DIRECT
+   5997 CB          8.8920   -8.4770   26.4220 C.3     379 LEU401      0.0000 DICT
+   5998 CG          9.2200   -8.2060   24.9570 C.3     379 LEU401      0.0000 DICT
+   5999 CD1        10.5970   -7.5830   24.8520 C.3     379 LEU401      0.0000 DICT
+   6000 CD2         9.1560   -9.4920   24.1660 C.3     379 LEU401      0.0000 DICT
+   6001 H           6.8280   -7.0280   26.0490 H       379 LEU401      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6002 HA          7.2740   -9.7600   26.2290 H       379 LEU401      0.0000 BACKBONE|DICT|DIRECT
+   6003 HB2         9.5220   -9.1850   26.7420 H       379 LEU401      0.0000 DICT
+   6004 HB3         9.0580   -7.6300   26.9260 H       379 LEU401      0.0000 DICT
+   6005 HG          8.5460   -7.5660   24.5880 H       379 LEU401      0.0000 DICT
+   6006 HD11       10.8100   -7.4060   23.8910 H       379 LEU401      0.0000 DICT
+   6007 HD12       10.6130   -6.7220   25.3610 H       379 LEU401      0.0000 DICT
+   6008 HD13       11.2760   -8.2090   25.2340 H       379 LEU401      0.0000 DICT
+   6009 HD21        9.3720   -9.3050   23.2080 H       379 LEU401      0.0000 DICT
+   6010 HD22        9.8180  -10.1440   24.5360 H       379 LEU401      0.0000 DICT
+   6011 HD23        8.2360   -9.8780   24.2310 H       379 LEU401      0.0000 DICT
+   6012 N           7.1590   -8.2810   29.0890 N.am    380 GLY402      0.0000 BACKBONE|DICT|DIRECT
+   6013 CA          7.0170   -8.5390   30.5130 C.3     380 GLY402      0.0000 BACKBONE|DICT|DIRECT
+   6014 C           5.8680   -9.4780   30.8250 C.2     380 GLY402      0.0000 BACKBONE|DICT|DIRECT
+   6015 O           6.0360  -10.4610   31.5510 O.2     380 GLY402      0.0000 BACKBONE|DICT|DIRECT
+   6016 H           7.0910   -7.3450   28.7440 H       380 GLY402      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6017 HA2         6.8560   -7.6700   30.9810 H       380 GLY402      0.0000 BACKBONE|DICT|DIRECT
+   6018 HA3         7.8650   -8.9480   30.8500 H       380 GLY402      0.0000 DICT
+   6019 N           4.6820   -9.1870   30.2790 N.am    381 GLU403      0.0000 BACKBONE|DICT|DIRECT
+   6020 CA          3.5310  -10.0640   30.4840 C.3     381 GLU403      0.0000 BACKBONE|DICT|DIRECT
+   6021 C           3.8390  -11.4850   30.0330 C.2     381 GLU403      0.0000 BACKBONE|DICT|DIRECT
+   6022 O           3.6520  -12.4440   30.7910 O.2     381 GLU403      0.0000 BACKBONE|DICT|DIRECT
+   6023 CB          2.3070   -9.5390   29.7320 C.3     381 GLU403      0.0000 DICT
+   6024 CG          2.0840   -8.0470   29.7830 C.3     381 GLU403      0.0000 DICT
+   6025 CD          0.8670   -7.6240   28.9690 C.2     381 GLU403      0.0000 DICT
+   6026 OE1         0.1810   -8.5110   28.4130 O.co2   381 GLU403      0.0000 DICT
+   6027 OE2         0.5970   -6.4070   28.8580 O.co2   381 GLU403      0.0000 DICT
+   6028 H           4.5820   -8.3610   29.7250 H       381 GLU403      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6029 HA          3.3180  -10.0820   31.4610 H       381 GLU403      0.0000 BACKBONE|DICT|DIRECT
+   6030 HB2         1.4980   -9.9820   30.1190 H       381 GLU403      0.0000 DICT
+   6031 HB3         2.4030   -9.8010   28.7720 H       381 GLU403      0.0000 DICT
+   6032 HG2         2.8930   -7.5870   29.4170 H       381 GLU403      0.0000 DICT
+   6033 HG3         1.9470   -7.7730   30.7350 H       381 GLU403      0.0000 DICT
+   6034 N           4.3260  -11.6380   28.7990 N.am    382 ASN404      0.0000 BACKBONE|DICT|DIRECT
+   6035 CA          4.5600  -12.9710   28.2540 C.3     382 ASN404      0.0000 BACKBONE|DICT|DIRECT
+   6036 C           5.6670  -13.7060   28.9980 C.2     382 ASN404      0.0000 BACKBONE|DICT|DIRECT
+   6037 O           5.6110  -14.9340   29.1240 O.2     382 ASN404      0.0000 BACKBONE|DICT|DIRECT
+   6038 CB          4.8780  -12.8780   26.7640 C.3     382 ASN404      0.0000 DICT
+   6039 CG          3.7030  -12.3740   25.9560 C.2     382 ASN404      0.0000 DICT
+   6040 OD1         2.5680  -12.3790   26.4300 O.2     382 ASN404      0.0000 DICT
+   6041 ND2         3.9650  -11.9410   24.7290 N.am    382 ASN404      0.0000 DICT
+   6042 H           4.5320  -10.8320   28.2440 H       382 ASN404      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6043 HA          3.7170  -13.4980   28.3570 H       382 ASN404      0.0000 BACKBONE|DICT|DIRECT
+   6044 HB2         5.1300  -13.7870   26.4320 H       382 ASN404      0.0000 DICT
+   6045 HB3         5.6470  -12.2520   26.6380 H       382 ASN404      0.0000 DICT
+   6046 HD21        4.9030  -11.9550   24.3840 H       382 ASN404      0.0000 DICT|ESSENTIAL
+   6047 HD22        3.2240  -11.6010   24.1500 H       382 ASN404      0.0000 DICT|ESSENTIAL
+   6048 N           6.6730  -12.9850   29.5000 N.am    383 LEU405      0.0000 BACKBONE|DICT|DIRECT
+   6049 CA          7.7020  -13.6360   30.3060 C.3     383 LEU405      0.0000 BACKBONE|DICT|DIRECT
+   6050 C           7.1280  -14.1440   31.6240 C.2     383 LEU405      0.0000 BACKBONE|DICT|DIRECT
+   6051 O           7.4460  -15.2580   32.0590 O.2     383 LEU405      0.0000 BACKBONE|DICT|DIRECT
+   6052 CB          8.8630  -12.6750   30.5620 C.3     383 LEU405      0.0000 DICT
+   6053 CG          9.9920  -13.2440   31.4260 C.3     383 LEU405      0.0000 DICT
+   6054 CD1        10.6870  -14.3980   30.7120 C.3     383 LEU405      0.0000 DICT
+   6055 CD2        10.9900  -12.1620   31.8110 C.3     383 LEU405      0.0000 DICT
+   6056 H           6.7210  -12.0020   29.3240 H       383 LEU405      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6057 HA          8.0520  -14.4200   29.7940 H       383 LEU405      0.0000 BACKBONE|DICT|DIRECT
+   6058 HB2         8.5000  -11.8640   31.0200 H       383 LEU405      0.0000 DICT
+   6059 HB3         9.2500  -12.4130   29.6780 H       383 LEU405      0.0000 DICT
+   6060 HG          9.5860  -13.6020   32.2670 H       383 LEU405      0.0000 DICT
+   6061 HD11       11.4200  -14.7550   31.2910 H       383 LEU405      0.0000 DICT
+   6062 HD12       10.0240  -15.1240   30.5270 H       383 LEU405      0.0000 DICT
+   6063 HD13       11.0730  -14.0720   29.8490 H       383 LEU405      0.0000 DICT
+   6064 HD21       11.7140  -12.5610   32.3730 H       383 LEU405      0.0000 DICT
+   6065 HD22       11.3900  -11.7680   30.9840 H       383 LEU405      0.0000 DICT
+   6066 HD23       10.5220  -11.4460   32.3290 H       383 LEU405      0.0000 DICT
+   6067 N           6.2840  -13.3380   32.2730 N.am    384 LYS406      0.0000 BACKBONE|DICT|DIRECT
+   6068 CA          5.6340  -13.7740   33.5050 C.3     384 LYS406      0.0000 BACKBONE|DICT|DIRECT
+   6069 C           4.7670  -15.0020   33.2560 C.2     384 LYS406      0.0000 BACKBONE|DICT|DIRECT
+   6070 O           4.8500  -15.9960   33.9870 O.2     384 LYS406      0.0000 BACKBONE|DICT|DIRECT
+   6071 CB          4.8050  -12.6250   34.0810 C.3     384 LYS406      0.0000 DICT
+   6072 CG          4.1140  -12.9230   35.4040 C.3     384 LYS406      0.0000 DICT
+   6073 CD          3.2920  -11.7210   35.8530 C.3     384 LYS406      0.0000 DICT
+   6074 CE          2.5640  -11.9900   37.1600 C.3     384 LYS406      0.0000 DICT
+   6075 NZ          1.6930  -10.8450   37.5520 N.4     384 LYS406      0.0000 DICT
+   6076 H           6.0950  -12.4250   31.9110 H       384 LYS406      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6077 HA          6.3430  -14.0160   34.1680 H       384 LYS406      0.0000 BACKBONE|DICT|DIRECT
+   6078 HB2         4.1020  -12.3850   33.4120 H       384 LYS406      0.0000 DICT
+   6079 HB3         5.4140  -11.8440   34.2190 H       384 LYS406      0.0000 DICT
+   6080 HG2         4.8040  -13.1290   36.0980 H       384 LYS406      0.0000 DICT
+   6081 HG3         3.5100  -13.7120   35.2910 H       384 LYS406      0.0000 DICT
+   6082 HD2         2.6180  -11.5070   35.1460 H       384 LYS406      0.0000 DICT
+   6083 HD3         3.9030  -10.9400   35.9780 H       384 LYS406      0.0000 DICT
+   6084 HE2         3.2390  -12.1450   37.8810 H       384 LYS406      0.0000 DICT
+   6085 HE3         1.9970  -12.8070   37.0530 H       384 LYS406      0.0000 DICT
+   6086 HZ1         1.2320  -11.0570   38.4130 H       384 LYS406      0.0000 DICT|ESSENTIAL
+   6087 HZ2         2.2530  -10.0240   37.6670 H       384 LYS406      0.0000 DICT|ESSENTIAL
+   6088 HZ3         1.0110  -10.6860   36.8390 H       384 LYS406      0.0000 DICT|ESSENTIAL
+   6089 N           3.9370  -14.9520   32.2120 N.am    385 ILE407      0.0000 BACKBONE|DICT|DIRECT
+   6090 CA          3.1170  -16.1000   31.8310 C.3     385 ILE407      0.0000 BACKBONE|DICT|DIRECT
+   6091 C           3.9930  -17.3140   31.5490 C.2     385 ILE407      0.0000 BACKBONE|DICT|DIRECT
+   6092 O           3.7650  -18.4050   32.0860 O.2     385 ILE407      0.0000 BACKBONE|DICT|DIRECT
+   6093 CB          2.2460  -15.7480   30.6110 C.3     385 ILE407      0.0000 DICT
+   6094 CG1         1.2150  -14.6810   30.9760 C.3     385 ILE407      0.0000 DICT
+   6095 CG2         1.5850  -16.9970   30.0450 C.3     385 ILE407      0.0000 DICT
+   6096 CD1         0.4820  -14.1210   29.7780 C.3     385 ILE407      0.0000 DICT
+   6097 H           3.8750  -14.1090   31.6780 H       385 ILE407      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6098 HA          2.5120  -16.3210   32.5960 H       385 ILE407      0.0000 BACKBONE|DICT|DIRECT
+   6099 HB          2.8440  -15.3690   29.9050 H       385 ILE407      0.0000 DICT
+   6100 HG12        1.6860  -13.9300   31.4390 H       385 ILE407      0.0000 DICT
+   6101 HG13        0.5440  -15.0870   31.5970 H       385 ILE407      0.0000 DICT
+   6102 HG21        1.0250  -16.7490   29.2550 H       385 ILE407      0.0000 DICT
+   6103 HG22        2.2890  -17.6480   29.7630 H       385 ILE407      0.0000 DICT
+   6104 HG23        1.0070  -17.4150   30.7460 H       385 ILE407      0.0000 DICT
+   6105 HD11       -0.1750  -13.4310   30.0820 H       385 ILE407      0.0000 DICT
+   6106 HD12        1.1390  -13.7020   29.1510 H       385 ILE407      0.0000 DICT
+   6107 HD13       -0.0030  -14.8590   29.3090 H       385 ILE407      0.0000 DICT
+   6108 N           5.0100  -17.1380   30.7010 N.am    386 LYS408      0.0000 BACKBONE|DICT|DIRECT
+   6109 CA          5.8490  -18.2560   30.2760 C.3     386 LYS408      0.0000 BACKBONE|DICT|DIRECT
+   6110 C           6.4880  -18.9630   31.4650 C.2     386 LYS408      0.0000 BACKBONE|DICT|DIRECT
+   6111 O           6.4550  -20.1940   31.5610 O.2     386 LYS408      0.0000 BACKBONE|DICT|DIRECT
+   6112 CB          6.9250  -17.7560   29.3140 C.3     386 LYS408      0.0000 DICT
+   6113 CG          7.8530  -18.8350   28.7990 C.3     386 LYS408      0.0000 DICT
+   6114 CD          7.6450  -19.0480   27.3120 C.3     386 LYS408      0.0000 DICT
+   6115 CE          8.5970  -20.0940   26.7760 C.3     386 LYS408      0.0000 DICT
+   6116 NZ          8.4740  -20.2450   25.3010 N.4     386 LYS408      0.0000 DICT
+   6117 H           5.2010  -16.2210   30.3500 H       386 LYS408      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6118 HA          5.2740  -18.9140   29.7900 H       386 LYS408      0.0000 BACKBONE|DICT|DIRECT
+   6119 HB2         7.4760  -17.0700   29.7900 H       386 LYS408      0.0000 DICT
+   6120 HB3         6.4710  -17.3330   28.5300 H       386 LYS408      0.0000 DICT
+   6121 HG2         7.6650  -19.6890   29.2830 H       386 LYS408      0.0000 DICT
+   6122 HG3         8.8000  -18.5600   28.9630 H       386 LYS408      0.0000 DICT
+   6123 HD2         7.8040  -18.1850   26.8330 H       386 LYS408      0.0000 DICT
+   6124 HD3         6.7050  -19.3490   27.1530 H       386 LYS408      0.0000 DICT
+   6125 HE2         8.3920  -20.9710   27.2100 H       386 LYS408      0.0000 DICT
+   6126 HE3         9.5340  -19.8230   26.9970 H       386 LYS408      0.0000 DICT
+   6127 HZ1         9.3560  -20.5220   24.9200 H       386 LYS408      0.0000 DICT|ESSENTIAL
+   6128 HZ2         7.7870  -20.9420   25.0930 H       386 LYS408      0.0000 DICT|ESSENTIAL
+   6129 HZ3         8.1960  -19.3730   24.8990 H       386 LYS408      0.0000 DICT|ESSENTIAL
+   6130 N           7.0850  -18.1960   32.3810 N.am    387 LEU409      0.0000 BACKBONE|DICT|DIRECT
+   6131 CA          7.7590  -18.8020   33.5250 C.3     387 LEU409      0.0000 BACKBONE|DICT|DIRECT
+   6132 C           6.7660  -19.4790   34.4630 C.2     387 LEU409      0.0000 BACKBONE|DICT|DIRECT
+   6133 O           7.0490  -20.5560   35.0000 O.2     387 LEU409      0.0000 BACKBONE|DICT|DIRECT
+   6134 CB          8.5700  -17.7450   34.2750 C.3     387 LEU409      0.0000 DICT
+   6135 CG          9.7530  -17.1320   33.5260 C.3     387 LEU409      0.0000 DICT
+   6136 CD1        10.2970  -15.9300   34.2820 C.3     387 LEU409      0.0000 DICT
+   6137 CD2        10.8440  -18.1700   33.3080 C.3     387 LEU409      0.0000 DICT
+   6138 H           7.0700  -17.2010   32.2820 H       387 LEU409      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6139 HA          8.3910  -19.4980   33.1830 H       387 LEU409      0.0000 BACKBONE|DICT|DIRECT
+   6140 HB2         8.9250  -18.1700   35.1080 H       387 LEU409      0.0000 DICT
+   6141 HB3         7.9470  -17.0020   34.5190 H       387 LEU409      0.0000 DICT
+   6142 HG          9.4320  -16.8210   32.6310 H       387 LEU409      0.0000 DICT
+   6143 HD11       11.0690  -15.5420   33.7790 H       387 LEU409      0.0000 DICT
+   6144 HD12        9.5780  -15.2410   34.3740 H       387 LEU409      0.0000 DICT
+   6145 HD13       10.6010  -16.2170   35.1900 H       387 LEU409      0.0000 DICT
+   6146 HD21       11.6090  -17.7520   32.8170 H       387 LEU409      0.0000 DICT
+   6147 HD22       11.1620  -18.5100   34.1930 H       387 LEU409      0.0000 DICT
+   6148 HD23       10.4790  -18.9300   32.7700 H       387 LEU409      0.0000 DICT
+   6149 N           5.6000  -18.8600   34.6750 N.am    388 ALA410      0.0000 BACKBONE|DICT|DIRECT
+   6150 CA          4.6060  -19.4360   35.5770 C.3     388 ALA410      0.0000 BACKBONE|DICT|DIRECT
+   6151 C           4.1670  -20.8170   35.1080 C.2     388 ALA410      0.0000 BACKBONE|DICT|DIRECT
+   6152 O           3.9930  -21.7320   35.9220 O.2     388 ALA410      0.0000 BACKBONE|DICT|DIRECT
+   6153 CB          3.4020  -18.5020   35.6970 C.3     388 ALA410      0.0000 DICT
+   6154 H           5.4070  -17.9950   34.2120 H       388 ALA410      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6155 HA          5.0210  -19.5300   36.4820 H       388 ALA410      0.0000 BACKBONE|DICT|DIRECT
+   6156 HB1         2.7280  -18.9050   36.3160 H       388 ALA410      0.0000 DICT
+   6157 HB2         3.7000  -17.6190   36.0580 H       388 ALA410      0.0000 DICT
+   6158 HB3         2.9900  -18.3710   34.7950 H       388 ALA410      0.0000 DICT
+   6159 N           4.0030  -20.9940   33.7970 N.am    389 GLN411      0.0000 BACKBONE|DICT|DIRECT
+   6160 CA          3.5840  -22.2780   33.2480 C.3     389 GLN411      0.0000 BACKBONE|DICT|DIRECT
+   6161 C           4.7480  -23.2590   33.1970 C.2     389 GLN411      0.0000 BACKBONE|DICT|DIRECT
+   6162 O           4.9650  -23.9260   32.1800 O.2     389 GLN411      0.0000 BACKBONE|DICT|DIRECT
+   6163 CB          2.9770  -22.0880   31.8560 C.3     389 GLN411      0.0000 DICT
+   6164 CG          1.9020  -21.0130   31.8020 C.3     389 GLN411      0.0000 DICT
+   6165 CD          1.3070  -20.8460   30.4200 C.2     389 GLN411      0.0000 DICT
+   6166 OE1         0.0880  -20.8150   30.2560 O.2     389 GLN411      0.0000 DICT
+   6167 NE2         2.1720  -20.7410   29.4140 N.am    389 GLN411      0.0000 DICT
+   6168 H           4.1710  -20.2290   33.1760 H       389 GLN411      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6169 HA          2.8800  -22.6590   33.8470 H       389 GLN411      0.0000 BACKBONE|DICT|DIRECT
+   6170 HB2         2.5720  -22.9550   31.5670 H       389 GLN411      0.0000 DICT
+   6171 HB3         3.7090  -21.8350   31.2240 H       389 GLN411      0.0000 DICT
+   6172 HG2         2.3060  -20.1430   32.0830 H       389 GLN411      0.0000 DICT
+   6173 HG3         1.1700  -21.2610   32.4370 H       389 GLN411      0.0000 DICT
+   6174 HE21        3.1550  -20.7710   29.5950 H       389 GLN411      0.0000 DICT|ESSENTIAL
+   6175 HE22        1.8390  -20.6320   28.4770 H       389 GLN411      0.0000 DICT|ESSENTIAL
+   6176 N           5.4930  -23.3570   34.2930 N.am    390 ALA412      0.0000 BACKBONE|DICT|DIRECT
+   6177 CA          6.6040  -24.2940   34.4000 C.3     390 ALA412      0.0000 BACKBONE|DICT|DIRECT
+   6178 C           6.9130  -24.5700   35.8670 C.2     390 ALA412      0.0000 BACKBONE|DICT|DIRECT
+   6179 O           7.7540  -25.4080   36.1870 O.2     390 ALA412      0.0000 BACKBONE|DICT|DIRECT
+   6180 CB          7.8330  -23.7520   33.6850 C.3     390 ALA412      0.0000 DICT
+   6181 H           5.2840  -22.7670   35.0720 H       390 ALA412      0.0000 BACKBONE|DICT|ESSENTIAL|DIRECT
+   6182 HA          6.3370  -25.1540   33.9650 H       390 ALA412      0.0000 BACKBONE|DICT|DIRECT
+   6183 HB1         8.5840  -24.4070   33.7690 H       390 ALA412      0.0000 DICT
+   6184 HB2         7.6210  -23.6100   32.7180 H       390 ALA412      0.0000 DICT
+   6185 HB3         8.1020  -22.8820   34.0980 H       390 ALA412      0.0000 DICT
+@<TRIPOS>BOND
+     1    2   11 1    BACKBONE|DICT
+     2    2    3 1    BACKBONE|DICT
+     3    2    5 1    DICT
+     4    2    1 1    BACKBONE|DICT
+     5    1   10 1    BACKBONE|DICT
+     6    5   12 1    DICT
+     7    5   13 1    DICT
+     8    5    6 1    DICT
+     9    6   14 1    DICT
+    10    6   15 1    DICT
+    11    6    7 1    DICT
+    12    7   16 1    DICT
+    13    7   17 1    DICT
+    14    7    8 1    DICT
+    15    8   18 1    DICT
+    16    8   19 1    DICT
+    17    8    9 1    DICT
+    18    9   20 1    DICT
+    19    9   21 1    DICT
+    20    9   22 1    DICT
+    21    3    4 2    BACKBONE|DICT
+    22   24   33 1    BACKBONE|DICT
+    23   24   25 1    BACKBONE|DICT
+    24   24   27 1    DICT
+    25   24   23 1    BACKBONE|DICT
+    26   23   32 1    BACKBONE|DICT
+    27   27   34 1    DICT
+    28   27   35 1    DICT
+    29   27   28 1    DICT
+    30   28   36 1    DICT
+    31   28   37 1    DICT
+    32   28   29 1    DICT
+    33   29   38 1    DICT
+    34   29   39 1    DICT
+    35   29   30 1    DICT
+    36   30   40 1    DICT
+    37   30   41 1    DICT
+    38   30   31 1    DICT
+    39   31   42 1    DICT
+    40   31   43 1    DICT
+    41   31   44 1    DICT
+    42   25   26 2    BACKBONE|DICT
+    43   46   54 1    BACKBONE|DICT
+    44   46   47 1    BACKBONE|DICT
+    45   46   49 1    DICT
+    46   46   45 1    BACKBONE|DICT
+    47   45   53 1    BACKBONE|DICT
+    48   49   55 1    DICT
+    49   49   50 1    DICT
+    50   49   51 1    DICT
+    51   51   58 1    DICT
+    52   51   59 1    DICT
+    53   51   60 1    DICT
+    54   50   56 1    DICT
+    55   50   57 1    DICT
+    56   50   52 1    DICT
+    57   52   61 1    DICT
+    58   52   62 1    DICT
+    59   52   63 1    DICT
+    60   47   48 2    BACKBONE|DICT
+    61   65   71 1    BACKBONE|DICT
+    62   65   66 1    BACKBONE|DICT
+    63   65   68 1    DICT
+    64   65   64 1    BACKBONE|DICT
+    65   64   70 1    BACKBONE|DICT
+    66   68   72 1    DICT
+    67   68   73 1    DICT
+    68   68   69 1    DICT
+    69   69   74 1    DICT
+    70   66   67 2    BACKBONE|DICT
+    71   76   81 1    DICT
+    72   76   80 1    BACKBONE|DICT
+    73   76   77 1    BACKBONE|DICT
+    74   76   75 1    BACKBONE|DICT
+    75   75   79 1    BACKBONE|DICT
+    76   77   78 2    BACKBONE|DICT
+    77   83   88 1    DICT
+    78   83   87 1    BACKBONE|DICT
+    79   83   84 1    BACKBONE|DICT
+    80   83   82 1    BACKBONE|DICT
+    81   82   86 1    BACKBONE|DICT
+    82   84   85 2    BACKBONE|DICT
+    83   90   96 1    BACKBONE|DICT
+    84   90   91 1    BACKBONE|DICT
+    85   90   93 1    DICT
+    86   90   89 1    BACKBONE|DICT
+    87   89   95 1    BACKBONE|DICT
+    88   93   97 1    DICT
+    89   93   98 1    DICT
+    90   93   94 1    DICT
+    91   94   99 1    DICT
+    92   91   92 2    BACKBONE|DICT
+    93  101  108 1    BACKBONE|DICT
+    94  101  102 1    BACKBONE|DICT
+    95  101  104 1    DICT
+    96  101  100 1    BACKBONE|DICT
+    97  100  107 1    BACKBONE|DICT
+    98  104  109 1    DICT
+    99  104  105 1    DICT
+   100  104  106 1    DICT
+   101  106  113 1    DICT
+   102  106  114 1    DICT
+   103  106  115 1    DICT
+   104  105  110 1    DICT
+   105  105  111 1    DICT
+   106  105  112 1    DICT
+   107  102  103 2    BACKBONE|DICT
+   108  117  124 1    BACKBONE|DICT
+   109  117  118 1    BACKBONE|DICT
+   110  117  120 1    DICT
+   111  117  116 1    BACKBONE|DICT
+   112  116  123 1    BACKBONE|DICT
+   113  120  125 1    DICT
+   114  120  121 1    DICT
+   115  120  122 1    DICT
+   116  122  129 1    DICT
+   117  122  130 1    DICT
+   118  122  131 1    DICT
+   119  121  126 1    DICT
+   120  121  127 1    DICT
+   121  121  128 1    DICT
+   122  118  119 2    BACKBONE|DICT
+   123  133  142 1    BACKBONE|DICT
+   124  133  134 1    BACKBONE|DICT
+   125  133  136 1    DICT
+   126  133  132 1    BACKBONE|DICT
+   127  132  141 1    BACKBONE|DICT
+   128  136  143 1    DICT
+   129  136  144 1    DICT
+   130  136  137 1    DICT
+   131  137  145 1    DICT
+   132  137  146 1    DICT
+   133  137  138 1    DICT
+   134  138  139 ar   DICT
+   135  138  140 ar   DICT
+   136  134  135 2    BACKBONE|DICT
+   137  148  156 1    BACKBONE|DICT
+   138  148  149 1    BACKBONE|DICT
+   139  148  151 1    DICT
+   140  148  147 1    BACKBONE|DICT
+   141  147  155 1    BACKBONE|DICT
+   142  151  157 1    DICT
+   143  151  158 1    DICT
+   144  151  152 1    DICT
+   145  152  159 1    DICT
+   146  152  160 1    DICT
+   147  152  153 1    DICT
+   148  153  154 1    DICT
+   149  154  161 1    DICT
+   150  154  162 1    DICT
+   151  154  163 1    DICT
+   152  149  150 2    BACKBONE|DICT
+   153  165  174 1    BACKBONE|DICT
+   154  165  166 1    BACKBONE|DICT
+   155  165  168 1    DICT
+   156  165  164 1    BACKBONE|DICT
+   157  164  173 1    BACKBONE|DICT
+   158  168  175 1    DICT
+   159  168  176 1    DICT
+   160  168  169 1    DICT
+   161  169  177 1    DICT
+   162  169  178 1    DICT
+   163  169  170 1    DICT
+   164  170  171 2    DICT
+   165  170  172 am   DICT
+   166  172  180 1    DICT
+   167  172  179 1    DICT
+   168  166  167 2    BACKBONE|DICT
+   169  182  187 1    DICT
+   170  182  186 1    BACKBONE|DICT
+   171  182  183 1    BACKBONE|DICT
+   172  182  181 1    BACKBONE|DICT
+   173  181  185 1    BACKBONE|DICT
+   174  183  184 2    BACKBONE|DICT
+   175  189  197 1    BACKBONE|DICT
+   176  189  190 1    BACKBONE|DICT
+   177  189  192 1    DICT
+   178  189  188 1    BACKBONE|DICT
+   179  188  196 1    BACKBONE|DICT
+   180  192  198 1    DICT
+   181  192  199 1    DICT
+   182  192  193 1    DICT
+   183  193  195 ar   DICT
+   184  193  194 ar   DICT
+   185  190  191 2    BACKBONE|DICT
+   186  201  210 1    BACKBONE|DICT
+   187  201  202 1    BACKBONE|DICT
+   188  201  204 1    DICT
+   189  201  200 1    BACKBONE|DICT
+   190  200  209 1    BACKBONE|DICT
+   191  204  211 1    DICT
+   192  204  212 1    DICT
+   193  204  205 1    DICT
+   194  205  213 1    DICT
+   195  205  214 1    DICT
+   196  205  206 1    DICT
+   197  206  207 ar   DICT
+   198  206  208 ar   DICT
+   199  202  203 2    BACKBONE|DICT
+   200  216  224 1    BACKBONE|DICT
+   201  216  217 1    BACKBONE|DICT
+   202  216  219 1    DICT
+   203  216  215 1    BACKBONE|DICT
+   204  215  223 1    BACKBONE|DICT
+   205  219  225 1    DICT
+   206  219  226 1    DICT
+   207  219  220 1    DICT
+   208  220  227 1    DICT
+   209  220  228 1    DICT
+   210  220  221 1    DICT
+   211  221  222 1    DICT
+   212  222  229 1    DICT
+   213  222  230 1    DICT
+   214  222  231 1    DICT
+   215  217  218 2    BACKBONE|DICT
+   216  233  240 1    BACKBONE|DICT
+   217  233  234 1    BACKBONE|DICT
+   218  233  236 1    DICT
+   219  233  232 1    BACKBONE|DICT
+   220  232  239 1    BACKBONE|DICT
+   221  236  241 1    DICT
+   222  236  237 1    DICT
+   223  236  238 1    DICT
+   224  238  245 1    DICT
+   225  238  243 1    DICT
+   226  238  244 1    DICT
+   227  237  242 1    DICT
+   228  234  235 2    BACKBONE|DICT
+   229  247  258 1    BACKBONE|DICT
+   230  247  248 1    BACKBONE|DICT
+   231  247  250 1    DICT
+   232  247  246 1    BACKBONE|DICT
+   233  246  257 1    BACKBONE|DICT
+   234  250  259 1    DICT
+   235  250  260 1    DICT
+   236  250  251 1    DICT
+   237  251  261 1    DICT
+   238  251  262 1    DICT
+   239  251  252 1    DICT
+   240  252  263 1    DICT
+   241  252  264 1    DICT
+   242  252  253 1    DICT
+   243  253  265 1    DICT
+   244  253  254 ar   DICT
+   245  254  255 ar   DICT
+   246  254  256 ar   DICT
+   247  256  269 1    DICT
+   248  256  268 1    DICT
+   249  255  267 1    DICT
+   250  255  266 1    DICT
+   251  248  249 2    BACKBONE|DICT
+   252  271  279 1    BACKBONE|DICT
+   253  271  272 1    BACKBONE|DICT
+   254  271  274 1    DICT
+   255  271  270 1    BACKBONE|DICT
+   256  270  278 1    BACKBONE|DICT
+   257  274  280 1    DICT
+   258  274  275 1    DICT
+   259  274  276 1    DICT
+   260  276  283 1    DICT
+   261  276  284 1    DICT
+   262  276  285 1    DICT
+   263  275  281 1    DICT
+   264  275  282 1    DICT
+   265  275  277 1    DICT
+   266  277  286 1    DICT
+   267  277  287 1    DICT
+   268  277  288 1    DICT
+   269  272  273 2    BACKBONE|DICT
+   270  290  298 1    BACKBONE|DICT
+   271  290  291 1    BACKBONE|DICT
+   272  290  293 1    DICT
+   273  290  289 1    BACKBONE|DICT
+   274  289  297 1    BACKBONE|DICT
+   275  293  299 1    DICT
+   276  293  294 1    DICT
+   277  293  295 1    DICT
+   278  295  302 1    DICT
+   279  295  303 1    DICT
+   280  295  304 1    DICT
+   281  294  300 1    DICT
+   282  294  301 1    DICT
+   283  294  296 1    DICT
+   284  296  305 1    DICT
+   285  296  306 1    DICT
+   286  296  307 1    DICT
+   287  291  292 2    BACKBONE|DICT
+   288  309  323 1    BACKBONE|DICT
+   289  309  310 1    BACKBONE|DICT
+   290  309  312 1    DICT
+   291  309  308 1    BACKBONE|DICT
+   292  308  322 1    BACKBONE|DICT
+   293  312  324 1    DICT
+   294  312  325 1    DICT
+   295  312  313 1    DICT
+   296  313  315 1    DICT
+   297  313  314 2    DICT
+   298  314  326 1    DICT
+   299  314  316 1    DICT
+   300  316  327 1    DICT
+   301  316  317 1    DICT
+   302  317  319 ar   DICT
+   303  317  315 ar   DICT
+   304  315  318 ar   DICT
+   305  318  328 1    DICT
+   306  318  320 ar   DICT
+   307  320  330 1    DICT
+   308  320  321 ar   DICT
+   309  321  331 1    DICT
+   310  321  319 ar   DICT
+   311  319  329 1    DICT
+   312  310  311 2    BACKBONE|DICT
+   313  333  342 1    BACKBONE|DICT
+   314  333  334 1    BACKBONE|DICT
+   315  333  336 1    DICT
+   316  333  332 1    BACKBONE|DICT
+   317  332  341 1    BACKBONE|DICT
+   318  336  343 1    DICT
+   319  336  344 1    DICT
+   320  336  337 1    DICT
+   321  337  345 1    DICT
+   322  337  346 1    DICT
+   323  337  338 1    DICT
+   324  338  339 ar   DICT
+   325  338  340 ar   DICT
+   326  334  335 2    BACKBONE|DICT
+   327  348  356 1    BACKBONE|DICT
+   328  348  349 1    BACKBONE|DICT
+   329  348  351 1    DICT
+   330  348  347 1    BACKBONE|DICT
+   331  347  355 1    BACKBONE|DICT
+   332  351  357 1    DICT
+   333  351  358 1    DICT
+   334  351  352 1    DICT
+   335  352  359 1    DICT
+   336  352  354 1    DICT
+   337  352  353 1    DICT
+   338  353  360 1    DICT
+   339  353  361 1    DICT
+   340  353  362 1    DICT
+   341  354  363 1    DICT
+   342  354  364 1    DICT
+   343  354  365 1    DICT
+   344  349  350 2    BACKBONE|DICT
+   345  367  375 1    BACKBONE|DICT
+   346  367  368 1    BACKBONE|DICT
+   347  367  370 1    DICT
+   348  367  366 1    BACKBONE|DICT
+   349  366  374 1    BACKBONE|DICT
+   350  370  376 1    DICT
+   351  370  371 1    DICT
+   352  370  372 1    DICT
+   353  372  379 1    DICT
+   354  372  380 1    DICT
+   355  372  381 1    DICT
+   356  371  377 1    DICT
+   357  371  378 1    DICT
+   358  371  373 1    DICT
+   359  373  382 1    DICT
+   360  373  383 1    DICT
+   361  373  384 1    DICT
+   362  368  369 2    BACKBONE|DICT
+   363  386  395 1    BACKBONE|DICT
+   364  386  387 1    BACKBONE|DICT
+   365  386  389 1    DICT
+   366  386  385 1    BACKBONE|DICT
+   367  385  394 1    BACKBONE|DICT
+   368  389  396 1    DICT
+   369  389  397 1    DICT
+   370  389  390 1    DICT
+   371  390  398 1    DICT
+   372  390  399 1    DICT
+   373  390  391 1    DICT
+   374  391  400 1    DICT
+   375  391  401 1    DICT
+   376  391  392 1    DICT
+   377  392  402 1    DICT
+   378  392  403 1    DICT
+   379  392  393 1    DICT
+   380  393  404 1    DICT
+   381  393  405 1    DICT
+   382  393  406 1    DICT
+   383  387  388 2    BACKBONE|DICT
+   384  408  417 1    BACKBONE|DICT
+   385  408  409 1    BACKBONE|DICT
+   386  408  411 1    DICT
+   387  408  407 1    BACKBONE|DICT
+   388  407  416 1    BACKBONE|DICT
+   389  411  418 1    DICT
+   390  411  419 1    DICT
+   391  411  412 1    DICT
+   392  412  420 1    DICT
+   393  412  421 1    DICT
+   394  412  413 1    DICT
+   395  413  414 ar   DICT
+   396  413  415 ar   DICT
+   397  409  410 2    BACKBONE|DICT
+   398  423  432 1    BACKBONE|DICT
+   399  423  424 1    BACKBONE|DICT
+   400  423  426 1    DICT
+   401  423  422 1    BACKBONE|DICT
+   402  422  431 1    BACKBONE|DICT
+   403  426  433 1    DICT
+   404  426  434 1    DICT
+   405  426  427 1    DICT
+   406  427  435 1    DICT
+   407  427  436 1    DICT
+   408  427  428 1    DICT
+   409  428  437 1    DICT
+   410  428  438 1    DICT
+   411  428  429 1    DICT
+   412  429  439 1    DICT
+   413  429  440 1    DICT
+   414  429  430 1    DICT
+   415  430  441 1    DICT
+   416  430  442 1    DICT
+   417  430  443 1    DICT
+   418  424  425 2    BACKBONE|DICT
+   419  445  453 1    BACKBONE|DICT
+   420  445  446 1    BACKBONE|DICT
+   421  445  448 1    DICT
+   422  445  444 1    BACKBONE|DICT
+   423  444  452 1    BACKBONE|DICT
+   424  448  454 1    DICT
+   425  448  455 1    DICT
+   426  448  449 1    DICT
+   427  449  456 1    DICT
+   428  449  451 1    DICT
+   429  449  450 1    DICT
+   430  450  457 1    DICT
+   431  450  458 1    DICT
+   432  450  459 1    DICT
+   433  451  460 1    DICT
+   434  451  461 1    DICT
+   435  451  462 1    DICT
+   436  446  447 2    BACKBONE|DICT
+   437  464  472 1    BACKBONE|DICT
+   438  464  465 1    BACKBONE|DICT
+   439  464  467 1    DICT
+   440  464  463 1    BACKBONE|DICT
+   441  463  471 1    BACKBONE|DICT
+   442  467  473 1    DICT
+   443  467  468 1    DICT
+   444  467  469 1    DICT
+   445  469  476 1    DICT
+   446  469  477 1    DICT
+   447  469  478 1    DICT
+   448  468  474 1    DICT
+   449  468  475 1    DICT
+   450  468  470 1    DICT
+   451  470  479 1    DICT
+   452  470  480 1    DICT
+   453  470  481 1    DICT
+   454  465  466 2    BACKBONE|DICT
+   455  483  494 1    BACKBONE|DICT
+   456  483  484 1    BACKBONE|DICT
+   457  483  486 1    DICT
+   458  483  482 1    BACKBONE|DICT
+   459  482  493 1    BACKBONE|DICT
+   460  486  495 1    DICT
+   461  486  496 1    DICT
+   462  486  487 1    DICT
+   463  487  489 ar   DICT
+   464  487  488 ar   DICT
+   465  488  497 1    DICT
+   466  488  490 ar   DICT
+   467  490  499 1    DICT
+   468  490  492 ar   DICT
+   469  492  501 1    DICT
+   470  492  491 ar   DICT
+   471  491  500 1    DICT
+   472  491  489 ar   DICT
+   473  489  498 1    DICT
+   474  484  485 2    BACKBONE|DICT
+   475  503  509 1    BACKBONE|DICT
+   476  503  502 1    BACKBONE|DICT
+   477  503  506 1    DICT
+   478  503  504 1    BACKBONE|DICT
+   479  504  505 2    BACKBONE|DICT
+   480  506  510 1    DICT
+   481  506  511 1    DICT
+   482  506  507 1    DICT
+   483  507  513 1    DICT
+   484  507  512 1    DICT
+   485  507  508 1    DICT
+   486  508  515 1    DICT
+   487  508  514 1    DICT
+   488  508  502 1    DICT
+   489  517  529 1    BACKBONE|DICT
+   490  517  518 1    BACKBONE|DICT
+   491  517  520 1    DICT
+   492  517  516 1    BACKBONE|DICT
+   493  516  528 1    BACKBONE|DICT
+   494  520  531 1    DICT
+   495  520  530 1    DICT
+   496  520  521 1    DICT
+   497  521  523 ar   DICT
+   498  521  522 ar   DICT
+   499  522  532 1    DICT
+   500  522  524 ar   DICT
+   501  524  534 1    DICT
+   502  524  526 ar   DICT
+   503  526  527 1    DICT
+   504  526  525 ar   DICT
+   505  525  535 1    DICT
+   506  525  523 ar   DICT
+   507  523  533 1    DICT
+   508  527  536 1    DICT
+   509  518  519 2    BACKBONE|DICT
+   510  538  545 1    BACKBONE|DICT
+   511  538  539 1    BACKBONE|DICT
+   512  538  541 1    DICT
+   513  538  537 1    BACKBONE|DICT
+   514  537  544 1    BACKBONE|DICT
+   515  541  546 1    DICT
+   516  541  542 1    DICT
+   517  541  543 1    DICT
+   518  543  550 1    DICT
+   519  543  551 1    DICT
+   520  543  552 1    DICT
+   521  542  547 1    DICT
+   522  542  548 1    DICT
+   523  542  549 1    DICT
+   524  539  540 2    BACKBONE|DICT
+   525  554  563 1    BACKBONE|DICT
+   526  554  555 1    BACKBONE|DICT
+   527  554  557 1    DICT
+   528  554  553 1    BACKBONE|DICT
+   529  553  562 1    BACKBONE|DICT
+   530  557  564 1    DICT
+   531  557  565 1    DICT
+   532  557  558 1    DICT
+   533  558  566 1    DICT
+   534  558  567 1    DICT
+   535  558  559 1    DICT
+   536  559  560 ar   DICT
+   537  559  561 ar   DICT
+   538  555  556 2    BACKBONE|DICT
+   539  569  577 1    BACKBONE|DICT
+   540  569  570 1    BACKBONE|DICT
+   541  569  572 1    DICT
+   542  569  568 1    BACKBONE|DICT
+   543  568  576 1    BACKBONE|DICT
+   544  572  578 1    DICT
+   545  572  579 1    DICT
+   546  572  573 1    DICT
+   547  573  580 1    DICT
+   548  573  575 1    DICT
+   549  573  574 1    DICT
+   550  574  581 1    DICT
+   551  574  582 1    DICT
+   552  574  583 1    DICT
+   553  575  584 1    DICT
+   554  575  585 1    DICT
+   555  575  586 1    DICT
+   556  570  571 2    BACKBONE|DICT
+   557  588  596 1    BACKBONE|DICT
+   558  588  589 1    BACKBONE|DICT
+   559  588  591 1    DICT
+   560  588  587 1    BACKBONE|DICT
+   561  587  595 1    BACKBONE|DICT
+   562  591  597 1    DICT
+   563  591  598 1    DICT
+   564  591  592 1    DICT
+   565  592  594 ar   DICT
+   566  592  593 ar   DICT
+   567  589  590 2    BACKBONE|DICT
+   568  600  608 1    BACKBONE|DICT
+   569  600  601 1    BACKBONE|DICT
+   570  600  603 1    DICT
+   571  600  599 1    BACKBONE|DICT
+   572  599  607 1    BACKBONE|DICT
+   573  603  609 1    DICT
+   574  603  610 1    DICT
+   575  603  604 1    DICT
+   576  604  611 1    DICT
+   577  604  606 1    DICT
+   578  604  605 1    DICT
+   579  605  612 1    DICT
+   580  605  613 1    DICT
+   581  605  614 1    DICT
+   582  606  615 1    DICT
+   583  606  616 1    DICT
+   584  606  617 1    DICT
+   585  601  602 2    BACKBONE|DICT
+   586  619  629 1    BACKBONE|DICT
+   587  619  620 1    BACKBONE|DICT
+   588  619  622 1    DICT
+   589  619  618 1    BACKBONE|DICT
+   590  618  628 1    BACKBONE|DICT
+   591  622  630 1    DICT
+   592  622  631 1    DICT
+   593  622  623 1    DICT
+   594  623  625 2    DICT
+   595  623  624 1    DICT
+   596  624  632 1    DICT
+   597  624  626 1    DICT
+   598  626  634 1    DICT
+   599  626  627 2    DICT
+   600  627  625 1    DICT
+   601  625  633 1    DICT
+   602  620  621 2    BACKBONE|DICT
+   603  636  642 1    BACKBONE|DICT
+   604  636  637 1    BACKBONE|DICT
+   605  636  639 1    DICT
+   606  636  635 1    BACKBONE|DICT
+   607  635  641 1    BACKBONE|DICT
+   608  639  643 1    DICT
+   609  639  644 1    DICT
+   610  639  640 1    DICT
+   611  640  645 1    DICT
+   612  637  638 2    BACKBONE|DICT
+   613  647  659 1    BACKBONE|DICT
+   614  647  648 1    BACKBONE|DICT
+   615  647  650 1    DICT
+   616  647  646 1    BACKBONE|DICT
+   617  646  658 1    BACKBONE|DICT
+   618  650  661 1    DICT
+   619  650  660 1    DICT
+   620  650  651 1    DICT
+   621  651  653 ar   DICT
+   622  651  652 ar   DICT
+   623  652  662 1    DICT
+   624  652  654 ar   DICT
+   625  654  664 1    DICT
+   626  654  656 ar   DICT
+   627  656  657 1    DICT
+   628  656  655 ar   DICT
+   629  655  665 1    DICT
+   630  655  653 ar   DICT
+   631  653  663 1    DICT
+   632  657  666 1    DICT
+   633  648  649 2    BACKBONE|DICT
+   634  668  676 1    BACKBONE|DICT
+   635  668  669 1    BACKBONE|DICT
+   636  668  671 1    DICT
+   637  668  667 1    BACKBONE|DICT
+   638  667  675 1    BACKBONE|DICT
+   639  671  677 1    DICT
+   640  671  678 1    DICT
+   641  671  672 1    DICT
+   642  672  674 ar   DICT
+   643  672  673 ar   DICT
+   644  669  670 2    BACKBONE|DICT
+   645  680  688 1    BACKBONE|DICT
+   646  680  681 1    BACKBONE|DICT
+   647  680  683 1    DICT
+   648  680  679 1    BACKBONE|DICT
+   649  679  687 1    BACKBONE|DICT
+   650  683  689 1    DICT
+   651  683  690 1    DICT
+   652  683  684 1    DICT
+   653  684  691 1    DICT
+   654  684  686 1    DICT
+   655  684  685 1    DICT
+   656  685  692 1    DICT
+   657  685  693 1    DICT
+   658  685  694 1    DICT
+   659  686  695 1    DICT
+   660  686  696 1    DICT
+   661  686  697 1    DICT
+   662  681  682 2    BACKBONE|DICT
+   663  699  704 1    DICT
+   664  699  703 1    BACKBONE|DICT
+   665  699  700 1    BACKBONE|DICT
+   666  699  698 1    BACKBONE|DICT
+   667  698  702 1    BACKBONE|DICT
+   668  700  701 2    BACKBONE|DICT
+   669  706  714 1    BACKBONE|DICT
+   670  706  707 1    BACKBONE|DICT
+   671  706  709 1    DICT
+   672  706  705 1    BACKBONE|DICT
+   673  705  713 1    BACKBONE|DICT
+   674  709  715 1    DICT
+   675  709  710 1    DICT
+   676  709  711 1    DICT
+   677  711  718 1    DICT
+   678  711  719 1    DICT
+   679  711  720 1    DICT
+   680  710  716 1    DICT
+   681  710  717 1    DICT
+   682  710  712 1    DICT
+   683  712  721 1    DICT
+   684  712  722 1    DICT
+   685  712  723 1    DICT
+   686  707  708 2    BACKBONE|DICT
+   687  725  734 1    BACKBONE|DICT
+   688  725  726 1    BACKBONE|DICT
+   689  725  728 1    DICT
+   690  725  724 1    BACKBONE|DICT
+   691  724  733 1    BACKBONE|DICT
+   692  728  735 1    DICT
+   693  728  736 1    DICT
+   694  728  729 1    DICT
+   695  729  737 1    DICT
+   696  729  738 1    DICT
+   697  729  730 1    DICT
+   698  730  731 ar   DICT
+   699  730  732 ar   DICT
+   700  726  727 2    BACKBONE|DICT
+   701  740  748 1    BACKBONE|DICT
+   702  740  741 1    BACKBONE|DICT
+   703  740  743 1    DICT
+   704  740  739 1    BACKBONE|DICT
+   705  739  747 1    BACKBONE|DICT
+   706  743  749 1    DICT
+   707  743  750 1    DICT
+   708  743  744 1    DICT
+   709  744  745 2    DICT
+   710  744  746 am   DICT
+   711  746  752 1    DICT
+   712  746  751 1    DICT
+   713  741  742 2    BACKBONE|DICT
+   714  754  765 1    BACKBONE|DICT
+   715  754  755 1    BACKBONE|DICT
+   716  754  757 1    DICT
+   717  754  753 1    BACKBONE|DICT
+   718  753  764 1    BACKBONE|DICT
+   719  757  766 1    DICT
+   720  757  767 1    DICT
+   721  757  758 1    DICT
+   722  758  768 1    DICT
+   723  758  769 1    DICT
+   724  758  759 1    DICT
+   725  759  770 1    DICT
+   726  759  771 1    DICT
+   727  759  760 1    DICT
+   728  760  772 1    DICT
+   729  760  761 ar   DICT
+   730  761  762 ar   DICT
+   731  761  763 ar   DICT
+   732  763  776 1    DICT
+   733  763  775 1    DICT
+   734  762  774 1    DICT
+   735  762  773 1    DICT
+   736  755  756 2    BACKBONE|DICT
+   737  778  786 1    BACKBONE|DICT
+   738  778  779 1    BACKBONE|DICT
+   739  778  781 1    DICT
+   740  778  777 1    BACKBONE|DICT
+   741  777  785 1    BACKBONE|DICT
+   742  781  787 1    DICT
+   743  781  788 1    DICT
+   744  781  782 1    DICT
+   745  782  784 ar   DICT
+   746  782  783 ar   DICT
+   747  779  780 2    BACKBONE|DICT
+   748  790  795 1    BACKBONE|DICT
+   749  790  791 1    BACKBONE|DICT
+   750  790  793 1    DICT
+   751  790  789 1    BACKBONE|DICT
+   752  789  794 1    BACKBONE|DICT
+   753  793  796 1    DICT
+   754  793  797 1    DICT
+   755  793  798 1    DICT
+   756  791  792 2    BACKBONE|DICT
+   757  800  807 1    BACKBONE|DICT
+   758  800  801 1    BACKBONE|DICT
+   759  800  803 1    DICT
+   760  800  799 1    BACKBONE|DICT
+   761  799  806 1    BACKBONE|DICT
+   762  803  808 1    DICT
+   763  803  804 1    DICT
+   764  803  805 1    DICT
+   765  805  812 1    DICT
+   766  805  810 1    DICT
+   767  805  811 1    DICT
+   768  804  809 1    DICT
+   769  801  802 2    BACKBONE|DICT
+   770  814  822 1    BACKBONE|DICT
+   771  814  815 1    BACKBONE|DICT
+   772  814  817 1    DICT
+   773  814  813 1    BACKBONE|DICT
+   774  813  821 1    BACKBONE|DICT
+   775  817  823 1    DICT
+   776  817  824 1    DICT
+   777  817  818 1    DICT
+   778  818  819 2    DICT
+   779  818  820 am   DICT
+   780  820  826 1    DICT
+   781  820  825 1    DICT
+   782  815  816 2    BACKBONE|DICT
+   783  828  836 1    BACKBONE|DICT
+   784  828  829 1    BACKBONE|DICT
+   785  828  831 1    DICT
+   786  828  827 1    BACKBONE|DICT
+   787  827  835 1    BACKBONE|DICT
+   788  831  837 1    DICT
+   789  831  838 1    DICT
+   790  831  832 1    DICT
+   791  832  834 ar   DICT
+   792  832  833 ar   DICT
+   793  829  830 2    BACKBONE|DICT
+   794  840  849 1    BACKBONE|DICT
+   795  840  841 1    BACKBONE|DICT
+   796  840  843 1    DICT
+   797  840  839 1    BACKBONE|DICT
+   798  839  848 1    BACKBONE|DICT
+   799  843  850 1    DICT
+   800  843  851 1    DICT
+   801  843  844 1    DICT
+   802  844  852 1    DICT
+   803  844  853 1    DICT
+   804  844  845 1    DICT
+   805  845  846 2    DICT
+   806  845  847 am   DICT
+   807  847  855 1    DICT
+   808  847  854 1    DICT
+   809  841  842 2    BACKBONE|DICT
+   810  857  864 1    BACKBONE|DICT
+   811  857  858 1    BACKBONE|DICT
+   812  857  860 1    DICT
+   813  857  856 1    BACKBONE|DICT
+   814  856  863 1    BACKBONE|DICT
+   815  860  865 1    DICT
+   816  860  861 1    DICT
+   817  860  862 1    DICT
+   818  862  869 1    DICT
+   819  862  870 1    DICT
+   820  862  871 1    DICT
+   821  861  866 1    DICT
+   822  861  867 1    DICT
+   823  861  868 1    DICT
+   824  858  859 2    BACKBONE|DICT
+   825  873  880 1    BACKBONE|DICT
+   826  873  874 1    BACKBONE|DICT
+   827  873  876 1    DICT
+   828  873  872 1    BACKBONE|DICT
+   829  872  879 1    BACKBONE|DICT
+   830  876  881 1    DICT
+   831  876  877 1    DICT
+   832  876  878 1    DICT
+   833  878  885 1    DICT
+   834  878  883 1    DICT
+   835  878  884 1    DICT
+   836  877  882 1    DICT
+   837  874  875 2    BACKBONE|DICT
+   838  887  896 1    BACKBONE|DICT
+   839  887  888 1    BACKBONE|DICT
+   840  887  890 1    DICT
+   841  887  886 1    BACKBONE|DICT
+   842  886  895 1    BACKBONE|DICT
+   843  890  897 1    DICT
+   844  890  898 1    DICT
+   845  890  891 1    DICT
+   846  891  899 1    DICT
+   847  891  900 1    DICT
+   848  891  892 1    DICT
+   849  892  901 1    DICT
+   850  892  902 1    DICT
+   851  892  893 1    DICT
+   852  893  903 1    DICT
+   853  893  904 1    DICT
+   854  893  894 1    DICT
+   855  894  905 1    DICT
+   856  894  906 1    DICT
+   857  894  907 1    DICT
+   858  888  889 2    BACKBONE|DICT
+   859  909  917 1    BACKBONE|DICT
+   860  909  910 1    BACKBONE|DICT
+   861  909  912 1    DICT
+   862  909  908 1    BACKBONE|DICT
+   863  908  916 1    BACKBONE|DICT
+   864  912  918 1    DICT
+   865  912  919 1    DICT
+   866  912  913 1    DICT
+   867  913  915 ar   DICT
+   868  913  914 ar   DICT
+   869  910  911 2    BACKBONE|DICT
+   870  921  926 1    BACKBONE|DICT
+   871  921  922 1    BACKBONE|DICT
+   872  921  924 1    DICT
+   873  921  920 1    BACKBONE|DICT
+   874  920  925 1    BACKBONE|DICT
+   875  924  927 1    DICT
+   876  924  928 1    DICT
+   877  924  929 1    DICT
+   878  922  923 2    BACKBONE|DICT
+   879  931  936 1    BACKBONE|DICT
+   880  931  932 1    BACKBONE|DICT
+   881  931  934 1    DICT
+   882  931  930 1    BACKBONE|DICT
+   883  930  935 1    BACKBONE|DICT
+   884  934  937 1    DICT
+   885  934  938 1    DICT
+   886  934  939 1    DICT
+   887  932  933 2    BACKBONE|DICT
+   888  941  950 1    BACKBONE|DICT
+   889  941  942 1    BACKBONE|DICT
+   890  941  944 1    DICT
+   891  941  940 1    BACKBONE|DICT
+   892  940  949 1    BACKBONE|DICT
+   893  944  951 1    DICT
+   894  944  952 1    DICT
+   895  944  945 1    DICT
+   896  945  953 1    DICT
+   897  945  954 1    DICT
+   898  945  946 1    DICT
+   899  946  947 ar   DICT
+   900  946  948 ar   DICT
+   901  942  943 2    BACKBONE|DICT
+   902  956  961 1    BACKBONE|DICT
+   903  956  957 1    BACKBONE|DICT
+   904  956  959 1    DICT
+   905  956  955 1    BACKBONE|DICT
+   906  955  960 1    BACKBONE|DICT
+   907  959  962 1    DICT
+   908  959  963 1    DICT
+   909  959  964 1    DICT
+   910  957  958 2    BACKBONE|DICT
+   911  966  974 1    BACKBONE|DICT
+   912  966  967 1    BACKBONE|DICT
+   913  966  969 1    DICT
+   914  966  965 1    BACKBONE|DICT
+   915  965  973 1    BACKBONE|DICT
+   916  969  975 1    DICT
+   917  969  970 1    DICT
+   918  969  971 1    DICT
+   919  971  978 1    DICT
+   920  971  979 1    DICT
+   921  971  980 1    DICT
+   922  970  976 1    DICT
+   923  970  977 1    DICT
+   924  970  972 1    DICT
+   925  972  981 1    DICT
+   926  972  982 1    DICT
+   927  972  983 1    DICT
+   928  967  968 2    BACKBONE|DICT
+   929  985  994 1    BACKBONE|DICT
+   930  985  986 1    BACKBONE|DICT
+   931  985  988 1    DICT
+   932  985  984 1    BACKBONE|DICT
+   933  984  993 1    BACKBONE|DICT
+   934  988  995 1    DICT
+   935  988  996 1    DICT
+   936  988  989 1    DICT
+   937  989  997 1    DICT
+   938  989  998 1    DICT
+   939  989  990 1    DICT
+   940  990  999 1    DICT
+   941  990 1000 1    DICT
+   942  990  991 1    DICT
+   943  991 1001 1    DICT
+   944  991 1002 1    DICT
+   945  991  992 1    DICT
+   946  992 1003 1    DICT
+   947  992 1004 1    DICT
+   948  992 1005 1    DICT
+   949  986  987 2    BACKBONE|DICT
+   950 1007 1016 1    BACKBONE|DICT
+   951 1007 1008 1    BACKBONE|DICT
+   952 1007 1010 1    DICT
+   953 1007 1006 1    BACKBONE|DICT
+   954 1006 1015 1    BACKBONE|DICT
+   955 1010 1017 1    DICT
+   956 1010 1018 1    DICT
+   957 1010 1011 1    DICT
+   958 1011 1019 1    DICT
+   959 1011 1020 1    DICT
+   960 1011 1012 1    DICT
+   961 1012 1021 1    DICT
+   962 1012 1022 1    DICT
+   963 1012 1013 1    DICT
+   964 1013 1023 1    DICT
+   965 1013 1024 1    DICT
+   966 1013 1014 1    DICT
+   967 1014 1025 1    DICT
+   968 1014 1026 1    DICT
+   969 1014 1027 1    DICT
+   970 1008 1009 2    BACKBONE|DICT
+   971 1029 1039 1    BACKBONE|DICT
+   972 1029 1030 1    BACKBONE|DICT
+   973 1029 1032 1    DICT
+   974 1029 1028 1    BACKBONE|DICT
+   975 1028 1038 1    BACKBONE|DICT
+   976 1032 1040 1    DICT
+   977 1032 1041 1    DICT
+   978 1032 1033 1    DICT
+   979 1033 1035 2    DICT
+   980 1033 1034 1    DICT
+   981 1034 1036 2    DICT
+   982 1036 1043 1    DICT
+   983 1036 1037 1    DICT
+   984 1037 1044 1    DICT
+   985 1037 1035 1    DICT
+   986 1035 1042 1    DICT
+   987 1030 1031 2    BACKBONE|DICT
+   988 1046 1054 1    BACKBONE|DICT
+   989 1046 1047 1    BACKBONE|DICT
+   990 1046 1049 1    DICT
+   991 1046 1045 1    BACKBONE|DICT
+   992 1045 1053 1    BACKBONE|DICT
+   993 1049 1055 1    DICT
+   994 1049 1056 1    DICT
+   995 1049 1050 1    DICT
+   996 1050 1051 2    DICT
+   997 1050 1052 am   DICT
+   998 1052 1058 1    DICT
+   999 1052 1057 1    DICT
+  1000 1047 1048 2    BACKBONE|DICT
+  1001 1060 1067 1    BACKBONE|DICT
+  1002 1060 1061 1    BACKBONE|DICT
+  1003 1060 1063 1    DICT
+  1004 1060 1059 1    BACKBONE|DICT
+  1005 1059 1066 1    BACKBONE|DICT
+  1006 1063 1068 1    DICT
+  1007 1063 1064 1    DICT
+  1008 1063 1065 1    DICT
+  1009 1065 1072 1    DICT
+  1010 1065 1073 1    DICT
+  1011 1065 1074 1    DICT
+  1012 1064 1069 1    DICT
+  1013 1064 1070 1    DICT
+  1014 1064 1071 1    DICT
+  1015 1061 1062 2    BACKBONE|DICT
+  1016 1076 1081 1    DICT
+  1017 1076 1080 1    BACKBONE|DICT
+  1018 1076 1077 1    BACKBONE|DICT
+  1019 1076 1075 1    BACKBONE|DICT
+  1020 1075 1079 1    BACKBONE|DICT
+  1021 1077 1078 2    BACKBONE|DICT
+  1022 1083 1090 1    BACKBONE|DICT
+  1023 1083 1084 1    BACKBONE|DICT
+  1024 1083 1086 1    DICT
+  1025 1083 1082 1    BACKBONE|DICT
+  1026 1082 1089 1    BACKBONE|DICT
+  1027 1086 1091 1    DICT
+  1028 1086 1087 1    DICT
+  1029 1086 1088 1    DICT
+  1030 1088 1095 1    DICT
+  1031 1088 1096 1    DICT
+  1032 1088 1097 1    DICT
+  1033 1087 1092 1    DICT
+  1034 1087 1093 1    DICT
+  1035 1087 1094 1    DICT
+  1036 1084 1085 2    BACKBONE|DICT
+  1037 1099 1108 1    BACKBONE|DICT
+  1038 1099 1100 1    BACKBONE|DICT
+  1039 1099 1102 1    DICT
+  1040 1099 1098 1    BACKBONE|DICT
+  1041 1098 1107 1    BACKBONE|DICT
+  1042 1102 1109 1    DICT
+  1043 1102 1110 1    DICT
+  1044 1102 1103 1    DICT
+  1045 1103 1111 1    DICT
+  1046 1103 1112 1    DICT
+  1047 1103 1104 1    DICT
+  1048 1104 1113 1    DICT
+  1049 1104 1114 1    DICT
+  1050 1104 1105 1    DICT
+  1051 1105 1115 1    DICT
+  1052 1105 1116 1    DICT
+  1053 1105 1106 1    DICT
+  1054 1106 1117 1    DICT
+  1055 1106 1118 1    DICT
+  1056 1106 1119 1    DICT
+  1057 1100 1101 2    BACKBONE|DICT
+  1058 1121 1127 1    BACKBONE|DICT
+  1059 1121 1122 1    BACKBONE|DICT
+  1060 1121 1124 1    DICT
+  1061 1121 1120 1    BACKBONE|DICT
+  1062 1120 1126 1    BACKBONE|DICT
+  1063 1124 1128 1    DICT
+  1064 1124 1129 1    DICT
+  1065 1124 1125 1    DICT
+  1066 1125 1130 1    DICT
+  1067 1122 1123 2    BACKBONE|DICT
+  1068 1132 1137 1    BACKBONE|DICT
+  1069 1132 1133 1    BACKBONE|DICT
+  1070 1132 1135 1    DICT
+  1071 1132 1131 1    BACKBONE|DICT
+  1072 1131 1136 1    BACKBONE|DICT
+  1073 1135 1138 1    DICT
+  1074 1135 1139 1    DICT
+  1075 1135 1140 1    DICT
+  1076 1133 1134 2    BACKBONE|DICT
+  1077 1142 1149 1    BACKBONE|DICT
+  1078 1142 1143 1    BACKBONE|DICT
+  1079 1142 1145 1    DICT
+  1080 1142 1141 1    BACKBONE|DICT
+  1081 1141 1148 1    BACKBONE|DICT
+  1082 1145 1150 1    DICT
+  1083 1145 1146 1    DICT
+  1084 1145 1147 1    DICT
+  1085 1147 1154 1    DICT
+  1086 1147 1152 1    DICT
+  1087 1147 1153 1    DICT
+  1088 1146 1151 1    DICT
+  1089 1143 1144 2    BACKBONE|DICT
+  1090 1156 1164 1    BACKBONE|DICT
+  1091 1156 1157 1    BACKBONE|DICT
+  1092 1156 1159 1    DICT
+  1093 1156 1155 1    BACKBONE|DICT
+  1094 1155 1163 1    BACKBONE|DICT
+  1095 1159 1165 1    DICT
+  1096 1159 1160 1    DICT
+  1097 1159 1161 1    DICT
+  1098 1161 1168 1    DICT
+  1099 1161 1169 1    DICT
+  1100 1161 1170 1    DICT
+  1101 1160 1166 1    DICT
+  1102 1160 1167 1    DICT
+  1103 1160 1162 1    DICT
+  1104 1162 1171 1    DICT
+  1105 1162 1172 1    DICT
+  1106 1162 1173 1    DICT
+  1107 1157 1158 2    BACKBONE|DICT
+  1108 1175 1182 1    BACKBONE|DICT
+  1109 1175 1176 1    BACKBONE|DICT
+  1110 1175 1178 1    DICT
+  1111 1175 1174 1    BACKBONE|DICT
+  1112 1174 1181 1    BACKBONE|DICT
+  1113 1178 1183 1    DICT
+  1114 1178 1179 1    DICT
+  1115 1178 1180 1    DICT
+  1116 1180 1187 1    DICT
+  1117 1180 1185 1    DICT
+  1118 1180 1186 1    DICT
+  1119 1179 1184 1    DICT
+  1120 1176 1177 2    BACKBONE|DICT
+  1121 1189 1195 1    BACKBONE|DICT
+  1122 1189 1188 1    BACKBONE|DICT
+  1123 1189 1192 1    DICT
+  1124 1189 1190 1    BACKBONE|DICT
+  1125 1190 1191 2    BACKBONE|DICT
+  1126 1192 1196 1    DICT
+  1127 1192 1197 1    DICT
+  1128 1192 1193 1    DICT
+  1129 1193 1199 1    DICT
+  1130 1193 1198 1    DICT
+  1131 1193 1194 1    DICT
+  1132 1194 1201 1    DICT
+  1133 1194 1200 1    DICT
+  1134 1194 1188 1    DICT
+  1135 1203 1211 1    BACKBONE|DICT
+  1136 1203 1204 1    BACKBONE|DICT
+  1137 1203 1206 1    DICT
+  1138 1203 1202 1    BACKBONE|DICT
+  1139 1202 1210 1    BACKBONE|DICT
+  1140 1206 1212 1    DICT
+  1141 1206 1213 1    DICT
+  1142 1206 1207 1    DICT
+  1143 1207 1209 ar   DICT
+  1144 1207 1208 ar   DICT
+  1145 1204 1205 2    BACKBONE|DICT
+  1146 1215 1224 1    BACKBONE|DICT
+  1147 1215 1216 1    BACKBONE|DICT
+  1148 1215 1218 1    DICT
+  1149 1215 1214 1    BACKBONE|DICT
+  1150 1214 1223 1    BACKBONE|DICT
+  1151 1218 1225 1    DICT
+  1152 1218 1226 1    DICT
+  1153 1218 1219 1    DICT
+  1154 1219 1227 1    DICT
+  1155 1219 1228 1    DICT
+  1156 1219 1220 1    DICT
+  1157 1220 1221 ar   DICT
+  1158 1220 1222 ar   DICT
+  1159 1216 1217 2    BACKBONE|DICT
+  1160 1230 1239 1    BACKBONE|DICT
+  1161 1230 1231 1    BACKBONE|DICT
+  1162 1230 1233 1    DICT
+  1163 1230 1229 1    BACKBONE|DICT
+  1164 1229 1238 1    BACKBONE|DICT
+  1165 1233 1240 1    DICT
+  1166 1233 1241 1    DICT
+  1167 1233 1234 1    DICT
+  1168 1234 1242 1    DICT
+  1169 1234 1243 1    DICT
+  1170 1234 1235 1    DICT
+  1171 1235 1244 1    DICT
+  1172 1235 1245 1    DICT
+  1173 1235 1236 1    DICT
+  1174 1236 1246 1    DICT
+  1175 1236 1247 1    DICT
+  1176 1236 1237 1    DICT
+  1177 1237 1248 1    DICT
+  1178 1237 1249 1    DICT
+  1179 1237 1250 1    DICT
+  1180 1231 1232 2    BACKBONE|DICT
+  1181 1252 1263 1    BACKBONE|DICT
+  1182 1252 1253 1    BACKBONE|DICT
+  1183 1252 1255 1    DICT
+  1184 1252 1251 1    BACKBONE|DICT
+  1185 1251 1262 1    BACKBONE|DICT
+  1186 1255 1264 1    DICT
+  1187 1255 1265 1    DICT
+  1188 1255 1256 1    DICT
+  1189 1256 1266 1    DICT
+  1190 1256 1267 1    DICT
+  1191 1256 1257 1    DICT
+  1192 1257 1268 1    DICT
+  1193 1257 1269 1    DICT
+  1194 1257 1258 1    DICT
+  1195 1258 1270 1    DICT
+  1196 1258 1259 ar   DICT
+  1197 1259 1260 ar   DICT
+  1198 1259 1261 ar   DICT
+  1199 1261 1274 1    DICT
+  1200 1261 1273 1    DICT
+  1201 1260 1272 1    DICT
+  1202 1260 1271 1    DICT
+  1203 1253 1254 2    BACKBONE|DICT
+  1204 1276 1283 1    BACKBONE|DICT
+  1205 1276 1277 1    BACKBONE|DICT
+  1206 1276 1279 1    DICT
+  1207 1276 1275 1    BACKBONE|DICT
+  1208 1275 1282 1    BACKBONE|DICT
+  1209 1279 1284 1    DICT
+  1210 1279 1280 1    DICT
+  1211 1279 1281 1    DICT
+  1212 1281 1288 1    DICT
+  1213 1281 1289 1    DICT
+  1214 1281 1290 1    DICT
+  1215 1280 1285 1    DICT
+  1216 1280 1286 1    DICT
+  1217 1280 1287 1    DICT
+  1218 1277 1278 2    BACKBONE|DICT
+  1219 1292 1301 1    BACKBONE|DICT
+  1220 1292 1293 1    BACKBONE|DICT
+  1221 1292 1295 1    DICT
+  1222 1292 1291 1    BACKBONE|DICT
+  1223 1291 1300 1    BACKBONE|DICT
+  1224 1295 1302 1    DICT
+  1225 1295 1303 1    DICT
+  1226 1295 1296 1    DICT
+  1227 1296 1304 1    DICT
+  1228 1296 1305 1    DICT
+  1229 1296 1297 1    DICT
+  1230 1297 1298 ar   DICT
+  1231 1297 1299 ar   DICT
+  1232 1293 1294 2    BACKBONE|DICT
+  1233 1307 1316 1    BACKBONE|DICT
+  1234 1307 1308 1    BACKBONE|DICT
+  1235 1307 1310 1    DICT
+  1236 1307 1306 1    BACKBONE|DICT
+  1237 1306 1315 1    BACKBONE|DICT
+  1238 1310 1317 1    DICT
+  1239 1310 1318 1    DICT
+  1240 1310 1311 1    DICT
+  1241 1311 1319 1    DICT
+  1242 1311 1320 1    DICT
+  1243 1311 1312 1    DICT
+  1244 1312 1313 ar   DICT
+  1245 1312 1314 ar   DICT
+  1246 1308 1309 2    BACKBONE|DICT
+  1247 1322 1333 1    BACKBONE|DICT
+  1248 1322 1323 1    BACKBONE|DICT
+  1249 1322 1325 1    DICT
+  1250 1322 1321 1    BACKBONE|DICT
+  1251 1321 1332 1    BACKBONE|DICT
+  1252 1325 1334 1    DICT
+  1253 1325 1335 1    DICT
+  1254 1325 1326 1    DICT
+  1255 1326 1328 ar   DICT
+  1256 1326 1327 ar   DICT
+  1257 1327 1336 1    DICT
+  1258 1327 1329 ar   DICT
+  1259 1329 1338 1    DICT
+  1260 1329 1331 ar   DICT
+  1261 1331 1340 1    DICT
+  1262 1331 1330 ar   DICT
+  1263 1330 1339 1    DICT
+  1264 1330 1328 ar   DICT
+  1265 1328 1337 1    DICT
+  1266 1323 1324 2    BACKBONE|DICT
+  1267 1342 1351 1    BACKBONE|DICT
+  1268 1342 1343 1    BACKBONE|DICT
+  1269 1342 1345 1    DICT
+  1270 1342 1341 1    BACKBONE|DICT
+  1271 1341 1350 1    BACKBONE|DICT
+  1272 1345 1352 1    DICT
+  1273 1345 1353 1    DICT
+  1274 1345 1346 1    DICT
+  1275 1346 1354 1    DICT
+  1276 1346 1355 1    DICT
+  1277 1346 1347 1    DICT
+  1278 1347 1356 1    DICT
+  1279 1347 1357 1    DICT
+  1280 1347 1348 1    DICT
+  1281 1348 1358 1    DICT
+  1282 1348 1359 1    DICT
+  1283 1348 1349 1    DICT
+  1284 1349 1360 1    DICT
+  1285 1349 1361 1    DICT
+  1286 1349 1362 1    DICT
+  1287 1343 1344 2    BACKBONE|DICT
+  1288 1364 1372 1    BACKBONE|DICT
+  1289 1364 1365 1    BACKBONE|DICT
+  1290 1364 1367 1    DICT
+  1291 1364 1363 1    BACKBONE|DICT
+  1292 1363 1371 1    BACKBONE|DICT
+  1293 1367 1373 1    DICT
+  1294 1367 1374 1    DICT
+  1295 1367 1368 1    DICT
+  1296 1368 1375 1    DICT
+  1297 1368 1370 1    DICT
+  1298 1368 1369 1    DICT
+  1299 1369 1376 1    DICT
+  1300 1369 1377 1    DICT
+  1301 1369 1378 1    DICT
+  1302 1370 1379 1    DICT
+  1303 1370 1380 1    DICT
+  1304 1370 1381 1    DICT
+  1305 1365 1366 2    BACKBONE|DICT
+  1306 1383 1392 1    BACKBONE|DICT
+  1307 1383 1384 1    BACKBONE|DICT
+  1308 1383 1386 1    DICT
+  1309 1383 1382 1    BACKBONE|DICT
+  1310 1382 1391 1    BACKBONE|DICT
+  1311 1386 1393 1    DICT
+  1312 1386 1394 1    DICT
+  1313 1386 1387 1    DICT
+  1314 1387 1395 1    DICT
+  1315 1387 1396 1    DICT
+  1316 1387 1388 1    DICT
+  1317 1388 1397 1    DICT
+  1318 1388 1398 1    DICT
+  1319 1388 1389 1    DICT
+  1320 1389 1399 1    DICT
+  1321 1389 1400 1    DICT
+  1322 1389 1390 1    DICT
+  1323 1390 1401 1    DICT
+  1324 1390 1402 1    DICT
+  1325 1390 1403 1    DICT
+  1326 1384 1385 2    BACKBONE|DICT
+  1327 1405 1414 1    BACKBONE|DICT
+  1328 1405 1406 1    BACKBONE|DICT
+  1329 1405 1408 1    DICT
+  1330 1405 1404 1    BACKBONE|DICT
+  1331 1404 1413 1    BACKBONE|DICT
+  1332 1408 1415 1    DICT
+  1333 1408 1416 1    DICT
+  1334 1408 1409 1    DICT
+  1335 1409 1417 1    DICT
+  1336 1409 1418 1    DICT
+  1337 1409 1410 1    DICT
+  1338 1410 1411 2    DICT
+  1339 1410 1412 am   DICT
+  1340 1412 1420 1    DICT
+  1341 1412 1419 1    DICT
+  1342 1406 1407 2    BACKBONE|DICT
+  1343 1422 1430 1    BACKBONE|DICT
+  1344 1422 1423 1    BACKBONE|DICT
+  1345 1422 1425 1    DICT
+  1346 1422 1421 1    BACKBONE|DICT
+  1347 1421 1429 1    BACKBONE|DICT
+  1348 1425 1431 1    DICT
+  1349 1425 1432 1    DICT
+  1350 1425 1426 1    DICT
+  1351 1426 1433 1    DICT
+  1352 1426 1434 1    DICT
+  1353 1426 1427 1    DICT
+  1354 1427 1428 1    DICT
+  1355 1428 1435 1    DICT
+  1356 1428 1436 1    DICT
+  1357 1428 1437 1    DICT
+  1358 1423 1424 2    BACKBONE|DICT
+  1359 1439 1453 1    BACKBONE|DICT
+  1360 1439 1440 1    BACKBONE|DICT
+  1361 1439 1442 1    DICT
+  1362 1439 1438 1    BACKBONE|DICT
+  1363 1438 1452 1    BACKBONE|DICT
+  1364 1442 1454 1    DICT
+  1365 1442 1455 1    DICT
+  1366 1442 1443 1    DICT
+  1367 1443 1445 1    DICT
+  1368 1443 1444 2    DICT
+  1369 1444 1456 1    DICT
+  1370 1444 1446 1    DICT
+  1371 1446 1457 1    DICT
+  1372 1446 1447 1    DICT
+  1373 1447 1449 ar   DICT
+  1374 1447 1445 ar   DICT
+  1375 1445 1448 ar   DICT
+  1376 1448 1458 1    DICT
+  1377 1448 1450 ar   DICT
+  1378 1450 1460 1    DICT
+  1379 1450 1451 ar   DICT
+  1380 1451 1461 1    DICT
+  1381 1451 1449 ar   DICT
+  1382 1449 1459 1    DICT
+  1383 1440 1441 2    BACKBONE|DICT
+  1384 1463 1472 1    BACKBONE|DICT
+  1385 1463 1464 1    BACKBONE|DICT
+  1386 1463 1466 1    DICT
+  1387 1463 1462 1    BACKBONE|DICT
+  1388 1462 1471 1    BACKBONE|DICT
+  1389 1466 1473 1    DICT
+  1390 1466 1474 1    DICT
+  1391 1466 1467 1    DICT
+  1392 1467 1475 1    DICT
+  1393 1467 1476 1    DICT
+  1394 1467 1468 1    DICT
+  1395 1468 1477 1    DICT
+  1396 1468 1478 1    DICT
+  1397 1468 1469 1    DICT
+  1398 1469 1479 1    DICT
+  1399 1469 1480 1    DICT
+  1400 1469 1470 1    DICT
+  1401 1470 1481 1    DICT
+  1402 1470 1482 1    DICT
+  1403 1470 1483 1    DICT
+  1404 1464 1465 2    BACKBONE|DICT
+  1405 1485 1491 1    BACKBONE|DICT
+  1406 1485 1486 1    BACKBONE|DICT
+  1407 1485 1488 1    DICT
+  1408 1485 1484 1    BACKBONE|DICT
+  1409 1484 1490 1    BACKBONE|DICT
+  1410 1488 1492 1    DICT
+  1411 1488 1493 1    DICT
+  1412 1488 1489 1    DICT
+  1413 1489 1494 1    DICT
+  1414 1486 1487 2    BACKBONE|DICT
+  1415 1496 1502 1    BACKBONE|DICT
+  1416 1496 1495 1    BACKBONE|DICT
+  1417 1496 1499 1    DICT
+  1418 1496 1497 1    BACKBONE|DICT
+  1419 1497 1498 2    BACKBONE|DICT
+  1420 1499 1503 1    DICT
+  1421 1499 1504 1    DICT
+  1422 1499 1500 1    DICT
+  1423 1500 1506 1    DICT
+  1424 1500 1505 1    DICT
+  1425 1500 1501 1    DICT
+  1426 1501 1508 1    DICT
+  1427 1501 1507 1    DICT
+  1428 1501 1495 1    DICT
+  1429 1510 1518 1    BACKBONE|DICT
+  1430 1510 1511 1    BACKBONE|DICT
+  1431 1510 1513 1    DICT
+  1432 1510 1509 1    BACKBONE|DICT
+  1433 1509 1517 1    BACKBONE|DICT
+  1434 1513 1519 1    DICT
+  1435 1513 1520 1    DICT
+  1436 1513 1514 1    DICT
+  1437 1514 1515 2    DICT
+  1438 1514 1516 am   DICT
+  1439 1516 1522 1    DICT
+  1440 1516 1521 1    DICT
+  1441 1511 1512 2    BACKBONE|DICT
+  1442 1524 1529 1    DICT
+  1443 1524 1528 1    BACKBONE|DICT
+  1444 1524 1525 1    BACKBONE|DICT
+  1445 1524 1523 1    BACKBONE|DICT
+  1446 1523 1527 1    BACKBONE|DICT
+  1447 1525 1526 2    BACKBONE|DICT
+  1448 1531 1538 1    BACKBONE|DICT
+  1449 1531 1532 1    BACKBONE|DICT
+  1450 1531 1534 1    DICT
+  1451 1531 1530 1    BACKBONE|DICT
+  1452 1530 1537 1    BACKBONE|DICT
+  1453 1534 1539 1    DICT
+  1454 1534 1535 1    DICT
+  1455 1534 1536 1    DICT
+  1456 1536 1543 1    DICT
+  1457 1536 1541 1    DICT
+  1458 1536 1542 1    DICT
+  1459 1535 1540 1    DICT
+  1460 1532 1533 2    BACKBONE|DICT
+  1461 1545 1553 1    BACKBONE|DICT
+  1462 1545 1546 1    BACKBONE|DICT
+  1463 1545 1548 1    DICT
+  1464 1545 1544 1    BACKBONE|DICT
+  1465 1544 1552 1    BACKBONE|DICT
+  1466 1548 1554 1    DICT
+  1467 1548 1549 1    DICT
+  1468 1548 1550 1    DICT
+  1469 1550 1557 1    DICT
+  1470 1550 1558 1    DICT
+  1471 1550 1559 1    DICT
+  1472 1549 1555 1    DICT
+  1473 1549 1556 1    DICT
+  1474 1549 1551 1    DICT
+  1475 1551 1560 1    DICT
+  1476 1551 1561 1    DICT
+  1477 1551 1562 1    DICT
+  1478 1546 1547 2    BACKBONE|DICT
+  1479 1564 1575 1    BACKBONE|DICT
+  1480 1564 1565 1    BACKBONE|DICT
+  1481 1564 1567 1    DICT
+  1482 1564 1563 1    BACKBONE|DICT
+  1483 1563 1574 1    BACKBONE|DICT
+  1484 1567 1576 1    DICT
+  1485 1567 1577 1    DICT
+  1486 1567 1568 1    DICT
+  1487 1568 1578 1    DICT
+  1488 1568 1579 1    DICT
+  1489 1568 1569 1    DICT
+  1490 1569 1580 1    DICT
+  1491 1569 1581 1    DICT
+  1492 1569 1570 1    DICT
+  1493 1570 1582 1    DICT
+  1494 1570 1571 ar   DICT
+  1495 1571 1572 ar   DICT
+  1496 1571 1573 ar   DICT
+  1497 1573 1586 1    DICT
+  1498 1573 1585 1    DICT
+  1499 1572 1584 1    DICT
+  1500 1572 1583 1    DICT
+  1501 1565 1566 2    BACKBONE|DICT
+  1502 1588 1596 1    BACKBONE|DICT
+  1503 1588 1589 1    BACKBONE|DICT
+  1504 1588 1591 1    DICT
+  1505 1588 1587 1    BACKBONE|DICT
+  1506 1587 1595 1    BACKBONE|DICT
+  1507 1591 1597 1    DICT
+  1508 1591 1598 1    DICT
+  1509 1591 1592 1    DICT
+  1510 1592 1593 2    DICT
+  1511 1592 1594 am   DICT
+  1512 1594 1600 1    DICT
+  1513 1594 1599 1    DICT
+  1514 1589 1590 2    BACKBONE|DICT
+  1515 1602 1610 1    BACKBONE|DICT
+  1516 1602 1603 1    BACKBONE|DICT
+  1517 1602 1605 1    DICT
+  1518 1602 1601 1    BACKBONE|DICT
+  1519 1601 1609 1    BACKBONE|DICT
+  1520 1605 1611 1    DICT
+  1521 1605 1606 1    DICT
+  1522 1605 1607 1    DICT
+  1523 1607 1614 1    DICT
+  1524 1607 1615 1    DICT
+  1525 1607 1616 1    DICT
+  1526 1606 1612 1    DICT
+  1527 1606 1613 1    DICT
+  1528 1606 1608 1    DICT
+  1529 1608 1617 1    DICT
+  1530 1608 1618 1    DICT
+  1531 1608 1619 1    DICT
+  1532 1603 1604 2    BACKBONE|DICT
+  1533 1621 1629 1    BACKBONE|DICT
+  1534 1621 1622 1    BACKBONE|DICT
+  1535 1621 1624 1    DICT
+  1536 1621 1620 1    BACKBONE|DICT
+  1537 1620 1628 1    BACKBONE|DICT
+  1538 1624 1630 1    DICT
+  1539 1624 1631 1    DICT
+  1540 1624 1625 1    DICT
+  1541 1625 1632 1    DICT
+  1542 1625 1627 1    DICT
+  1543 1625 1626 1    DICT
+  1544 1626 1633 1    DICT
+  1545 1626 1634 1    DICT
+  1546 1626 1635 1    DICT
+  1547 1627 1636 1    DICT
+  1548 1627 1637 1    DICT
+  1549 1627 1638 1    DICT
+  1550 1622 1623 2    BACKBONE|DICT
+  1551 1640 1645 1    DICT
+  1552 1640 1644 1    BACKBONE|DICT
+  1553 1640 1641 1    BACKBONE|DICT
+  1554 1640 1639 1    BACKBONE|DICT
+  1555 1639 1643 1    BACKBONE|DICT
+  1556 1641 1642 2    BACKBONE|DICT
+  1557 1647 1652 1    DICT
+  1558 1647 1651 1    BACKBONE|DICT
+  1559 1647 1648 1    BACKBONE|DICT
+  1560 1647 1646 1    BACKBONE|DICT
+  1561 1646 1650 1    BACKBONE|DICT
+  1562 1648 1649 2    BACKBONE|DICT
+  1563 1654 1661 1    BACKBONE|DICT
+  1564 1654 1655 1    BACKBONE|DICT
+  1565 1654 1657 1    DICT
+  1566 1654 1653 1    BACKBONE|DICT
+  1567 1653 1660 1    BACKBONE|DICT
+  1568 1657 1662 1    DICT
+  1569 1657 1658 1    DICT
+  1570 1657 1659 1    DICT
+  1571 1659 1666 1    DICT
+  1572 1659 1664 1    DICT
+  1573 1659 1665 1    DICT
+  1574 1658 1663 1    DICT
+  1575 1655 1656 2    BACKBONE|DICT
+  1576 1668 1675 1    BACKBONE|DICT
+  1577 1668 1669 1    BACKBONE|DICT
+  1578 1668 1671 1    DICT
+  1579 1668 1667 1    BACKBONE|DICT
+  1580 1667 1674 1    BACKBONE|DICT
+  1581 1671 1676 1    DICT
+  1582 1671 1672 1    DICT
+  1583 1671 1673 1    DICT
+  1584 1673 1680 1    DICT
+  1585 1673 1681 1    DICT
+  1586 1673 1682 1    DICT
+  1587 1672 1677 1    DICT
+  1588 1672 1678 1    DICT
+  1589 1672 1679 1    DICT
+  1590 1669 1670 2    BACKBONE|DICT
+  1591 1684 1695 1    BACKBONE|DICT
+  1592 1684 1685 1    BACKBONE|DICT
+  1593 1684 1687 1    DICT
+  1594 1684 1683 1    BACKBONE|DICT
+  1595 1683 1694 1    BACKBONE|DICT
+  1596 1687 1696 1    DICT
+  1597 1687 1697 1    DICT
+  1598 1687 1688 1    DICT
+  1599 1688 1690 ar   DICT
+  1600 1688 1689 ar   DICT
+  1601 1689 1698 1    DICT
+  1602 1689 1691 ar   DICT
+  1603 1691 1700 1    DICT
+  1604 1691 1693 ar   DICT
+  1605 1693 1702 1    DICT
+  1606 1693 1692 ar   DICT
+  1607 1692 1701 1    DICT
+  1608 1692 1690 ar   DICT
+  1609 1690 1699 1    DICT
+  1610 1685 1686 2    BACKBONE|DICT
+  1611 1704 1715 1    BACKBONE|DICT
+  1612 1704 1705 1    BACKBONE|DICT
+  1613 1704 1707 1    DICT
+  1614 1704 1703 1    BACKBONE|DICT
+  1615 1703 1714 1    BACKBONE|DICT
+  1616 1707 1716 1    DICT
+  1617 1707 1717 1    DICT
+  1618 1707 1708 1    DICT
+  1619 1708 1718 1    DICT
+  1620 1708 1719 1    DICT
+  1621 1708 1709 1    DICT
+  1622 1709 1720 1    DICT
+  1623 1709 1721 1    DICT
+  1624 1709 1710 1    DICT
+  1625 1710 1722 1    DICT
+  1626 1710 1711 ar   DICT
+  1627 1711 1712 ar   DICT
+  1628 1711 1713 ar   DICT
+  1629 1713 1726 1    DICT
+  1630 1713 1725 1    DICT
+  1631 1712 1724 1    DICT
+  1632 1712 1723 1    DICT
+  1633 1705 1706 2    BACKBONE|DICT
+  1634 1728 1737 1    BACKBONE|DICT
+  1635 1728 1729 1    BACKBONE|DICT
+  1636 1728 1731 1    DICT
+  1637 1728 1727 1    BACKBONE|DICT
+  1638 1727 1736 1    BACKBONE|DICT
+  1639 1731 1738 1    DICT
+  1640 1731 1739 1    DICT
+  1641 1731 1732 1    DICT
+  1642 1732 1740 1    DICT
+  1643 1732 1741 1    DICT
+  1644 1732 1733 1    DICT
+  1645 1733 1734 ar   DICT
+  1646 1733 1735 ar   DICT
+  1647 1729 1730 2    BACKBONE|DICT
+  1648 1743 1748 1    BACKBONE|DICT
+  1649 1743 1744 1    BACKBONE|DICT
+  1650 1743 1746 1    DICT
+  1651 1743 1742 1    BACKBONE|DICT
+  1652 1742 1747 1    BACKBONE|DICT
+  1653 1746 1749 1    DICT
+  1654 1746 1750 1    DICT
+  1655 1746 1751 1    DICT
+  1656 1744 1745 2    BACKBONE|DICT
+  1657 1753 1761 1    BACKBONE|DICT
+  1658 1753 1754 1    BACKBONE|DICT
+  1659 1753 1756 1    DICT
+  1660 1753 1752 1    BACKBONE|DICT
+  1661 1752 1760 1    BACKBONE|DICT
+  1662 1756 1762 1    DICT
+  1663 1756 1757 1    DICT
+  1664 1756 1758 1    DICT
+  1665 1758 1765 1    DICT
+  1666 1758 1766 1    DICT
+  1667 1758 1767 1    DICT
+  1668 1757 1763 1    DICT
+  1669 1757 1764 1    DICT
+  1670 1757 1759 1    DICT
+  1671 1759 1768 1    DICT
+  1672 1759 1769 1    DICT
+  1673 1759 1770 1    DICT
+  1674 1754 1755 2    BACKBONE|DICT
+  1675 1772 1780 1    BACKBONE|DICT
+  1676 1772 1773 1    BACKBONE|DICT
+  1677 1772 1775 1    DICT
+  1678 1772 1771 1    BACKBONE|DICT
+  1679 1771 1779 1    BACKBONE|DICT
+  1680 1775 1781 1    DICT
+  1681 1775 1776 1    DICT
+  1682 1775 1777 1    DICT
+  1683 1777 1784 1    DICT
+  1684 1777 1785 1    DICT
+  1685 1777 1786 1    DICT
+  1686 1776 1782 1    DICT
+  1687 1776 1783 1    DICT
+  1688 1776 1778 1    DICT
+  1689 1778 1787 1    DICT
+  1690 1778 1788 1    DICT
+  1691 1778 1789 1    DICT
+  1692 1773 1774 2    BACKBONE|DICT
+  1693 1791 1797 1    BACKBONE|DICT
+  1694 1791 1792 1    BACKBONE|DICT
+  1695 1791 1794 1    DICT
+  1696 1791 1790 1    BACKBONE|DICT
+  1697 1790 1796 1    BACKBONE|DICT
+  1698 1794 1798 1    DICT
+  1699 1794 1799 1    DICT
+  1700 1794 1795 1    DICT
+  1701 1795 1800 1    DICT
+  1702 1792 1793 2    BACKBONE|DICT
+  1703 1802 1811 1    BACKBONE|DICT
+  1704 1802 1803 1    BACKBONE|DICT
+  1705 1802 1805 1    DICT
+  1706 1802 1801 1    BACKBONE|DICT
+  1707 1801 1810 1    BACKBONE|DICT
+  1708 1805 1812 1    DICT
+  1709 1805 1813 1    DICT
+  1710 1805 1806 1    DICT
+  1711 1806 1814 1    DICT
+  1712 1806 1815 1    DICT
+  1713 1806 1807 1    DICT
+  1714 1807 1816 1    DICT
+  1715 1807 1817 1    DICT
+  1716 1807 1808 1    DICT
+  1717 1808 1818 1    DICT
+  1718 1808 1819 1    DICT
+  1719 1808 1809 1    DICT
+  1720 1809 1820 1    DICT
+  1721 1809 1821 1    DICT
+  1722 1809 1822 1    DICT
+  1723 1803 1804 2    BACKBONE|DICT
+  1724 1824 1832 1    BACKBONE|DICT
+  1725 1824 1825 1    BACKBONE|DICT
+  1726 1824 1827 1    DICT
+  1727 1824 1823 1    BACKBONE|DICT
+  1728 1823 1831 1    BACKBONE|DICT
+  1729 1827 1833 1    DICT
+  1730 1827 1834 1    DICT
+  1731 1827 1828 1    DICT
+  1732 1828 1829 2    DICT
+  1733 1828 1830 am   DICT
+  1734 1830 1836 1    DICT
+  1735 1830 1835 1    DICT
+  1736 1825 1826 2    BACKBONE|DICT
+  1737 1838 1846 1    BACKBONE|DICT
+  1738 1838 1839 1    BACKBONE|DICT
+  1739 1838 1841 1    DICT
+  1740 1838 1837 1    BACKBONE|DICT
+  1741 1837 1845 1    BACKBONE|DICT
+  1742 1841 1847 1    DICT
+  1743 1841 1842 1    DICT
+  1744 1841 1843 1    DICT
+  1745 1843 1850 1    DICT
+  1746 1843 1851 1    DICT
+  1747 1843 1852 1    DICT
+  1748 1842 1848 1    DICT
+  1749 1842 1849 1    DICT
+  1750 1842 1844 1    DICT
+  1751 1844 1853 1    DICT
+  1752 1844 1854 1    DICT
+  1753 1844 1855 1    DICT
+  1754 1839 1840 2    BACKBONE|DICT
+  1755 1857 1863 1    BACKBONE|DICT
+  1756 1857 1856 1    BACKBONE|DICT
+  1757 1857 1860 1    DICT
+  1758 1857 1858 1    BACKBONE|DICT
+  1759 1858 1859 2    BACKBONE|DICT
+  1760 1860 1864 1    DICT
+  1761 1860 1865 1    DICT
+  1762 1860 1861 1    DICT
+  1763 1861 1867 1    DICT
+  1764 1861 1866 1    DICT
+  1765 1861 1862 1    DICT
+  1766 1862 1869 1    DICT
+  1767 1862 1868 1    DICT
+  1768 1862 1856 1    DICT
+  1769 1871 1882 1    BACKBONE|DICT
+  1770 1871 1872 1    BACKBONE|DICT
+  1771 1871 1874 1    DICT
+  1772 1871 1870 1    BACKBONE|DICT
+  1773 1870 1881 1    BACKBONE|DICT
+  1774 1874 1883 1    DICT
+  1775 1874 1884 1    DICT
+  1776 1874 1875 1    DICT
+  1777 1875 1885 1    DICT
+  1778 1875 1886 1    DICT
+  1779 1875 1876 1    DICT
+  1780 1876 1887 1    DICT
+  1781 1876 1888 1    DICT
+  1782 1876 1877 1    DICT
+  1783 1877 1889 1    DICT
+  1784 1877 1878 ar   DICT
+  1785 1878 1879 ar   DICT
+  1786 1878 1880 ar   DICT
+  1787 1880 1893 1    DICT
+  1788 1880 1892 1    DICT
+  1789 1879 1891 1    DICT
+  1790 1879 1890 1    DICT
+  1791 1872 1873 2    BACKBONE|DICT
+  1792 1895 1903 1    BACKBONE|DICT
+  1793 1895 1896 1    BACKBONE|DICT
+  1794 1895 1898 1    DICT
+  1795 1895 1894 1    BACKBONE|DICT
+  1796 1894 1902 1    BACKBONE|DICT
+  1797 1898 1904 1    DICT
+  1798 1898 1905 1    DICT
+  1799 1898 1899 1    DICT
+  1800 1899 1906 1    DICT
+  1801 1899 1901 1    DICT
+  1802 1899 1900 1    DICT
+  1803 1900 1907 1    DICT
+  1804 1900 1908 1    DICT
+  1805 1900 1909 1    DICT
+  1806 1901 1910 1    DICT
+  1807 1901 1911 1    DICT
+  1808 1901 1912 1    DICT
+  1809 1896 1897 2    BACKBONE|DICT
+  1810 1914 1921 1    BACKBONE|DICT
+  1811 1914 1915 1    BACKBONE|DICT
+  1812 1914 1917 1    DICT
+  1813 1914 1913 1    BACKBONE|DICT
+  1814 1913 1920 1    BACKBONE|DICT
+  1815 1917 1922 1    DICT
+  1816 1917 1918 1    DICT
+  1817 1917 1919 1    DICT
+  1818 1919 1926 1    DICT
+  1819 1919 1927 1    DICT
+  1820 1919 1928 1    DICT
+  1821 1918 1923 1    DICT
+  1822 1918 1924 1    DICT
+  1823 1918 1925 1    DICT
+  1824 1915 1916 2    BACKBONE|DICT
+  1825 1930 1936 1    BACKBONE|DICT
+  1826 1930 1931 1    BACKBONE|DICT
+  1827 1930 1933 1    DICT
+  1828 1930 1929 1    BACKBONE|DICT
+  1829 1929 1935 1    BACKBONE|DICT
+  1830 1933 1937 1    DICT
+  1831 1933 1938 1    DICT
+  1832 1933 1934 1    DICT
+  1833 1934 1939 1    DICT
+  1834 1931 1932 2    BACKBONE|DICT
+  1835 1941 1946 1    DICT
+  1836 1941 1945 1    BACKBONE|DICT
+  1837 1941 1942 1    BACKBONE|DICT
+  1838 1941 1940 1    BACKBONE|DICT
+  1839 1940 1944 1    BACKBONE|DICT
+  1840 1942 1943 2    BACKBONE|DICT
+  1841 1948 1962 1    BACKBONE|DICT
+  1842 1948 1949 1    BACKBONE|DICT
+  1843 1948 1951 1    DICT
+  1844 1948 1947 1    BACKBONE|DICT
+  1845 1947 1961 1    BACKBONE|DICT
+  1846 1951 1963 1    DICT
+  1847 1951 1964 1    DICT
+  1848 1951 1952 1    DICT
+  1849 1952 1954 1    DICT
+  1850 1952 1953 2    DICT
+  1851 1953 1965 1    DICT
+  1852 1953 1955 1    DICT
+  1853 1955 1966 1    DICT
+  1854 1955 1956 1    DICT
+  1855 1956 1958 ar   DICT
+  1856 1956 1954 ar   DICT
+  1857 1954 1957 ar   DICT
+  1858 1957 1967 1    DICT
+  1859 1957 1959 ar   DICT
+  1860 1959 1969 1    DICT
+  1861 1959 1960 ar   DICT
+  1862 1960 1970 1    DICT
+  1863 1960 1958 ar   DICT
+  1864 1958 1968 1    DICT
+  1865 1949 1950 2    BACKBONE|DICT
+  1866 1972 1979 1    BACKBONE|DICT
+  1867 1972 1973 1    BACKBONE|DICT
+  1868 1972 1975 1    DICT
+  1869 1972 1971 1    BACKBONE|DICT
+  1870 1971 1978 1    BACKBONE|DICT
+  1871 1975 1980 1    DICT
+  1872 1975 1976 1    DICT
+  1873 1975 1977 1    DICT
+  1874 1977 1984 1    DICT
+  1875 1977 1985 1    DICT
+  1876 1977 1986 1    DICT
+  1877 1976 1981 1    DICT
+  1878 1976 1982 1    DICT
+  1879 1976 1983 1    DICT
+  1880 1973 1974 2    BACKBONE|DICT
+  1881 1988 1997 1    BACKBONE|DICT
+  1882 1988 1989 1    BACKBONE|DICT
+  1883 1988 1991 1    DICT
+  1884 1988 1987 1    BACKBONE|DICT
+  1885 1987 1996 1    BACKBONE|DICT
+  1886 1991 1998 1    DICT
+  1887 1991 1999 1    DICT
+  1888 1991 1992 1    DICT
+  1889 1992 2000 1    DICT
+  1890 1992 2001 1    DICT
+  1891 1992 1993 1    DICT
+  1892 1993 2002 1    DICT
+  1893 1993 2003 1    DICT
+  1894 1993 1994 1    DICT
+  1895 1994 2004 1    DICT
+  1896 1994 2005 1    DICT
+  1897 1994 1995 1    DICT
+  1898 1995 2006 1    DICT
+  1899 1995 2007 1    DICT
+  1900 1995 2008 1    DICT
+  1901 1989 1990 2    BACKBONE|DICT
+  1902 2010 2016 1    BACKBONE|DICT
+  1903 2010 2009 1    BACKBONE|DICT
+  1904 2010 2013 1    DICT
+  1905 2010 2011 1    BACKBONE|DICT
+  1906 2011 2012 2    BACKBONE|DICT
+  1907 2013 2017 1    DICT
+  1908 2013 2018 1    DICT
+  1909 2013 2014 1    DICT
+  1910 2014 2020 1    DICT
+  1911 2014 2019 1    DICT
+  1912 2014 2015 1    DICT
+  1913 2015 2022 1    DICT
+  1914 2015 2021 1    DICT
+  1915 2015 2009 1    DICT
+  1916 2024 2032 1    BACKBONE|DICT
+  1917 2024 2025 1    BACKBONE|DICT
+  1918 2024 2027 1    DICT
+  1919 2024 2023 1    BACKBONE|DICT
+  1920 2023 2031 1    BACKBONE|DICT
+  1921 2027 2033 1    DICT
+  1922 2027 2028 1    DICT
+  1923 2027 2029 1    DICT
+  1924 2029 2036 1    DICT
+  1925 2029 2037 1    DICT
+  1926 2029 2038 1    DICT
+  1927 2028 2034 1    DICT
+  1928 2028 2035 1    DICT
+  1929 2028 2030 1    DICT
+  1930 2030 2039 1    DICT
+  1931 2030 2040 1    DICT
+  1932 2030 2041 1    DICT
+  1933 2025 2026 2    BACKBONE|DICT
+  1934 2043 2051 1    BACKBONE|DICT
+  1935 2043 2044 1    BACKBONE|DICT
+  1936 2043 2046 1    DICT
+  1937 2043 2042 1    BACKBONE|DICT
+  1938 2042 2050 1    BACKBONE|DICT
+  1939 2046 2052 1    DICT
+  1940 2046 2047 1    DICT
+  1941 2046 2048 1    DICT
+  1942 2048 2055 1    DICT
+  1943 2048 2056 1    DICT
+  1944 2048 2057 1    DICT
+  1945 2047 2053 1    DICT
+  1946 2047 2054 1    DICT
+  1947 2047 2049 1    DICT
+  1948 2049 2058 1    DICT
+  1949 2049 2059 1    DICT
+  1950 2049 2060 1    DICT
+  1951 2044 2045 2    BACKBONE|DICT
+  1952 2062 2070 1    BACKBONE|DICT
+  1953 2062 2063 1    BACKBONE|DICT
+  1954 2062 2065 1    DICT
+  1955 2062 2061 1    BACKBONE|DICT
+  1956 2061 2069 1    BACKBONE|DICT
+  1957 2065 2071 1    DICT
+  1958 2065 2066 1    DICT
+  1959 2065 2067 1    DICT
+  1960 2067 2074 1    DICT
+  1961 2067 2075 1    DICT
+  1962 2067 2076 1    DICT
+  1963 2066 2072 1    DICT
+  1964 2066 2073 1    DICT
+  1965 2066 2068 1    DICT
+  1966 2068 2077 1    DICT
+  1967 2068 2078 1    DICT
+  1968 2068 2079 1    DICT
+  1969 2063 2064 2    BACKBONE|DICT
+  1970 2081 2086 1    DICT
+  1971 2081 2085 1    BACKBONE|DICT
+  1972 2081 2082 1    BACKBONE|DICT
+  1973 2081 2080 1    BACKBONE|DICT
+  1974 2080 2084 1    BACKBONE|DICT
+  1975 2082 2083 2    BACKBONE|DICT
+  1976 2088 2098 1    BACKBONE|DICT
+  1977 2088 2089 1    BACKBONE|DICT
+  1978 2088 2091 1    DICT
+  1979 2088 2087 1    BACKBONE|DICT
+  1980 2087 2097 1    BACKBONE|DICT
+  1981 2091 2099 1    DICT
+  1982 2091 2100 1    DICT
+  1983 2091 2092 1    DICT
+  1984 2092 2094 2    DICT
+  1985 2092 2093 1    DICT
+  1986 2093 2095 2    DICT
+  1987 2095 2102 1    DICT
+  1988 2095 2096 1    DICT
+  1989 2096 2103 1    DICT
+  1990 2096 2094 1    DICT
+  1991 2094 2101 1    DICT
+  1992 2089 2090 2    BACKBONE|DICT
+  1993 2105 2115 1    BACKBONE|DICT
+  1994 2105 2106 1    BACKBONE|DICT
+  1995 2105 2108 1    DICT
+  1996 2105 2104 1    BACKBONE|DICT
+  1997 2104 2114 1    BACKBONE|DICT
+  1998 2108 2116 1    DICT
+  1999 2108 2117 1    DICT
+  2000 2108 2109 1    DICT
+  2001 2109 2111 2    DICT
+  2002 2109 2110 1    DICT
+  2003 2110 2118 1    DICT
+  2004 2110 2112 1    DICT
+  2005 2112 2120 1    DICT
+  2006 2112 2113 2    DICT
+  2007 2113 2111 1    DICT
+  2008 2111 2119 1    DICT
+  2009 2106 2107 2    BACKBONE|DICT
+  2010 2122 2127 1    BACKBONE|DICT
+  2011 2122 2123 1    BACKBONE|DICT
+  2012 2122 2125 1    DICT
+  2013 2122 2121 1    BACKBONE|DICT
+  2014 2121 2126 1    BACKBONE|DICT
+  2015 2125 2128 1    DICT
+  2016 2125 2129 1    DICT
+  2017 2125 2130 1    DICT
+  2018 2123 2124 2    BACKBONE|DICT
+  2019 2132 2143 1    BACKBONE|DICT
+  2020 2132 2133 1    BACKBONE|DICT
+  2021 2132 2135 1    DICT
+  2022 2132 2131 1    BACKBONE|DICT
+  2023 2131 2142 1    BACKBONE|DICT
+  2024 2135 2144 1    DICT
+  2025 2135 2145 1    DICT
+  2026 2135 2136 1    DICT
+  2027 2136 2146 1    DICT
+  2028 2136 2147 1    DICT
+  2029 2136 2137 1    DICT
+  2030 2137 2148 1    DICT
+  2031 2137 2149 1    DICT
+  2032 2137 2138 1    DICT
+  2033 2138 2150 1    DICT
+  2034 2138 2139 ar   DICT
+  2035 2139 2140 ar   DICT
+  2036 2139 2141 ar   DICT
+  2037 2141 2154 1    DICT
+  2038 2141 2153 1    DICT
+  2039 2140 2152 1    DICT
+  2040 2140 2151 1    DICT
+  2041 2133 2134 2    BACKBONE|DICT
+  2042 2156 2161 1    BACKBONE|DICT
+  2043 2156 2157 1    BACKBONE|DICT
+  2044 2156 2159 1    DICT
+  2045 2156 2155 1    BACKBONE|DICT
+  2046 2155 2160 1    BACKBONE|DICT
+  2047 2159 2162 1    DICT
+  2048 2159 2163 1    DICT
+  2049 2159 2164 1    DICT
+  2050 2157 2158 2    BACKBONE|DICT
+  2051 2166 2173 1    BACKBONE|DICT
+  2052 2166 2167 1    BACKBONE|DICT
+  2053 2166 2169 1    DICT
+  2054 2166 2165 1    BACKBONE|DICT
+  2055 2165 2172 1    BACKBONE|DICT
+  2056 2169 2174 1    DICT
+  2057 2169 2170 1    DICT
+  2058 2169 2171 1    DICT
+  2059 2171 2178 1    DICT
+  2060 2171 2176 1    DICT
+  2061 2171 2177 1    DICT
+  2062 2170 2175 1    DICT
+  2063 2167 2168 2    BACKBONE|DICT
+  2064 2180 2188 1    BACKBONE|DICT
+  2065 2180 2181 1    BACKBONE|DICT
+  2066 2180 2183 1    DICT
+  2067 2180 2179 1    BACKBONE|DICT
+  2068 2179 2187 1    BACKBONE|DICT
+  2069 2183 2189 1    DICT
+  2070 2183 2190 1    DICT
+  2071 2183 2184 1    DICT
+  2072 2184 2186 ar   DICT
+  2073 2184 2185 ar   DICT
+  2074 2181 2182 2    BACKBONE|DICT
+  2075 2192 2203 1    BACKBONE|DICT
+  2076 2192 2193 1    BACKBONE|DICT
+  2077 2192 2195 1    DICT
+  2078 2192 2191 1    BACKBONE|DICT
+  2079 2191 2202 1    BACKBONE|DICT
+  2080 2195 2204 1    DICT
+  2081 2195 2205 1    DICT
+  2082 2195 2196 1    DICT
+  2083 2196 2198 ar   DICT
+  2084 2196 2197 ar   DICT
+  2085 2197 2206 1    DICT
+  2086 2197 2199 ar   DICT
+  2087 2199 2208 1    DICT
+  2088 2199 2201 ar   DICT
+  2089 2201 2210 1    DICT
+  2090 2201 2200 ar   DICT
+  2091 2200 2209 1    DICT
+  2092 2200 2198 ar   DICT
+  2093 2198 2207 1    DICT
+  2094 2193 2194 2    BACKBONE|DICT
+  2095 2212 2219 1    BACKBONE|DICT
+  2096 2212 2213 1    BACKBONE|DICT
+  2097 2212 2215 1    DICT
+  2098 2212 2211 1    BACKBONE|DICT
+  2099 2211 2218 1    BACKBONE|DICT
+  2100 2215 2220 1    DICT
+  2101 2215 2216 1    DICT
+  2102 2215 2217 1    DICT
+  2103 2217 2224 1    DICT
+  2104 2217 2225 1    DICT
+  2105 2217 2226 1    DICT
+  2106 2216 2221 1    DICT
+  2107 2216 2222 1    DICT
+  2108 2216 2223 1    DICT
+  2109 2213 2214 2    BACKBONE|DICT
+  2110 2228 2235 1    BACKBONE|DICT
+  2111 2228 2229 1    BACKBONE|DICT
+  2112 2228 2231 1    DICT
+  2113 2228 2227 1    BACKBONE|DICT
+  2114 2227 2234 1    BACKBONE|DICT
+  2115 2231 2236 1    DICT
+  2116 2231 2232 1    DICT
+  2117 2231 2233 1    DICT
+  2118 2233 2240 1    DICT
+  2119 2233 2241 1    DICT
+  2120 2233 2242 1    DICT
+  2121 2232 2237 1    DICT
+  2122 2232 2238 1    DICT
+  2123 2232 2239 1    DICT
+  2124 2229 2230 2    BACKBONE|DICT
+  2125 2244 2250 1    BACKBONE|DICT
+  2126 2244 2243 1    BACKBONE|DICT
+  2127 2244 2247 1    DICT
+  2128 2244 2245 1    BACKBONE|DICT
+  2129 2245 2246 2    BACKBONE|DICT
+  2130 2247 2251 1    DICT
+  2131 2247 2252 1    DICT
+  2132 2247 2248 1    DICT
+  2133 2248 2254 1    DICT
+  2134 2248 2253 1    DICT
+  2135 2248 2249 1    DICT
+  2136 2249 2256 1    DICT
+  2137 2249 2255 1    DICT
+  2138 2249 2243 1    DICT
+  2139 2258 2263 1    DICT
+  2140 2258 2262 1    BACKBONE|DICT
+  2141 2258 2259 1    BACKBONE|DICT
+  2142 2258 2257 1    BACKBONE|DICT
+  2143 2257 2261 1    BACKBONE|DICT
+  2144 2259 2260 2    BACKBONE|DICT
+  2145 2265 2271 1    BACKBONE|DICT
+  2146 2265 2264 1    BACKBONE|DICT
+  2147 2265 2268 1    DICT
+  2148 2265 2266 1    BACKBONE|DICT
+  2149 2266 2267 2    BACKBONE|DICT
+  2150 2268 2272 1    DICT
+  2151 2268 2273 1    DICT
+  2152 2268 2269 1    DICT
+  2153 2269 2275 1    DICT
+  2154 2269 2274 1    DICT
+  2155 2269 2270 1    DICT
+  2156 2270 2277 1    DICT
+  2157 2270 2276 1    DICT
+  2158 2270 2264 1    DICT
+  2159 2279 2284 1    DICT
+  2160 2279 2283 1    BACKBONE|DICT
+  2161 2279 2280 1    BACKBONE|DICT
+  2162 2279 2278 1    BACKBONE|DICT
+  2163 2278 2282 1    BACKBONE|DICT
+  2164 2280 2281 2    BACKBONE|DICT
+  2165 2286 2295 1    BACKBONE|DICT
+  2166 2286 2287 1    BACKBONE|DICT
+  2167 2286 2289 1    DICT
+  2168 2286 2285 1    BACKBONE|DICT
+  2169 2285 2294 1    BACKBONE|DICT
+  2170 2289 2296 1    DICT
+  2171 2289 2297 1    DICT
+  2172 2289 2290 1    DICT
+  2173 2290 2298 1    DICT
+  2174 2290 2299 1    DICT
+  2175 2290 2291 1    DICT
+  2176 2291 2300 1    DICT
+  2177 2291 2301 1    DICT
+  2178 2291 2292 1    DICT
+  2179 2292 2302 1    DICT
+  2180 2292 2303 1    DICT
+  2181 2292 2293 1    DICT
+  2182 2293 2304 1    DICT
+  2183 2293 2305 1    DICT
+  2184 2293 2306 1    DICT
+  2185 2287 2288 2    BACKBONE|DICT
+  2186 2308 2315 1    BACKBONE|DICT
+  2187 2308 2309 1    BACKBONE|DICT
+  2188 2308 2311 1    DICT
+  2189 2308 2307 1    BACKBONE|DICT
+  2190 2307 2314 1    BACKBONE|DICT
+  2191 2311 2316 1    DICT
+  2192 2311 2312 1    DICT
+  2193 2311 2313 1    DICT
+  2194 2313 2320 1    DICT
+  2195 2313 2321 1    DICT
+  2196 2313 2322 1    DICT
+  2197 2312 2317 1    DICT
+  2198 2312 2318 1    DICT
+  2199 2312 2319 1    DICT
+  2200 2309 2310 2    BACKBONE|DICT
+  2201 2324 2333 1    BACKBONE|DICT
+  2202 2324 2325 1    BACKBONE|DICT
+  2203 2324 2327 1    DICT
+  2204 2324 2323 1    BACKBONE|DICT
+  2205 2323 2332 1    BACKBONE|DICT
+  2206 2327 2334 1    DICT
+  2207 2327 2335 1    DICT
+  2208 2327 2328 1    DICT
+  2209 2328 2336 1    DICT
+  2210 2328 2337 1    DICT
+  2211 2328 2329 1    DICT
+  2212 2329 2330 ar   DICT
+  2213 2329 2331 ar   DICT
+  2214 2325 2326 2    BACKBONE|DICT
+  2215 2339 2347 1    BACKBONE|DICT
+  2216 2339 2340 1    BACKBONE|DICT
+  2217 2339 2342 1    DICT
+  2218 2339 2338 1    BACKBONE|DICT
+  2219 2338 2346 1    BACKBONE|DICT
+  2220 2342 2348 1    DICT
+  2221 2342 2343 1    DICT
+  2222 2342 2344 1    DICT
+  2223 2344 2351 1    DICT
+  2224 2344 2352 1    DICT
+  2225 2344 2353 1    DICT
+  2226 2343 2349 1    DICT
+  2227 2343 2350 1    DICT
+  2228 2343 2345 1    DICT
+  2229 2345 2354 1    DICT
+  2230 2345 2355 1    DICT
+  2231 2345 2356 1    DICT
+  2232 2340 2341 2    BACKBONE|DICT
+  2233 2358 2365 1    BACKBONE|DICT
+  2234 2358 2359 1    BACKBONE|DICT
+  2235 2358 2361 1    DICT
+  2236 2358 2357 1    BACKBONE|DICT
+  2237 2357 2364 1    BACKBONE|DICT
+  2238 2361 2366 1    DICT
+  2239 2361 2362 1    DICT
+  2240 2361 2363 1    DICT
+  2241 2363 2370 1    DICT
+  2242 2363 2368 1    DICT
+  2243 2363 2369 1    DICT
+  2244 2362 2367 1    DICT
+  2245 2359 2360 2    BACKBONE|DICT
+  2246 2372 2384 1    BACKBONE|DICT
+  2247 2372 2373 1    BACKBONE|DICT
+  2248 2372 2375 1    DICT
+  2249 2372 2371 1    BACKBONE|DICT
+  2250 2371 2383 1    BACKBONE|DICT
+  2251 2375 2386 1    DICT
+  2252 2375 2385 1    DICT
+  2253 2375 2376 1    DICT
+  2254 2376 2378 ar   DICT
+  2255 2376 2377 ar   DICT
+  2256 2377 2387 1    DICT
+  2257 2377 2379 ar   DICT
+  2258 2379 2389 1    DICT
+  2259 2379 2381 ar   DICT
+  2260 2381 2382 1    DICT
+  2261 2381 2380 ar   DICT
+  2262 2380 2390 1    DICT
+  2263 2380 2378 ar   DICT
+  2264 2378 2388 1    DICT
+  2265 2382 2391 1    DICT
+  2266 2373 2374 2    BACKBONE|DICT
+  2267 2393 2400 1    BACKBONE|DICT
+  2268 2393 2394 1    BACKBONE|DICT
+  2269 2393 2396 1    DICT
+  2270 2393 2392 1    BACKBONE|DICT
+  2271 2392 2399 1    BACKBONE|DICT
+  2272 2396 2401 1    DICT
+  2273 2396 2397 1    DICT
+  2274 2396 2398 1    DICT
+  2275 2398 2405 1    DICT
+  2276 2398 2403 1    DICT
+  2277 2398 2404 1    DICT
+  2278 2397 2402 1    DICT
+  2279 2394 2395 2    BACKBONE|DICT
+  2280 2407 2413 1    BACKBONE|DICT
+  2281 2407 2406 1    BACKBONE|DICT
+  2282 2407 2410 1    DICT
+  2283 2407 2408 1    BACKBONE|DICT
+  2284 2408 2409 2    BACKBONE|DICT
+  2285 2410 2414 1    DICT
+  2286 2410 2415 1    DICT
+  2287 2410 2411 1    DICT
+  2288 2411 2417 1    DICT
+  2289 2411 2416 1    DICT
+  2290 2411 2412 1    DICT
+  2291 2412 2419 1    DICT
+  2292 2412 2418 1    DICT
+  2293 2412 2406 1    DICT
+  2294 2421 2427 1    BACKBONE|DICT
+  2295 2421 2422 1    BACKBONE|DICT
+  2296 2421 2424 1    DICT
+  2297 2421 2420 1    BACKBONE|DICT
+  2298 2420 2426 1    BACKBONE|DICT
+  2299 2424 2428 1    DICT
+  2300 2424 2429 1    DICT
+  2301 2424 2425 1    DICT
+  2302 2425 2430 1    DICT
+  2303 2422 2423 2    BACKBONE|DICT
+  2304 2432 2440 1    BACKBONE|DICT
+  2305 2432 2433 1    BACKBONE|DICT
+  2306 2432 2435 1    DICT
+  2307 2432 2431 1    BACKBONE|DICT
+  2308 2431 2439 1    BACKBONE|DICT
+  2309 2435 2441 1    DICT
+  2310 2435 2442 1    DICT
+  2311 2435 2436 1    DICT
+  2312 2436 2438 ar   DICT
+  2313 2436 2437 ar   DICT
+  2314 2433 2434 2    BACKBONE|DICT
+  2315 2444 2449 1    DICT
+  2316 2444 2448 1    BACKBONE|DICT
+  2317 2444 2445 1    BACKBONE|DICT
+  2318 2444 2443 1    BACKBONE|DICT
+  2319 2443 2447 1    BACKBONE|DICT
+  2320 2445 2446 2    BACKBONE|DICT
+  2321 2451 2458 1    BACKBONE|DICT
+  2322 2451 2452 1    BACKBONE|DICT
+  2323 2451 2454 1    DICT
+  2324 2451 2450 1    BACKBONE|DICT
+  2325 2450 2457 1    BACKBONE|DICT
+  2326 2454 2459 1    DICT
+  2327 2454 2455 1    DICT
+  2328 2454 2456 1    DICT
+  2329 2456 2463 1    DICT
+  2330 2456 2461 1    DICT
+  2331 2456 2462 1    DICT
+  2332 2455 2460 1    DICT
+  2333 2452 2453 2    BACKBONE|DICT
+  2334 2465 2474 1    BACKBONE|DICT
+  2335 2465 2466 1    BACKBONE|DICT
+  2336 2465 2468 1    DICT
+  2337 2465 2464 1    BACKBONE|DICT
+  2338 2464 2473 1    BACKBONE|DICT
+  2339 2468 2475 1    DICT
+  2340 2468 2476 1    DICT
+  2341 2468 2469 1    DICT
+  2342 2469 2477 1    DICT
+  2343 2469 2478 1    DICT
+  2344 2469 2470 1    DICT
+  2345 2470 2471 2    DICT
+  2346 2470 2472 am   DICT
+  2347 2472 2480 1    DICT
+  2348 2472 2479 1    DICT
+  2349 2466 2467 2    BACKBONE|DICT
+  2350 2482 2491 1    BACKBONE|DICT
+  2351 2482 2483 1    BACKBONE|DICT
+  2352 2482 2485 1    DICT
+  2353 2482 2481 1    BACKBONE|DICT
+  2354 2481 2490 1    BACKBONE|DICT
+  2355 2485 2492 1    DICT
+  2356 2485 2493 1    DICT
+  2357 2485 2486 1    DICT
+  2358 2486 2494 1    DICT
+  2359 2486 2495 1    DICT
+  2360 2486 2487 1    DICT
+  2361 2487 2496 1    DICT
+  2362 2487 2497 1    DICT
+  2363 2487 2488 1    DICT
+  2364 2488 2498 1    DICT
+  2365 2488 2499 1    DICT
+  2366 2488 2489 1    DICT
+  2367 2489 2500 1    DICT
+  2368 2489 2501 1    DICT
+  2369 2489 2502 1    DICT
+  2370 2483 2484 2    BACKBONE|DICT
+  2371 2504 2511 1    BACKBONE|DICT
+  2372 2504 2505 1    BACKBONE|DICT
+  2373 2504 2507 1    DICT
+  2374 2504 2503 1    BACKBONE|DICT
+  2375 2503 2510 1    BACKBONE|DICT
+  2376 2507 2512 1    DICT
+  2377 2507 2508 1    DICT
+  2378 2507 2509 1    DICT
+  2379 2509 2516 1    DICT
+  2380 2509 2517 1    DICT
+  2381 2509 2518 1    DICT
+  2382 2508 2513 1    DICT
+  2383 2508 2514 1    DICT
+  2384 2508 2515 1    DICT
+  2385 2505 2506 2    BACKBONE|DICT
+  2386 2520 2527 1    BACKBONE|DICT
+  2387 2520 2521 1    BACKBONE|DICT
+  2388 2520 2523 1    DICT
+  2389 2520 2519 1    BACKBONE|DICT
+  2390 2519 2526 1    BACKBONE|DICT
+  2391 2523 2528 1    DICT
+  2392 2523 2524 1    DICT
+  2393 2523 2525 1    DICT
+  2394 2525 2532 1    DICT
+  2395 2525 2530 1    DICT
+  2396 2525 2531 1    DICT
+  2397 2524 2529 1    DICT
+  2398 2521 2522 2    BACKBONE|DICT
+  2399 2534 2546 1    BACKBONE|DICT
+  2400 2534 2535 1    BACKBONE|DICT
+  2401 2534 2537 1    DICT
+  2402 2534 2533 1    BACKBONE|DICT
+  2403 2533 2545 1    BACKBONE|DICT
+  2404 2537 2548 1    DICT
+  2405 2537 2547 1    DICT
+  2406 2537 2538 1    DICT
+  2407 2538 2540 ar   DICT
+  2408 2538 2539 ar   DICT
+  2409 2539 2549 1    DICT
+  2410 2539 2541 ar   DICT
+  2411 2541 2551 1    DICT
+  2412 2541 2543 ar   DICT
+  2413 2543 2544 1    DICT
+  2414 2543 2542 ar   DICT
+  2415 2542 2552 1    DICT
+  2416 2542 2540 ar   DICT
+  2417 2540 2550 1    DICT
+  2418 2544 2553 1    DICT
+  2419 2535 2536 2    BACKBONE|DICT
+  2420 2555 2563 1    BACKBONE|DICT
+  2421 2555 2556 1    BACKBONE|DICT
+  2422 2555 2558 1    DICT
+  2423 2555 2554 1    BACKBONE|DICT
+  2424 2554 2562 1    BACKBONE|DICT
+  2425 2558 2564 1    DICT
+  2426 2558 2565 1    DICT
+  2427 2558 2559 1    DICT
+  2428 2559 2566 1    DICT
+  2429 2559 2561 1    DICT
+  2430 2559 2560 1    DICT
+  2431 2560 2567 1    DICT
+  2432 2560 2568 1    DICT
+  2433 2560 2569 1    DICT
+  2434 2561 2570 1    DICT
+  2435 2561 2571 1    DICT
+  2436 2561 2572 1    DICT
+  2437 2556 2557 2    BACKBONE|DICT
+  2438 2574 2581 1    BACKBONE|DICT
+  2439 2574 2575 1    BACKBONE|DICT
+  2440 2574 2577 1    DICT
+  2441 2574 2573 1    BACKBONE|DICT
+  2442 2573 2580 1    BACKBONE|DICT
+  2443 2577 2582 1    DICT
+  2444 2577 2578 1    DICT
+  2445 2577 2579 1    DICT
+  2446 2579 2586 1    DICT
+  2447 2579 2587 1    DICT
+  2448 2579 2588 1    DICT
+  2449 2578 2583 1    DICT
+  2450 2578 2584 1    DICT
+  2451 2578 2585 1    DICT
+  2452 2575 2576 2    BACKBONE|DICT
+  2453 2590 2600 1    BACKBONE|DICT
+  2454 2590 2591 1    BACKBONE|DICT
+  2455 2590 2593 1    DICT
+  2456 2590 2589 1    BACKBONE|DICT
+  2457 2589 2599 1    BACKBONE|DICT
+  2458 2593 2601 1    DICT
+  2459 2593 2602 1    DICT
+  2460 2593 2594 1    DICT
+  2461 2594 2596 2    DICT
+  2462 2594 2595 1    DICT
+  2463 2595 2597 2    DICT
+  2464 2597 2604 1    DICT
+  2465 2597 2598 1    DICT
+  2466 2598 2605 1    DICT
+  2467 2598 2596 1    DICT
+  2468 2596 2603 1    DICT
+  2469 2591 2592 2    BACKBONE|DICT
+  2470 2607 2615 1    BACKBONE|DICT
+  2471 2607 2608 1    BACKBONE|DICT
+  2472 2607 2610 1    DICT
+  2473 2607 2606 1    BACKBONE|DICT
+  2474 2606 2614 1    BACKBONE|DICT
+  2475 2610 2616 1    DICT
+  2476 2610 2617 1    DICT
+  2477 2610 2611 1    DICT
+  2478 2611 2612 2    DICT
+  2479 2611 2613 am   DICT
+  2480 2613 2619 1    DICT
+  2481 2613 2618 1    DICT
+  2482 2608 2609 2    BACKBONE|DICT
+  2483 2621 2632 1    BACKBONE|DICT
+  2484 2621 2622 1    BACKBONE|DICT
+  2485 2621 2624 1    DICT
+  2486 2621 2620 1    BACKBONE|DICT
+  2487 2620 2631 1    BACKBONE|DICT
+  2488 2624 2633 1    DICT
+  2489 2624 2634 1    DICT
+  2490 2624 2625 1    DICT
+  2491 2625 2627 ar   DICT
+  2492 2625 2626 ar   DICT
+  2493 2626 2635 1    DICT
+  2494 2626 2628 ar   DICT
+  2495 2628 2637 1    DICT
+  2496 2628 2630 ar   DICT
+  2497 2630 2639 1    DICT
+  2498 2630 2629 ar   DICT
+  2499 2629 2638 1    DICT
+  2500 2629 2627 ar   DICT
+  2501 2627 2636 1    DICT
+  2502 2622 2623 2    BACKBONE|DICT
+  2503 2641 2650 1    BACKBONE|DICT
+  2504 2641 2642 1    BACKBONE|DICT
+  2505 2641 2644 1    DICT
+  2506 2641 2640 1    BACKBONE|DICT
+  2507 2640 2649 1    BACKBONE|DICT
+  2508 2644 2651 1    DICT
+  2509 2644 2652 1    DICT
+  2510 2644 2645 1    DICT
+  2511 2645 2653 1    DICT
+  2512 2645 2654 1    DICT
+  2513 2645 2646 1    DICT
+  2514 2646 2647 ar   DICT
+  2515 2646 2648 ar   DICT
+  2516 2642 2643 2    BACKBONE|DICT
+  2517 2656 2665 1    BACKBONE|DICT
+  2518 2656 2657 1    BACKBONE|DICT
+  2519 2656 2659 1    DICT
+  2520 2656 2655 1    BACKBONE|DICT
+  2521 2655 2664 1    BACKBONE|DICT
+  2522 2659 2666 1    DICT
+  2523 2659 2667 1    DICT
+  2524 2659 2660 1    DICT
+  2525 2660 2668 1    DICT
+  2526 2660 2669 1    DICT
+  2527 2660 2661 1    DICT
+  2528 2661 2662 ar   DICT
+  2529 2661 2663 ar   DICT
+  2530 2657 2658 2    BACKBONE|DICT
+  2531 2671 2676 1    DICT
+  2532 2671 2675 1    BACKBONE|DICT
+  2533 2671 2672 1    BACKBONE|DICT
+  2534 2671 2670 1    BACKBONE|DICT
+  2535 2670 2674 1    BACKBONE|DICT
+  2536 2672 2673 2    BACKBONE|DICT
+  2537 2678 2683 1    DICT
+  2538 2678 2682 1    BACKBONE|DICT
+  2539 2678 2679 1    BACKBONE|DICT
+  2540 2678 2677 1    BACKBONE|DICT
+  2541 2677 2681 1    BACKBONE|DICT
+  2542 2679 2680 2    BACKBONE|DICT
+  2543 2685 2690 1    DICT
+  2544 2685 2689 1    BACKBONE|DICT
+  2545 2685 2686 1    BACKBONE|DICT
+  2546 2685 2684 1    BACKBONE|DICT
+  2547 2684 2688 1    BACKBONE|DICT
+  2548 2686 2687 2    BACKBONE|DICT
+  2549 2692 2699 1    BACKBONE|DICT
+  2550 2692 2693 1    BACKBONE|DICT
+  2551 2692 2695 1    DICT
+  2552 2692 2691 1    BACKBONE|DICT
+  2553 2691 2698 1    BACKBONE|DICT
+  2554 2695 2700 1    DICT
+  2555 2695 2696 1    DICT
+  2556 2695 2697 1    DICT
+  2557 2697 2704 1    DICT
+  2558 2697 2705 1    DICT
+  2559 2697 2706 1    DICT
+  2560 2696 2701 1    DICT
+  2561 2696 2702 1    DICT
+  2562 2696 2703 1    DICT
+  2563 2693 2694 2    BACKBONE|DICT
+  2564 2708 2713 1    BACKBONE|DICT
+  2565 2708 2709 1    BACKBONE|DICT
+  2566 2708 2711 1    DICT
+  2567 2708 2707 1    BACKBONE|DICT
+  2568 2707 2712 1    BACKBONE|DICT
+  2569 2711 2714 1    DICT
+  2570 2711 2715 1    DICT
+  2571 2711 2716 1    DICT
+  2572 2709 2710 2    BACKBONE|DICT
+  2573 2718 2726 1    BACKBONE|DICT
+  2574 2718 2719 1    BACKBONE|DICT
+  2575 2718 2721 1    DICT
+  2576 2718 2717 1    BACKBONE|DICT
+  2577 2717 2725 1    BACKBONE|DICT
+  2578 2721 2727 1    DICT
+  2579 2721 2728 1    DICT
+  2580 2721 2722 1    DICT
+  2581 2722 2729 1    DICT
+  2582 2722 2730 1    DICT
+  2583 2722 2723 1    DICT
+  2584 2723 2724 1    DICT
+  2585 2724 2731 1    DICT
+  2586 2724 2732 1    DICT
+  2587 2724 2733 1    DICT
+  2588 2719 2720 2    BACKBONE|DICT
+  2589 2735 2740 1    DICT
+  2590 2735 2739 1    BACKBONE|DICT
+  2591 2735 2736 1    BACKBONE|DICT
+  2592 2735 2734 1    BACKBONE|DICT
+  2593 2734 2738 1    BACKBONE|DICT
+  2594 2736 2737 2    BACKBONE|DICT
+  2595 2742 2750 1    BACKBONE|DICT
+  2596 2742 2743 1    BACKBONE|DICT
+  2597 2742 2745 1    DICT
+  2598 2742 2741 1    BACKBONE|DICT
+  2599 2741 2749 1    BACKBONE|DICT
+  2600 2745 2751 1    DICT
+  2601 2745 2752 1    DICT
+  2602 2745 2746 1    DICT
+  2603 2746 2753 1    DICT
+  2604 2746 2754 1    DICT
+  2605 2746 2747 1    DICT
+  2606 2747 2748 1    DICT
+  2607 2748 2755 1    DICT
+  2608 2748 2756 1    DICT
+  2609 2748 2757 1    DICT
+  2610 2743 2744 2    BACKBONE|DICT
+  2611 2759 2771 1    BACKBONE|DICT
+  2612 2759 2760 1    BACKBONE|DICT
+  2613 2759 2762 1    DICT
+  2614 2759 2758 1    BACKBONE|DICT
+  2615 2758 2770 1    BACKBONE|DICT
+  2616 2762 2773 1    DICT
+  2617 2762 2772 1    DICT
+  2618 2762 2763 1    DICT
+  2619 2763 2765 ar   DICT
+  2620 2763 2764 ar   DICT
+  2621 2764 2774 1    DICT
+  2622 2764 2766 ar   DICT
+  2623 2766 2776 1    DICT
+  2624 2766 2768 ar   DICT
+  2625 2768 2769 1    DICT
+  2626 2768 2767 ar   DICT
+  2627 2767 2777 1    DICT
+  2628 2767 2765 ar   DICT
+  2629 2765 2775 1    DICT
+  2630 2769 2778 1    DICT
+  2631 2760 2761 2    BACKBONE|DICT
+  2632 2780 2788 1    BACKBONE|DICT
+  2633 2780 2781 1    BACKBONE|DICT
+  2634 2780 2783 1    DICT
+  2635 2780 2779 1    BACKBONE|DICT
+  2636 2779 2787 1    BACKBONE|DICT
+  2637 2783 2789 1    DICT
+  2638 2783 2790 1    DICT
+  2639 2783 2784 1    DICT
+  2640 2784 2785 2    DICT
+  2641 2784 2786 am   DICT
+  2642 2786 2792 1    DICT
+  2643 2786 2791 1    DICT
+  2644 2781 2782 2    BACKBONE|DICT
+  2645 2794 2803 1    BACKBONE|DICT
+  2646 2794 2795 1    BACKBONE|DICT
+  2647 2794 2797 1    DICT
+  2648 2794 2793 1    BACKBONE|DICT
+  2649 2793 2802 1    BACKBONE|DICT
+  2650 2797 2804 1    DICT
+  2651 2797 2805 1    DICT
+  2652 2797 2798 1    DICT
+  2653 2798 2806 1    DICT
+  2654 2798 2807 1    DICT
+  2655 2798 2799 1    DICT
+  2656 2799 2800 2    DICT
+  2657 2799 2801 am   DICT
+  2658 2801 2809 1    DICT
+  2659 2801 2808 1    DICT
+  2660 2795 2796 2    BACKBONE|DICT
+  2661 2811 2819 1    BACKBONE|DICT
+  2662 2811 2812 1    BACKBONE|DICT
+  2663 2811 2814 1    DICT
+  2664 2811 2810 1    BACKBONE|DICT
+  2665 2810 2818 1    BACKBONE|DICT
+  2666 2814 2820 1    DICT
+  2667 2814 2821 1    DICT
+  2668 2814 2815 1    DICT
+  2669 2815 2817 ar   DICT
+  2670 2815 2816 ar   DICT
+  2671 2812 2813 2    BACKBONE|DICT
+  2672 2823 2832 1    BACKBONE|DICT
+  2673 2823 2824 1    BACKBONE|DICT
+  2674 2823 2826 1    DICT
+  2675 2823 2822 1    BACKBONE|DICT
+  2676 2822 2831 1    BACKBONE|DICT
+  2677 2826 2833 1    DICT
+  2678 2826 2834 1    DICT
+  2679 2826 2827 1    DICT
+  2680 2827 2835 1    DICT
+  2681 2827 2836 1    DICT
+  2682 2827 2828 1    DICT
+  2683 2828 2837 1    DICT
+  2684 2828 2838 1    DICT
+  2685 2828 2829 1    DICT
+  2686 2829 2839 1    DICT
+  2687 2829 2840 1    DICT
+  2688 2829 2830 1    DICT
+  2689 2830 2841 1    DICT
+  2690 2830 2842 1    DICT
+  2691 2830 2843 1    DICT
+  2692 2824 2825 2    BACKBONE|DICT
+  2693 2845 2851 1    BACKBONE|DICT
+  2694 2845 2846 1    BACKBONE|DICT
+  2695 2845 2848 1    DICT
+  2696 2845 2844 1    BACKBONE|DICT
+  2697 2844 2850 1    BACKBONE|DICT
+  2698 2848 2852 1    DICT
+  2699 2848 2853 1    DICT
+  2700 2848 2849 1    DICT
+  2701 2849 2854 1    DICT
+  2702 2846 2847 2    BACKBONE|DICT
+  2703 2856 2864 1    BACKBONE|DICT
+  2704 2856 2857 1    BACKBONE|DICT
+  2705 2856 2859 1    DICT
+  2706 2856 2855 1    BACKBONE|DICT
+  2707 2855 2863 1    BACKBONE|DICT
+  2708 2859 2865 1    DICT
+  2709 2859 2860 1    DICT
+  2710 2859 2861 1    DICT
+  2711 2861 2868 1    DICT
+  2712 2861 2869 1    DICT
+  2713 2861 2870 1    DICT
+  2714 2860 2866 1    DICT
+  2715 2860 2867 1    DICT
+  2716 2860 2862 1    DICT
+  2717 2862 2871 1    DICT
+  2718 2862 2872 1    DICT
+  2719 2862 2873 1    DICT
+  2720 2857 2858 2    BACKBONE|DICT
+  2721 2875 2884 1    BACKBONE|DICT
+  2722 2875 2876 1    BACKBONE|DICT
+  2723 2875 2878 1    DICT
+  2724 2875 2874 1    BACKBONE|DICT
+  2725 2874 2883 1    BACKBONE|DICT
+  2726 2878 2885 1    DICT
+  2727 2878 2886 1    DICT
+  2728 2878 2879 1    DICT
+  2729 2879 2887 1    DICT
+  2730 2879 2888 1    DICT
+  2731 2879 2880 1    DICT
+  2732 2880 2881 ar   DICT
+  2733 2880 2882 ar   DICT
+  2734 2876 2877 2    BACKBONE|DICT
+  2735 2890 2898 1    BACKBONE|DICT
+  2736 2890 2891 1    BACKBONE|DICT
+  2737 2890 2893 1    DICT
+  2738 2890 2889 1    BACKBONE|DICT
+  2739 2889 2897 1    BACKBONE|DICT
+  2740 2893 2899 1    DICT
+  2741 2893 2900 1    DICT
+  2742 2893 2894 1    DICT
+  2743 2894 2896 ar   DICT
+  2744 2894 2895 ar   DICT
+  2745 2891 2892 2    BACKBONE|DICT
+  2746 2902 2913 1    BACKBONE|DICT
+  2747 2902 2903 1    BACKBONE|DICT
+  2748 2902 2905 1    DICT
+  2749 2902 2901 1    BACKBONE|DICT
+  2750 2901 2912 1    BACKBONE|DICT
+  2751 2905 2914 1    DICT
+  2752 2905 2915 1    DICT
+  2753 2905 2906 1    DICT
+  2754 2906 2908 ar   DICT
+  2755 2906 2907 ar   DICT
+  2756 2907 2916 1    DICT
+  2757 2907 2909 ar   DICT
+  2758 2909 2918 1    DICT
+  2759 2909 2911 ar   DICT
+  2760 2911 2920 1    DICT
+  2761 2911 2910 ar   DICT
+  2762 2910 2919 1    DICT
+  2763 2910 2908 ar   DICT
+  2764 2908 2917 1    DICT
+  2765 2903 2904 2    BACKBONE|DICT
+  2766 2922 2927 1    BACKBONE|DICT
+  2767 2922 2923 1    BACKBONE|DICT
+  2768 2922 2925 1    DICT
+  2769 2922 2921 1    BACKBONE|DICT
+  2770 2921 2926 1    BACKBONE|DICT
+  2771 2925 2928 1    DICT
+  2772 2925 2929 1    DICT
+  2773 2925 2930 1    DICT
+  2774 2923 2924 2    BACKBONE|DICT
+  2775 2932 2942 1    BACKBONE|DICT
+  2776 2932 2933 1    BACKBONE|DICT
+  2777 2932 2935 1    DICT
+  2778 2932 2931 1    BACKBONE|DICT
+  2779 2931 2941 1    BACKBONE|DICT
+  2780 2935 2943 1    DICT
+  2781 2935 2944 1    DICT
+  2782 2935 2936 1    DICT
+  2783 2936 2938 2    DICT
+  2784 2936 2937 1    DICT
+  2785 2937 2939 2    DICT
+  2786 2939 2946 1    DICT
+  2787 2939 2940 1    DICT
+  2788 2940 2947 1    DICT
+  2789 2940 2938 1    DICT
+  2790 2938 2945 1    DICT
+  2791 2933 2934 2    BACKBONE|DICT
+  2792 2949 2955 1    BACKBONE|DICT
+  2793 2949 2950 1    BACKBONE|DICT
+  2794 2949 2952 1    DICT
+  2795 2949 2948 1    BACKBONE|DICT
+  2796 2948 2954 1    BACKBONE|DICT
+  2797 2952 2956 1    DICT
+  2798 2952 2957 1    DICT
+  2799 2952 2953 1    DICT
+  2800 2953 2958 1    DICT
+  2801 2950 2951 2    BACKBONE|DICT
+  2802 2960 2966 1    BACKBONE|DICT
+  2803 2960 2961 1    BACKBONE|DICT
+  2804 2960 2963 1    DICT
+  2805 2960 2959 1    BACKBONE|DICT
+  2806 2959 2965 1    BACKBONE|DICT
+  2807 2963 2967 1    DICT
+  2808 2963 2968 1    DICT
+  2809 2963 2964 1    DICT
+  2810 2964 2969 1    DICT
+  2811 2961 2962 2    BACKBONE|DICT
+  2812 2971 2982 1    BACKBONE|DICT
+  2813 2971 2972 1    BACKBONE|DICT
+  2814 2971 2974 1    DICT
+  2815 2971 2970 1    BACKBONE|DICT
+  2816 2970 2981 1    BACKBONE|DICT
+  2817 2974 2983 1    DICT
+  2818 2974 2984 1    DICT
+  2819 2974 2975 1    DICT
+  2820 2975 2977 ar   DICT
+  2821 2975 2976 ar   DICT
+  2822 2976 2985 1    DICT
+  2823 2976 2978 ar   DICT
+  2824 2978 2987 1    DICT
+  2825 2978 2980 ar   DICT
+  2826 2980 2989 1    DICT
+  2827 2980 2979 ar   DICT
+  2828 2979 2988 1    DICT
+  2829 2979 2977 ar   DICT
+  2830 2977 2986 1    DICT
+  2831 2972 2973 2    BACKBONE|DICT
+  2832 2991 3000 1    BACKBONE|DICT
+  2833 2991 2992 1    BACKBONE|DICT
+  2834 2991 2994 1    DICT
+  2835 2991 2990 1    BACKBONE|DICT
+  2836 2990 2999 1    BACKBONE|DICT
+  2837 2994 3001 1    DICT
+  2838 2994 3002 1    DICT
+  2839 2994 2995 1    DICT
+  2840 2995 3003 1    DICT
+  2841 2995 3004 1    DICT
+  2842 2995 2996 1    DICT
+  2843 2996 2997 2    DICT
+  2844 2996 2998 am   DICT
+  2845 2998 3006 1    DICT
+  2846 2998 3005 1    DICT
+  2847 2992 2993 2    BACKBONE|DICT
+  2848 3008 3016 1    BACKBONE|DICT
+  2849 3008 3009 1    BACKBONE|DICT
+  2850 3008 3011 1    DICT
+  2851 3008 3007 1    BACKBONE|DICT
+  2852 3007 3015 1    BACKBONE|DICT
+  2853 3011 3017 1    DICT
+  2854 3011 3018 1    DICT
+  2855 3011 3012 1    DICT
+  2856 3012 3019 1    DICT
+  2857 3012 3020 1    DICT
+  2858 3012 3013 1    DICT
+  2859 3013 3014 1    DICT
+  2860 3014 3021 1    DICT
+  2861 3014 3022 1    DICT
+  2862 3014 3023 1    DICT
+  2863 3009 3010 2    BACKBONE|DICT
+  2864 3025 3030 1    BACKBONE|DICT
+  2865 3025 3026 1    BACKBONE|DICT
+  2866 3025 3028 1    DICT
+  2867 3025 3024 1    BACKBONE|DICT
+  2868 3024 3029 1    BACKBONE|DICT
+  2869 3028 3031 1    DICT
+  2870 3028 3032 1    DICT
+  2871 3028 3033 1    DICT
+  2872 3026 3027 2    BACKBONE|DICT
+  2873 3035 3043 1    BACKBONE|DICT
+  2874 3035 3036 1    BACKBONE|DICT
+  2875 3035 3038 1    DICT
+  2876 3035 3034 1    BACKBONE|DICT
+  2877 3034 3042 1    BACKBONE|DICT
+  2878 3038 3044 1    DICT
+  2879 3038 3045 1    DICT
+  2880 3038 3039 1    DICT
+  2881 3039 3046 1    DICT
+  2882 3039 3041 1    DICT
+  2883 3039 3040 1    DICT
+  2884 3040 3047 1    DICT
+  2885 3040 3048 1    DICT
+  2886 3040 3049 1    DICT
+  2887 3041 3050 1    DICT
+  2888 3041 3051 1    DICT
+  2889 3041 3052 1    DICT
+  2890 3036 3037 2    BACKBONE|DICT
+  2891 3054 3060 1    BACKBONE|DICT
+  2892 3054 3055 1    BACKBONE|DICT
+  2893 3054 3057 1    DICT
+  2894 3054 3053 1    BACKBONE|DICT
+  2895 3053 3059 1    BACKBONE|DICT
+  2896 3057 3061 1    DICT
+  2897 3057 3062 1    DICT
+  2898 3057 3058 1    DICT
+  2899 3058 3063 1    DICT
+  2900 3055 3056 2    BACKBONE|DICT
+  2901 3065 3074 1    BACKBONE|DICT
+  2902 3065 3066 1    BACKBONE|DICT
+  2903 3065 3068 1    DICT
+  2904 3065 3064 1    BACKBONE|DICT
+  2905 3064 3073 1    BACKBONE|DICT
+  2906 3068 3075 1    DICT
+  2907 3068 3076 1    DICT
+  2908 3068 3069 1    DICT
+  2909 3069 3077 1    DICT
+  2910 3069 3078 1    DICT
+  2911 3069 3070 1    DICT
+  2912 3070 3079 1    DICT
+  2913 3070 3080 1    DICT
+  2914 3070 3071 1    DICT
+  2915 3071 3081 1    DICT
+  2916 3071 3082 1    DICT
+  2917 3071 3072 1    DICT
+  2918 3072 3083 1    DICT
+  2919 3072 3084 1    DICT
+  2920 3072 3085 1    DICT
+  2921 3066 3067 2    BACKBONE|DICT
+  2922 3087 3092 1    DICT
+  2923 3087 3091 1    BACKBONE|DICT
+  2924 3087 3088 1    BACKBONE|DICT
+  2925 3087 3086 1    BACKBONE|DICT
+  2926 3086 3090 1    BACKBONE|DICT
+  2927 3088 3089 2    BACKBONE|DICT
+  2928 3094 3108 1    BACKBONE|DICT
+  2929 3094 3095 1    BACKBONE|DICT
+  2930 3094 3097 1    DICT
+  2931 3094 3093 1    BACKBONE|DICT
+  2932 3093 3107 1    BACKBONE|DICT
+  2933 3097 3109 1    DICT
+  2934 3097 3110 1    DICT
+  2935 3097 3098 1    DICT
+  2936 3098 3100 1    DICT
+  2937 3098 3099 2    DICT
+  2938 3099 3111 1    DICT
+  2939 3099 3101 1    DICT
+  2940 3101 3112 1    DICT
+  2941 3101 3102 1    DICT
+  2942 3102 3104 ar   DICT
+  2943 3102 3100 ar   DICT
+  2944 3100 3103 ar   DICT
+  2945 3103 3113 1    DICT
+  2946 3103 3105 ar   DICT
+  2947 3105 3115 1    DICT
+  2948 3105 3106 ar   DICT
+  2949 3106 3116 1    DICT
+  2950 3106 3104 ar   DICT
+  2951 3104 3114 1    DICT
+  2952 3095 3096 2    BACKBONE|DICT
+  2953 3118 3124 1    BACKBONE|DICT
+  2954 3118 3117 1    BACKBONE|DICT
+  2955 3118 3121 1    DICT
+  2956 3118 3119 1    BACKBONE|DICT
+  2957 3119 3120 2    BACKBONE|DICT
+  2958 3121 3125 1    DICT
+  2959 3121 3126 1    DICT
+  2960 3121 3122 1    DICT
+  2961 3122 3128 1    DICT
+  2962 3122 3127 1    DICT
+  2963 3122 3123 1    DICT
+  2964 3123 3130 1    DICT
+  2965 3123 3129 1    DICT
+  2966 3123 3117 1    DICT
+  2967 3132 3140 1    BACKBONE|DICT
+  2968 3132 3133 1    BACKBONE|DICT
+  2969 3132 3135 1    DICT
+  2970 3132 3131 1    BACKBONE|DICT
+  2971 3131 3139 1    BACKBONE|DICT
+  2972 3135 3141 1    DICT
+  2973 3135 3142 1    DICT
+  2974 3135 3136 1    DICT
+  2975 3136 3143 1    DICT
+  2976 3136 3138 1    DICT
+  2977 3136 3137 1    DICT
+  2978 3137 3144 1    DICT
+  2979 3137 3145 1    DICT
+  2980 3137 3146 1    DICT
+  2981 3138 3147 1    DICT
+  2982 3138 3148 1    DICT
+  2983 3138 3149 1    DICT
+  2984 3133 3134 2    BACKBONE|DICT
+  2985 3151 3163 1    BACKBONE|DICT
+  2986 3151 3152 1    BACKBONE|DICT
+  2987 3151 3154 1    DICT
+  2988 3151 3150 1    BACKBONE|DICT
+  2989 3150 3162 1    BACKBONE|DICT
+  2990 3154 3165 1    DICT
+  2991 3154 3164 1    DICT
+  2992 3154 3155 1    DICT
+  2993 3155 3157 ar   DICT
+  2994 3155 3156 ar   DICT
+  2995 3156 3166 1    DICT
+  2996 3156 3158 ar   DICT
+  2997 3158 3168 1    DICT
+  2998 3158 3160 ar   DICT
+  2999 3160 3161 1    DICT
+  3000 3160 3159 ar   DICT
+  3001 3159 3169 1    DICT
+  3002 3159 3157 ar   DICT
+  3003 3157 3167 1    DICT
+  3004 3161 3170 1    DICT
+  3005 3152 3153 2    BACKBONE|DICT
+  3006 3172 3180 1    BACKBONE|DICT
+  3007 3172 3173 1    BACKBONE|DICT
+  3008 3172 3175 1    DICT
+  3009 3172 3171 1    BACKBONE|DICT
+  3010 3171 3179 1    BACKBONE|DICT
+  3011 3175 3181 1    DICT
+  3012 3175 3182 1    DICT
+  3013 3175 3176 1    DICT
+  3014 3176 3183 1    DICT
+  3015 3176 3178 1    DICT
+  3016 3176 3177 1    DICT
+  3017 3177 3184 1    DICT
+  3018 3177 3185 1    DICT
+  3019 3177 3186 1    DICT
+  3020 3178 3187 1    DICT
+  3021 3178 3188 1    DICT
+  3022 3178 3189 1    DICT
+  3023 3173 3174 2    BACKBONE|DICT
+  3024 3191 3197 1    BACKBONE|DICT
+  3025 3191 3192 1    BACKBONE|DICT
+  3026 3191 3194 1    DICT
+  3027 3191 3190 1    BACKBONE|DICT
+  3028 3190 3196 1    BACKBONE|DICT
+  3029 3194 3198 1    DICT
+  3030 3194 3199 1    DICT
+  3031 3194 3195 1    DICT
+  3032 3195 3200 1    DICT
+  3033 3192 3193 2    BACKBONE|DICT
+  3034 3202 3209 1    BACKBONE|DICT
+  3035 3202 3203 1    BACKBONE|DICT
+  3036 3202 3205 1    DICT
+  3037 3202 3201 1    BACKBONE|DICT
+  3038 3201 3208 1    BACKBONE|DICT
+  3039 3205 3210 1    DICT
+  3040 3205 3206 1    DICT
+  3041 3205 3207 1    DICT
+  3042 3207 3214 1    DICT
+  3043 3207 3212 1    DICT
+  3044 3207 3213 1    DICT
+  3045 3206 3211 1    DICT
+  3046 3203 3204 2    BACKBONE|DICT
+  3047 3216 3225 1    BACKBONE|DICT
+  3048 3216 3217 1    BACKBONE|DICT
+  3049 3216 3219 1    DICT
+  3050 3216 3215 1    BACKBONE|DICT
+  3051 3215 3224 1    BACKBONE|DICT
+  3052 3219 3226 1    DICT
+  3053 3219 3227 1    DICT
+  3054 3219 3220 1    DICT
+  3055 3220 3228 1    DICT
+  3056 3220 3229 1    DICT
+  3057 3220 3221 1    DICT
+  3058 3221 3230 1    DICT
+  3059 3221 3231 1    DICT
+  3060 3221 3222 1    DICT
+  3061 3222 3232 1    DICT
+  3062 3222 3233 1    DICT
+  3063 3222 3223 1    DICT
+  3064 3223 3234 1    DICT
+  3065 3223 3235 1    DICT
+  3066 3223 3236 1    DICT
+  3067 3217 3218 2    BACKBONE|DICT
+  3068 3238 3246 1    BACKBONE|DICT
+  3069 3238 3239 1    BACKBONE|DICT
+  3070 3238 3241 1    DICT
+  3071 3238 3237 1    BACKBONE|DICT
+  3072 3237 3245 1    BACKBONE|DICT
+  3073 3241 3247 1    DICT
+  3074 3241 3248 1    DICT
+  3075 3241 3242 1    DICT
+  3076 3242 3243 2    DICT
+  3077 3242 3244 am   DICT
+  3078 3244 3250 1    DICT
+  3079 3244 3249 1    DICT
+  3080 3239 3240 2    BACKBONE|DICT
+  3081 3252 3259 1    BACKBONE|DICT
+  3082 3252 3253 1    BACKBONE|DICT
+  3083 3252 3255 1    DICT
+  3084 3252 3251 1    BACKBONE|DICT
+  3085 3251 3258 1    BACKBONE|DICT
+  3086 3255 3260 1    DICT
+  3087 3255 3256 1    DICT
+  3088 3255 3257 1    DICT
+  3089 3257 3264 1    DICT
+  3090 3257 3262 1    DICT
+  3091 3257 3263 1    DICT
+  3092 3256 3261 1    DICT
+  3093 3253 3254 2    BACKBONE|DICT
+  3094 3266 3274 1    BACKBONE|DICT
+  3095 3266 3267 1    BACKBONE|DICT
+  3096 3266 3269 1    DICT
+  3097 3266 3265 1    BACKBONE|DICT
+  3098 3265 3273 1    BACKBONE|DICT
+  3099 3269 3275 1    DICT
+  3100 3269 3270 1    DICT
+  3101 3269 3271 1    DICT
+  3102 3271 3278 1    DICT
+  3103 3271 3279 1    DICT
+  3104 3271 3280 1    DICT
+  3105 3270 3276 1    DICT
+  3106 3270 3277 1    DICT
+  3107 3270 3272 1    DICT
+  3108 3272 3281 1    DICT
+  3109 3272 3282 1    DICT
+  3110 3272 3283 1    DICT
+  3111 3267 3268 2    BACKBONE|DICT
+  3112 3285 3293 1    BACKBONE|DICT
+  3113 3285 3286 1    BACKBONE|DICT
+  3114 3285 3288 1    DICT
+  3115 3285 3284 1    BACKBONE|DICT
+  3116 3284 3292 1    BACKBONE|DICT
+  3117 3288 3294 1    DICT
+  3118 3288 3295 1    DICT
+  3119 3288 3289 1    DICT
+  3120 3289 3296 1    DICT
+  3121 3289 3291 1    DICT
+  3122 3289 3290 1    DICT
+  3123 3290 3297 1    DICT
+  3124 3290 3298 1    DICT
+  3125 3290 3299 1    DICT
+  3126 3291 3300 1    DICT
+  3127 3291 3301 1    DICT
+  3128 3291 3302 1    DICT
+  3129 3286 3287 2    BACKBONE|DICT
+  3130 3304 3313 1    BACKBONE|DICT
+  3131 3304 3305 1    BACKBONE|DICT
+  3132 3304 3307 1    DICT
+  3133 3304 3303 1    BACKBONE|DICT
+  3134 3303 3312 1    BACKBONE|DICT
+  3135 3307 3314 1    DICT
+  3136 3307 3315 1    DICT
+  3137 3307 3308 1    DICT
+  3138 3308 3316 1    DICT
+  3139 3308 3317 1    DICT
+  3140 3308 3309 1    DICT
+  3141 3309 3318 1    DICT
+  3142 3309 3319 1    DICT
+  3143 3309 3310 1    DICT
+  3144 3310 3320 1    DICT
+  3145 3310 3321 1    DICT
+  3146 3310 3311 1    DICT
+  3147 3311 3322 1    DICT
+  3148 3311 3323 1    DICT
+  3149 3311 3324 1    DICT
+  3150 3305 3306 2    BACKBONE|DICT
+  3151 3326 3335 1    BACKBONE|DICT
+  3152 3326 3327 1    BACKBONE|DICT
+  3153 3326 3329 1    DICT
+  3154 3326 3325 1    BACKBONE|DICT
+  3155 3325 3334 1    BACKBONE|DICT
+  3156 3329 3336 1    DICT
+  3157 3329 3337 1    DICT
+  3158 3329 3330 1    DICT
+  3159 3330 3338 1    DICT
+  3160 3330 3339 1    DICT
+  3161 3330 3331 1    DICT
+  3162 3331 3340 1    DICT
+  3163 3331 3341 1    DICT
+  3164 3331 3332 1    DICT
+  3165 3332 3342 1    DICT
+  3166 3332 3343 1    DICT
+  3167 3332 3333 1    DICT
+  3168 3333 3344 1    DICT
+  3169 3333 3345 1    DICT
+  3170 3333 3346 1    DICT
+  3171 3327 3328 2    BACKBONE|DICT
+  3172 3348 3360 1    BACKBONE|DICT
+  3173 3348 3349 1    BACKBONE|DICT
+  3174 3348 3351 1    DICT
+  3175 3348 3347 1    BACKBONE|DICT
+  3176 3347 3359 1    BACKBONE|DICT
+  3177 3351 3362 1    DICT
+  3178 3351 3361 1    DICT
+  3179 3351 3352 1    DICT
+  3180 3352 3354 ar   DICT
+  3181 3352 3353 ar   DICT
+  3182 3353 3363 1    DICT
+  3183 3353 3355 ar   DICT
+  3184 3355 3365 1    DICT
+  3185 3355 3357 ar   DICT
+  3186 3357 3358 1    DICT
+  3187 3357 3356 ar   DICT
+  3188 3356 3366 1    DICT
+  3189 3356 3354 ar   DICT
+  3190 3354 3364 1    DICT
+  3191 3358 3367 1    DICT
+  3192 3349 3350 2    BACKBONE|DICT
+  3193 3369 3377 1    BACKBONE|DICT
+  3194 3369 3370 1    BACKBONE|DICT
+  3195 3369 3372 1    DICT
+  3196 3369 3368 1    BACKBONE|DICT
+  3197 3368 3376 1    BACKBONE|DICT
+  3198 3372 3378 1    DICT
+  3199 3372 3379 1    DICT
+  3200 3372 3373 1    DICT
+  3201 3373 3375 ar   DICT
+  3202 3373 3374 ar   DICT
+  3203 3370 3371 2    BACKBONE|DICT
+  3204 3381 3386 1    DICT
+  3205 3381 3385 1    BACKBONE|DICT
+  3206 3381 3382 1    BACKBONE|DICT
+  3207 3381 3380 1    BACKBONE|DICT
+  3208 3380 3384 1    BACKBONE|DICT
+  3209 3382 3383 2    BACKBONE|DICT
+  3210 3388 3399 1    BACKBONE|DICT
+  3211 3388 3389 1    BACKBONE|DICT
+  3212 3388 3391 1    DICT
+  3213 3388 3387 1    BACKBONE|DICT
+  3214 3387 3398 1    BACKBONE|DICT
+  3215 3391 3400 1    DICT
+  3216 3391 3401 1    DICT
+  3217 3391 3392 1    DICT
+  3218 3392 3402 1    DICT
+  3219 3392 3403 1    DICT
+  3220 3392 3393 1    DICT
+  3221 3393 3404 1    DICT
+  3222 3393 3405 1    DICT
+  3223 3393 3394 1    DICT
+  3224 3394 3406 1    DICT
+  3225 3394 3395 ar   DICT
+  3226 3395 3396 ar   DICT
+  3227 3395 3397 ar   DICT
+  3228 3397 3410 1    DICT
+  3229 3397 3409 1    DICT
+  3230 3396 3408 1    DICT
+  3231 3396 3407 1    DICT
+  3232 3389 3390 2    BACKBONE|DICT
+  3233 3412 3423 1    BACKBONE|DICT
+  3234 3412 3413 1    BACKBONE|DICT
+  3235 3412 3415 1    DICT
+  3236 3412 3411 1    BACKBONE|DICT
+  3237 3411 3422 1    BACKBONE|DICT
+  3238 3415 3424 1    DICT
+  3239 3415 3425 1    DICT
+  3240 3415 3416 1    DICT
+  3241 3416 3418 ar   DICT
+  3242 3416 3417 ar   DICT
+  3243 3417 3426 1    DICT
+  3244 3417 3419 ar   DICT
+  3245 3419 3428 1    DICT
+  3246 3419 3421 ar   DICT
+  3247 3421 3430 1    DICT
+  3248 3421 3420 ar   DICT
+  3249 3420 3429 1    DICT
+  3250 3420 3418 ar   DICT
+  3251 3418 3427 1    DICT
+  3252 3413 3414 2    BACKBONE|DICT
+  3253 3432 3441 1    BACKBONE|DICT
+  3254 3432 3433 1    BACKBONE|DICT
+  3255 3432 3435 1    DICT
+  3256 3432 3431 1    BACKBONE|DICT
+  3257 3431 3440 1    BACKBONE|DICT
+  3258 3435 3442 1    DICT
+  3259 3435 3443 1    DICT
+  3260 3435 3436 1    DICT
+  3261 3436 3444 1    DICT
+  3262 3436 3445 1    DICT
+  3263 3436 3437 1    DICT
+  3264 3437 3446 1    DICT
+  3265 3437 3447 1    DICT
+  3266 3437 3438 1    DICT
+  3267 3438 3448 1    DICT
+  3268 3438 3449 1    DICT
+  3269 3438 3439 1    DICT
+  3270 3439 3450 1    DICT
+  3271 3439 3451 1    DICT
+  3272 3439 3452 1    DICT
+  3273 3433 3434 2    BACKBONE|DICT
+  3274 3454 3462 1    BACKBONE|DICT
+  3275 3454 3455 1    BACKBONE|DICT
+  3276 3454 3457 1    DICT
+  3277 3454 3453 1    BACKBONE|DICT
+  3278 3453 3461 1    BACKBONE|DICT
+  3279 3457 3463 1    DICT
+  3280 3457 3464 1    DICT
+  3281 3457 3458 1    DICT
+  3282 3458 3460 ar   DICT
+  3283 3458 3459 ar   DICT
+  3284 3455 3456 2    BACKBONE|DICT
+  3285 3466 3474 1    BACKBONE|DICT
+  3286 3466 3467 1    BACKBONE|DICT
+  3287 3466 3469 1    DICT
+  3288 3466 3465 1    BACKBONE|DICT
+  3289 3465 3473 1    BACKBONE|DICT
+  3290 3469 3475 1    DICT
+  3291 3469 3470 1    DICT
+  3292 3469 3471 1    DICT
+  3293 3471 3478 1    DICT
+  3294 3471 3479 1    DICT
+  3295 3471 3480 1    DICT
+  3296 3470 3476 1    DICT
+  3297 3470 3477 1    DICT
+  3298 3470 3472 1    DICT
+  3299 3472 3481 1    DICT
+  3300 3472 3482 1    DICT
+  3301 3472 3483 1    DICT
+  3302 3467 3468 2    BACKBONE|DICT
+  3303 3485 3496 1    BACKBONE|DICT
+  3304 3485 3486 1    BACKBONE|DICT
+  3305 3485 3488 1    DICT
+  3306 3485 3484 1    BACKBONE|DICT
+  3307 3484 3495 1    BACKBONE|DICT
+  3308 3488 3497 1    DICT
+  3309 3488 3498 1    DICT
+  3310 3488 3489 1    DICT
+  3311 3489 3491 ar   DICT
+  3312 3489 3490 ar   DICT
+  3313 3490 3499 1    DICT
+  3314 3490 3492 ar   DICT
+  3315 3492 3501 1    DICT
+  3316 3492 3494 ar   DICT
+  3317 3494 3503 1    DICT
+  3318 3494 3493 ar   DICT
+  3319 3493 3502 1    DICT
+  3320 3493 3491 ar   DICT
+  3321 3491 3500 1    DICT
+  3322 3486 3487 2    BACKBONE|DICT
+  3323 3505 3514 1    BACKBONE|DICT
+  3324 3505 3506 1    BACKBONE|DICT
+  3325 3505 3508 1    DICT
+  3326 3505 3504 1    BACKBONE|DICT
+  3327 3504 3513 1    BACKBONE|DICT
+  3328 3508 3515 1    DICT
+  3329 3508 3516 1    DICT
+  3330 3508 3509 1    DICT
+  3331 3509 3517 1    DICT
+  3332 3509 3518 1    DICT
+  3333 3509 3510 1    DICT
+  3334 3510 3511 2    DICT
+  3335 3510 3512 am   DICT
+  3336 3512 3520 1    DICT
+  3337 3512 3519 1    DICT
+  3338 3506 3507 2    BACKBONE|DICT
+  3339 3522 3531 1    BACKBONE|DICT
+  3340 3522 3523 1    BACKBONE|DICT
+  3341 3522 3525 1    DICT
+  3342 3522 3521 1    BACKBONE|DICT
+  3343 3521 3530 1    BACKBONE|DICT
+  3344 3525 3532 1    DICT
+  3345 3525 3533 1    DICT
+  3346 3525 3526 1    DICT
+  3347 3526 3534 1    DICT
+  3348 3526 3535 1    DICT
+  3349 3526 3527 1    DICT
+  3350 3527 3528 ar   DICT
+  3351 3527 3529 ar   DICT
+  3352 3523 3524 2    BACKBONE|DICT
+  3353 3537 3545 1    BACKBONE|DICT
+  3354 3537 3538 1    BACKBONE|DICT
+  3355 3537 3540 1    DICT
+  3356 3537 3536 1    BACKBONE|DICT
+  3357 3536 3544 1    BACKBONE|DICT
+  3358 3540 3546 1    DICT
+  3359 3540 3541 1    DICT
+  3360 3540 3542 1    DICT
+  3361 3542 3549 1    DICT
+  3362 3542 3550 1    DICT
+  3363 3542 3551 1    DICT
+  3364 3541 3547 1    DICT
+  3365 3541 3548 1    DICT
+  3366 3541 3543 1    DICT
+  3367 3543 3552 1    DICT
+  3368 3543 3553 1    DICT
+  3369 3543 3554 1    DICT
+  3370 3538 3539 2    BACKBONE|DICT
+  3371 3556 3568 1    BACKBONE|DICT
+  3372 3556 3557 1    BACKBONE|DICT
+  3373 3556 3559 1    DICT
+  3374 3556 3555 1    BACKBONE|DICT
+  3375 3555 3567 1    BACKBONE|DICT
+  3376 3559 3570 1    DICT
+  3377 3559 3569 1    DICT
+  3378 3559 3560 1    DICT
+  3379 3560 3562 ar   DICT
+  3380 3560 3561 ar   DICT
+  3381 3561 3571 1    DICT
+  3382 3561 3563 ar   DICT
+  3383 3563 3573 1    DICT
+  3384 3563 3565 ar   DICT
+  3385 3565 3566 1    DICT
+  3386 3565 3564 ar   DICT
+  3387 3564 3574 1    DICT
+  3388 3564 3562 ar   DICT
+  3389 3562 3572 1    DICT
+  3390 3566 3575 1    DICT
+  3391 3557 3558 2    BACKBONE|DICT
+  3392 3577 3585 1    BACKBONE|DICT
+  3393 3577 3578 1    BACKBONE|DICT
+  3394 3577 3580 1    DICT
+  3395 3577 3576 1    BACKBONE|DICT
+  3396 3576 3584 1    BACKBONE|DICT
+  3397 3580 3586 1    DICT
+  3398 3580 3587 1    DICT
+  3399 3580 3581 1    DICT
+  3400 3581 3583 ar   DICT
+  3401 3581 3582 ar   DICT
+  3402 3578 3579 2    BACKBONE|DICT
+  3403 3589 3598 1    BACKBONE|DICT
+  3404 3589 3590 1    BACKBONE|DICT
+  3405 3589 3592 1    DICT
+  3406 3589 3588 1    BACKBONE|DICT
+  3407 3588 3597 1    BACKBONE|DICT
+  3408 3592 3599 1    DICT
+  3409 3592 3600 1    DICT
+  3410 3592 3593 1    DICT
+  3411 3593 3601 1    DICT
+  3412 3593 3602 1    DICT
+  3413 3593 3594 1    DICT
+  3414 3594 3603 1    DICT
+  3415 3594 3604 1    DICT
+  3416 3594 3595 1    DICT
+  3417 3595 3605 1    DICT
+  3418 3595 3606 1    DICT
+  3419 3595 3596 1    DICT
+  3420 3596 3607 1    DICT
+  3421 3596 3608 1    DICT
+  3422 3596 3609 1    DICT
+  3423 3590 3591 2    BACKBONE|DICT
+  3424 3611 3620 1    BACKBONE|DICT
+  3425 3611 3612 1    BACKBONE|DICT
+  3426 3611 3614 1    DICT
+  3427 3611 3610 1    BACKBONE|DICT
+  3428 3610 3619 1    BACKBONE|DICT
+  3429 3614 3621 1    DICT
+  3430 3614 3622 1    DICT
+  3431 3614 3615 1    DICT
+  3432 3615 3623 1    DICT
+  3433 3615 3624 1    DICT
+  3434 3615 3616 1    DICT
+  3435 3616 3617 2    DICT
+  3436 3616 3618 am   DICT
+  3437 3618 3626 1    DICT
+  3438 3618 3625 1    DICT
+  3439 3612 3613 2    BACKBONE|DICT
+  3440 3628 3640 1    BACKBONE|DICT
+  3441 3628 3629 1    BACKBONE|DICT
+  3442 3628 3631 1    DICT
+  3443 3628 3627 1    BACKBONE|DICT
+  3444 3627 3639 1    BACKBONE|DICT
+  3445 3631 3642 1    DICT
+  3446 3631 3641 1    DICT
+  3447 3631 3632 1    DICT
+  3448 3632 3634 ar   DICT
+  3449 3632 3633 ar   DICT
+  3450 3633 3643 1    DICT
+  3451 3633 3635 ar   DICT
+  3452 3635 3645 1    DICT
+  3453 3635 3637 ar   DICT
+  3454 3637 3638 1    DICT
+  3455 3637 3636 ar   DICT
+  3456 3636 3646 1    DICT
+  3457 3636 3634 ar   DICT
+  3458 3634 3644 1    DICT
+  3459 3638 3647 1    DICT
+  3460 3629 3630 2    BACKBONE|DICT
+  3461 3649 3658 1    BACKBONE|DICT
+  3462 3649 3650 1    BACKBONE|DICT
+  3463 3649 3652 1    DICT
+  3464 3649 3648 1    BACKBONE|DICT
+  3465 3648 3657 1    BACKBONE|DICT
+  3466 3652 3659 1    DICT
+  3467 3652 3660 1    DICT
+  3468 3652 3653 1    DICT
+  3469 3653 3661 1    DICT
+  3470 3653 3662 1    DICT
+  3471 3653 3654 1    DICT
+  3472 3654 3663 1    DICT
+  3473 3654 3664 1    DICT
+  3474 3654 3655 1    DICT
+  3475 3655 3665 1    DICT
+  3476 3655 3666 1    DICT
+  3477 3655 3656 1    DICT
+  3478 3656 3667 1    DICT
+  3479 3656 3668 1    DICT
+  3480 3656 3669 1    DICT
+  3481 3650 3651 2    BACKBONE|DICT
+  3482 3671 3677 1    BACKBONE|DICT
+  3483 3671 3672 1    BACKBONE|DICT
+  3484 3671 3674 1    DICT
+  3485 3671 3670 1    BACKBONE|DICT
+  3486 3670 3676 1    BACKBONE|DICT
+  3487 3674 3678 1    DICT
+  3488 3674 3679 1    DICT
+  3489 3674 3675 1    DICT
+  3490 3675 3680 1    DICT
+  3491 3672 3673 2    BACKBONE|DICT
+  3492 3682 3691 1    BACKBONE|DICT
+  3493 3682 3683 1    BACKBONE|DICT
+  3494 3682 3685 1    DICT
+  3495 3682 3681 1    BACKBONE|DICT
+  3496 3681 3690 1    BACKBONE|DICT
+  3497 3685 3692 1    DICT
+  3498 3685 3693 1    DICT
+  3499 3685 3686 1    DICT
+  3500 3686 3694 1    DICT
+  3501 3686 3695 1    DICT
+  3502 3686 3687 1    DICT
+  3503 3687 3688 2    DICT
+  3504 3687 3689 am   DICT
+  3505 3689 3697 1    DICT
+  3506 3689 3696 1    DICT
+  3507 3683 3684 2    BACKBONE|DICT
+  3508 3699 3710 1    BACKBONE|DICT
+  3509 3699 3700 1    BACKBONE|DICT
+  3510 3699 3702 1    DICT
+  3511 3699 3698 1    BACKBONE|DICT
+  3512 3698 3709 1    BACKBONE|DICT
+  3513 3702 3711 1    DICT
+  3514 3702 3712 1    DICT
+  3515 3702 3703 1    DICT
+  3516 3703 3705 ar   DICT
+  3517 3703 3704 ar   DICT
+  3518 3704 3713 1    DICT
+  3519 3704 3706 ar   DICT
+  3520 3706 3715 1    DICT
+  3521 3706 3708 ar   DICT
+  3522 3708 3717 1    DICT
+  3523 3708 3707 ar   DICT
+  3524 3707 3716 1    DICT
+  3525 3707 3705 ar   DICT
+  3526 3705 3714 1    DICT
+  3527 3700 3701 2    BACKBONE|DICT
+  3528 3719 3728 1    BACKBONE|DICT
+  3529 3719 3720 1    BACKBONE|DICT
+  3530 3719 3722 1    DICT
+  3531 3719 3718 1    BACKBONE|DICT
+  3532 3718 3727 1    BACKBONE|DICT
+  3533 3722 3729 1    DICT
+  3534 3722 3730 1    DICT
+  3535 3722 3723 1    DICT
+  3536 3723 3731 1    DICT
+  3537 3723 3732 1    DICT
+  3538 3723 3724 1    DICT
+  3539 3724 3725 ar   DICT
+  3540 3724 3726 ar   DICT
+  3541 3720 3721 2    BACKBONE|DICT
+  3542 3734 3739 1    BACKBONE|DICT
+  3543 3734 3735 1    BACKBONE|DICT
+  3544 3734 3737 1    DICT
+  3545 3734 3733 1    BACKBONE|DICT
+  3546 3733 3738 1    BACKBONE|DICT
+  3547 3737 3740 1    DICT
+  3548 3737 3741 1    DICT
+  3549 3737 3742 1    DICT
+  3550 3735 3736 2    BACKBONE|DICT
+  3551 3744 3753 1    BACKBONE|DICT
+  3552 3744 3745 1    BACKBONE|DICT
+  3553 3744 3747 1    DICT
+  3554 3744 3743 1    BACKBONE|DICT
+  3555 3743 3752 1    BACKBONE|DICT
+  3556 3747 3754 1    DICT
+  3557 3747 3755 1    DICT
+  3558 3747 3748 1    DICT
+  3559 3748 3756 1    DICT
+  3560 3748 3757 1    DICT
+  3561 3748 3749 1    DICT
+  3562 3749 3750 2    DICT
+  3563 3749 3751 am   DICT
+  3564 3751 3759 1    DICT
+  3565 3751 3758 1    DICT
+  3566 3745 3746 2    BACKBONE|DICT
+  3567 3761 3770 1    BACKBONE|DICT
+  3568 3761 3762 1    BACKBONE|DICT
+  3569 3761 3764 1    DICT
+  3570 3761 3760 1    BACKBONE|DICT
+  3571 3760 3769 1    BACKBONE|DICT
+  3572 3764 3771 1    DICT
+  3573 3764 3772 1    DICT
+  3574 3764 3765 1    DICT
+  3575 3765 3773 1    DICT
+  3576 3765 3774 1    DICT
+  3577 3765 3766 1    DICT
+  3578 3766 3775 1    DICT
+  3579 3766 3776 1    DICT
+  3580 3766 3767 1    DICT
+  3581 3767 3777 1    DICT
+  3582 3767 3778 1    DICT
+  3583 3767 3768 1    DICT
+  3584 3768 3779 1    DICT
+  3585 3768 3780 1    DICT
+  3586 3768 3781 1    DICT
+  3587 3762 3763 2    BACKBONE|DICT
+  3588 3783 3791 1    BACKBONE|DICT
+  3589 3783 3784 1    BACKBONE|DICT
+  3590 3783 3786 1    DICT
+  3591 3783 3782 1    BACKBONE|DICT
+  3592 3782 3790 1    BACKBONE|DICT
+  3593 3786 3792 1    DICT
+  3594 3786 3787 1    DICT
+  3595 3786 3788 1    DICT
+  3596 3788 3795 1    DICT
+  3597 3788 3796 1    DICT
+  3598 3788 3797 1    DICT
+  3599 3787 3793 1    DICT
+  3600 3787 3794 1    DICT
+  3601 3787 3789 1    DICT
+  3602 3789 3798 1    DICT
+  3603 3789 3799 1    DICT
+  3604 3789 3800 1    DICT
+  3605 3784 3785 2    BACKBONE|DICT
+  3606 3802 3816 1    BACKBONE|DICT
+  3607 3802 3803 1    BACKBONE|DICT
+  3608 3802 3805 1    DICT
+  3609 3802 3801 1    BACKBONE|DICT
+  3610 3801 3815 1    BACKBONE|DICT
+  3611 3805 3817 1    DICT
+  3612 3805 3818 1    DICT
+  3613 3805 3806 1    DICT
+  3614 3806 3808 1    DICT
+  3615 3806 3807 2    DICT
+  3616 3807 3819 1    DICT
+  3617 3807 3809 1    DICT
+  3618 3809 3820 1    DICT
+  3619 3809 3810 1    DICT
+  3620 3810 3812 ar   DICT
+  3621 3810 3808 ar   DICT
+  3622 3808 3811 ar   DICT
+  3623 3811 3821 1    DICT
+  3624 3811 3813 ar   DICT
+  3625 3813 3823 1    DICT
+  3626 3813 3814 ar   DICT
+  3627 3814 3824 1    DICT
+  3628 3814 3812 ar   DICT
+  3629 3812 3822 1    DICT
+  3630 3803 3804 2    BACKBONE|DICT
+  3631 3826 3838 1    BACKBONE|DICT
+  3632 3826 3827 1    BACKBONE|DICT
+  3633 3826 3829 1    DICT
+  3634 3826 3825 1    BACKBONE|DICT
+  3635 3825 3837 1    BACKBONE|DICT
+  3636 3829 3840 1    DICT
+  3637 3829 3839 1    DICT
+  3638 3829 3830 1    DICT
+  3639 3830 3832 ar   DICT
+  3640 3830 3831 ar   DICT
+  3641 3831 3841 1    DICT
+  3642 3831 3833 ar   DICT
+  3643 3833 3843 1    DICT
+  3644 3833 3835 ar   DICT
+  3645 3835 3836 1    DICT
+  3646 3835 3834 ar   DICT
+  3647 3834 3844 1    DICT
+  3648 3834 3832 ar   DICT
+  3649 3832 3842 1    DICT
+  3650 3836 3845 1    DICT
+  3651 3827 3828 2    BACKBONE|DICT
+  3652 3847 3856 1    BACKBONE|DICT
+  3653 3847 3848 1    BACKBONE|DICT
+  3654 3847 3850 1    DICT
+  3655 3847 3846 1    BACKBONE|DICT
+  3656 3846 3855 1    BACKBONE|DICT
+  3657 3850 3857 1    DICT
+  3658 3850 3858 1    DICT
+  3659 3850 3851 1    DICT
+  3660 3851 3859 1    DICT
+  3661 3851 3860 1    DICT
+  3662 3851 3852 1    DICT
+  3663 3852 3853 ar   DICT
+  3664 3852 3854 ar   DICT
+  3665 3848 3849 2    BACKBONE|DICT
+  3666 3862 3872 1    BACKBONE|DICT
+  3667 3862 3863 1    BACKBONE|DICT
+  3668 3862 3865 1    DICT
+  3669 3862 3861 1    BACKBONE|DICT
+  3670 3861 3871 1    BACKBONE|DICT
+  3671 3865 3873 1    DICT
+  3672 3865 3874 1    DICT
+  3673 3865 3866 1    DICT
+  3674 3866 3868 2    DICT
+  3675 3866 3867 1    DICT
+  3676 3867 3869 2    DICT
+  3677 3869 3876 1    DICT
+  3678 3869 3870 1    DICT
+  3679 3870 3877 1    DICT
+  3680 3870 3868 1    DICT
+  3681 3868 3875 1    DICT
+  3682 3863 3864 2    BACKBONE|DICT
+  3683 3879 3890 1    BACKBONE|DICT
+  3684 3879 3880 1    BACKBONE|DICT
+  3685 3879 3882 1    DICT
+  3686 3879 3878 1    BACKBONE|DICT
+  3687 3878 3889 1    BACKBONE|DICT
+  3688 3882 3891 1    DICT
+  3689 3882 3892 1    DICT
+  3690 3882 3883 1    DICT
+  3691 3883 3893 1    DICT
+  3692 3883 3894 1    DICT
+  3693 3883 3884 1    DICT
+  3694 3884 3895 1    DICT
+  3695 3884 3896 1    DICT
+  3696 3884 3885 1    DICT
+  3697 3885 3897 1    DICT
+  3698 3885 3886 ar   DICT
+  3699 3886 3887 ar   DICT
+  3700 3886 3888 ar   DICT
+  3701 3888 3901 1    DICT
+  3702 3888 3900 1    DICT
+  3703 3887 3899 1    DICT
+  3704 3887 3898 1    DICT
+  3705 3880 3881 2    BACKBONE|DICT
+  3706 3903 3911 1    BACKBONE|DICT
+  3707 3903 3904 1    BACKBONE|DICT
+  3708 3903 3906 1    DICT
+  3709 3903 3902 1    BACKBONE|DICT
+  3710 3902 3910 1    BACKBONE|DICT
+  3711 3906 3912 1    DICT
+  3712 3906 3913 1    DICT
+  3713 3906 3907 1    DICT
+  3714 3907 3914 1    DICT
+  3715 3907 3909 1    DICT
+  3716 3907 3908 1    DICT
+  3717 3908 3915 1    DICT
+  3718 3908 3916 1    DICT
+  3719 3908 3917 1    DICT
+  3720 3909 3918 1    DICT
+  3721 3909 3919 1    DICT
+  3722 3909 3920 1    DICT
+  3723 3904 3905 2    BACKBONE|DICT
+  3724 3922 3930 1    BACKBONE|DICT
+  3725 3922 3923 1    BACKBONE|DICT
+  3726 3922 3925 1    DICT
+  3727 3922 3921 1    BACKBONE|DICT
+  3728 3921 3929 1    BACKBONE|DICT
+  3729 3925 3931 1    DICT
+  3730 3925 3926 1    DICT
+  3731 3925 3927 1    DICT
+  3732 3927 3934 1    DICT
+  3733 3927 3935 1    DICT
+  3734 3927 3936 1    DICT
+  3735 3926 3932 1    DICT
+  3736 3926 3933 1    DICT
+  3737 3926 3928 1    DICT
+  3738 3928 3937 1    DICT
+  3739 3928 3938 1    DICT
+  3740 3928 3939 1    DICT
+  3741 3923 3924 2    BACKBONE|DICT
+  3742 3941 3949 1    BACKBONE|DICT
+  3743 3941 3942 1    BACKBONE|DICT
+  3744 3941 3944 1    DICT
+  3745 3941 3940 1    BACKBONE|DICT
+  3746 3940 3948 1    BACKBONE|DICT
+  3747 3944 3950 1    DICT
+  3748 3944 3951 1    DICT
+  3749 3944 3945 1    DICT
+  3750 3945 3947 ar   DICT
+  3751 3945 3946 ar   DICT
+  3752 3942 3943 2    BACKBONE|DICT
+  3753 3953 3961 1    BACKBONE|DICT
+  3754 3953 3954 1    BACKBONE|DICT
+  3755 3953 3956 1    DICT
+  3756 3953 3952 1    BACKBONE|DICT
+  3757 3952 3960 1    BACKBONE|DICT
+  3758 3956 3962 1    DICT
+  3759 3956 3963 1    DICT
+  3760 3956 3957 1    DICT
+  3761 3957 3959 ar   DICT
+  3762 3957 3958 ar   DICT
+  3763 3954 3955 2    BACKBONE|DICT
+  3764 3965 3973 1    BACKBONE|DICT
+  3765 3965 3966 1    BACKBONE|DICT
+  3766 3965 3968 1    DICT
+  3767 3965 3964 1    BACKBONE|DICT
+  3768 3964 3972 1    BACKBONE|DICT
+  3769 3968 3974 1    DICT
+  3770 3968 3975 1    DICT
+  3771 3968 3969 1    DICT
+  3772 3969 3976 1    DICT
+  3773 3969 3977 1    DICT
+  3774 3969 3970 1    DICT
+  3775 3970 3971 1    DICT
+  3776 3971 3978 1    DICT
+  3777 3971 3979 1    DICT
+  3778 3971 3980 1    DICT
+  3779 3966 3967 2    BACKBONE|DICT
+  3780 3982 3989 1    BACKBONE|DICT
+  3781 3982 3983 1    BACKBONE|DICT
+  3782 3982 3985 1    DICT
+  3783 3982 3981 1    BACKBONE|DICT
+  3784 3981 3988 1    BACKBONE|DICT
+  3785 3985 3990 1    DICT
+  3786 3985 3986 1    DICT
+  3787 3985 3987 1    DICT
+  3788 3987 3994 1    DICT
+  3789 3987 3995 1    DICT
+  3790 3987 3996 1    DICT
+  3791 3986 3991 1    DICT
+  3792 3986 3992 1    DICT
+  3793 3986 3993 1    DICT
+  3794 3983 3984 2    BACKBONE|DICT
+  3795 3998 4003 1    BACKBONE|DICT
+  3796 3998 3999 1    BACKBONE|DICT
+  3797 3998 4001 1    DICT
+  3798 3998 3997 1    BACKBONE|DICT
+  3799 3997 4002 1    BACKBONE|DICT
+  3800 4001 4004 1    DICT
+  3801 4001 4005 1    DICT
+  3802 4001 4006 1    DICT
+  3803 3999 4000 2    BACKBONE|DICT
+  3804 4008 4017 1    BACKBONE|DICT
+  3805 4008 4009 1    BACKBONE|DICT
+  3806 4008 4011 1    DICT
+  3807 4008 4007 1    BACKBONE|DICT
+  3808 4007 4016 1    BACKBONE|DICT
+  3809 4011 4018 1    DICT
+  3810 4011 4019 1    DICT
+  3811 4011 4012 1    DICT
+  3812 4012 4020 1    DICT
+  3813 4012 4021 1    DICT
+  3814 4012 4013 1    DICT
+  3815 4013 4014 2    DICT
+  3816 4013 4015 am   DICT
+  3817 4015 4023 1    DICT
+  3818 4015 4022 1    DICT
+  3819 4009 4010 2    BACKBONE|DICT
+  3820 4025 4030 1    BACKBONE|DICT
+  3821 4025 4026 1    BACKBONE|DICT
+  3822 4025 4028 1    DICT
+  3823 4025 4024 1    BACKBONE|DICT
+  3824 4024 4029 1    BACKBONE|DICT
+  3825 4028 4031 1    DICT
+  3826 4028 4032 1    DICT
+  3827 4028 4033 1    DICT
+  3828 4026 4027 2    BACKBONE|DICT
+  3829 4035 4043 1    BACKBONE|DICT
+  3830 4035 4036 1    BACKBONE|DICT
+  3831 4035 4038 1    DICT
+  3832 4035 4034 1    BACKBONE|DICT
+  3833 4034 4042 1    BACKBONE|DICT
+  3834 4038 4044 1    DICT
+  3835 4038 4045 1    DICT
+  3836 4038 4039 1    DICT
+  3837 4039 4046 1    DICT
+  3838 4039 4047 1    DICT
+  3839 4039 4040 1    DICT
+  3840 4040 4041 1    DICT
+  3841 4041 4048 1    DICT
+  3842 4041 4049 1    DICT
+  3843 4041 4050 1    DICT
+  3844 4036 4037 2    BACKBONE|DICT
+  3845 4052 4061 1    BACKBONE|DICT
+  3846 4052 4053 1    BACKBONE|DICT
+  3847 4052 4055 1    DICT
+  3848 4052 4051 1    BACKBONE|DICT
+  3849 4051 4060 1    BACKBONE|DICT
+  3850 4055 4062 1    DICT
+  3851 4055 4063 1    DICT
+  3852 4055 4056 1    DICT
+  3853 4056 4064 1    DICT
+  3854 4056 4065 1    DICT
+  3855 4056 4057 1    DICT
+  3856 4057 4066 1    DICT
+  3857 4057 4067 1    DICT
+  3858 4057 4058 1    DICT
+  3859 4058 4068 1    DICT
+  3860 4058 4069 1    DICT
+  3861 4058 4059 1    DICT
+  3862 4059 4070 1    DICT
+  3863 4059 4071 1    DICT
+  3864 4059 4072 1    DICT
+  3865 4053 4054 2    BACKBONE|DICT
+  3866 4074 4080 1    BACKBONE|DICT
+  3867 4074 4075 1    BACKBONE|DICT
+  3868 4074 4077 1    DICT
+  3869 4074 4073 1    BACKBONE|DICT
+  3870 4073 4079 1    BACKBONE|DICT
+  3871 4077 4081 1    DICT
+  3872 4077 4082 1    DICT
+  3873 4077 4078 1    DICT
+  3874 4078 4083 1    DICT
+  3875 4075 4076 2    BACKBONE|DICT
+  3876 4085 4094 1    BACKBONE|DICT
+  3877 4085 4086 1    BACKBONE|DICT
+  3878 4085 4088 1    DICT
+  3879 4085 4084 1    BACKBONE|DICT
+  3880 4084 4093 1    BACKBONE|DICT
+  3881 4088 4095 1    DICT
+  3882 4088 4096 1    DICT
+  3883 4088 4089 1    DICT
+  3884 4089 4097 1    DICT
+  3885 4089 4098 1    DICT
+  3886 4089 4090 1    DICT
+  3887 4090 4091 ar   DICT
+  3888 4090 4092 ar   DICT
+  3889 4086 4087 2    BACKBONE|DICT
+  3890 4100 4105 1    DICT
+  3891 4100 4104 1    BACKBONE|DICT
+  3892 4100 4101 1    BACKBONE|DICT
+  3893 4100 4099 1    BACKBONE|DICT
+  3894 4099 4103 1    BACKBONE|DICT
+  3895 4101 4102 2    BACKBONE|DICT
+  3896 4107 4112 1    DICT
+  3897 4107 4111 1    BACKBONE|DICT
+  3898 4107 4108 1    BACKBONE|DICT
+  3899 4107 4106 1    BACKBONE|DICT
+  3900 4106 4110 1    BACKBONE|DICT
+  3901 4108 4109 2    BACKBONE|DICT
+  3902 4114 4125 1    BACKBONE|DICT
+  3903 4114 4115 1    BACKBONE|DICT
+  3904 4114 4117 1    DICT
+  3905 4114 4113 1    BACKBONE|DICT
+  3906 4113 4124 1    BACKBONE|DICT
+  3907 4117 4126 1    DICT
+  3908 4117 4127 1    DICT
+  3909 4117 4118 1    DICT
+  3910 4118 4120 ar   DICT
+  3911 4118 4119 ar   DICT
+  3912 4119 4128 1    DICT
+  3913 4119 4121 ar   DICT
+  3914 4121 4130 1    DICT
+  3915 4121 4123 ar   DICT
+  3916 4123 4132 1    DICT
+  3917 4123 4122 ar   DICT
+  3918 4122 4131 1    DICT
+  3919 4122 4120 ar   DICT
+  3920 4120 4129 1    DICT
+  3921 4115 4116 2    BACKBONE|DICT
+  3922 4134 4142 1    BACKBONE|DICT
+  3923 4134 4135 1    BACKBONE|DICT
+  3924 4134 4137 1    DICT
+  3925 4134 4133 1    BACKBONE|DICT
+  3926 4133 4141 1    BACKBONE|DICT
+  3927 4137 4143 1    DICT
+  3928 4137 4138 1    DICT
+  3929 4137 4139 1    DICT
+  3930 4139 4146 1    DICT
+  3931 4139 4147 1    DICT
+  3932 4139 4148 1    DICT
+  3933 4138 4144 1    DICT
+  3934 4138 4145 1    DICT
+  3935 4138 4140 1    DICT
+  3936 4140 4149 1    DICT
+  3937 4140 4150 1    DICT
+  3938 4140 4151 1    DICT
+  3939 4135 4136 2    BACKBONE|DICT
+  3940 4153 4167 1    BACKBONE|DICT
+  3941 4153 4154 1    BACKBONE|DICT
+  3942 4153 4156 1    DICT
+  3943 4153 4152 1    BACKBONE|DICT
+  3944 4152 4166 1    BACKBONE|DICT
+  3945 4156 4168 1    DICT
+  3946 4156 4169 1    DICT
+  3947 4156 4157 1    DICT
+  3948 4157 4159 1    DICT
+  3949 4157 4158 2    DICT
+  3950 4158 4170 1    DICT
+  3951 4158 4160 1    DICT
+  3952 4160 4171 1    DICT
+  3953 4160 4161 1    DICT
+  3954 4161 4163 ar   DICT
+  3955 4161 4159 ar   DICT
+  3956 4159 4162 ar   DICT
+  3957 4162 4172 1    DICT
+  3958 4162 4164 ar   DICT
+  3959 4164 4174 1    DICT
+  3960 4164 4165 ar   DICT
+  3961 4165 4175 1    DICT
+  3962 4165 4163 ar   DICT
+  3963 4163 4173 1    DICT
+  3964 4154 4155 2    BACKBONE|DICT
+  3965 4177 4182 1    BACKBONE|DICT
+  3966 4177 4178 1    BACKBONE|DICT
+  3967 4177 4180 1    DICT
+  3968 4177 4176 1    BACKBONE|DICT
+  3969 4176 4181 1    BACKBONE|DICT
+  3970 4180 4183 1    DICT
+  3971 4180 4184 1    DICT
+  3972 4180 4185 1    DICT
+  3973 4178 4179 2    BACKBONE|DICT
+  3974 4187 4193 1    BACKBONE|DICT
+  3975 4187 4188 1    BACKBONE|DICT
+  3976 4187 4190 1    DICT
+  3977 4187 4186 1    BACKBONE|DICT
+  3978 4186 4192 1    BACKBONE|DICT
+  3979 4190 4194 1    DICT
+  3980 4190 4195 1    DICT
+  3981 4190 4191 1    DICT
+  3982 4191 4196 1    DICT
+  3983 4188 4189 2    BACKBONE|DICT
+  3984 4198 4207 1    BACKBONE|DICT
+  3985 4198 4199 1    BACKBONE|DICT
+  3986 4198 4201 1    DICT
+  3987 4198 4197 1    BACKBONE|DICT
+  3988 4197 4206 1    BACKBONE|DICT
+  3989 4201 4208 1    DICT
+  3990 4201 4209 1    DICT
+  3991 4201 4202 1    DICT
+  3992 4202 4210 1    DICT
+  3993 4202 4211 1    DICT
+  3994 4202 4203 1    DICT
+  3995 4203 4212 1    DICT
+  3996 4203 4213 1    DICT
+  3997 4203 4204 1    DICT
+  3998 4204 4214 1    DICT
+  3999 4204 4215 1    DICT
+  4000 4204 4205 1    DICT
+  4001 4205 4216 1    DICT
+  4002 4205 4217 1    DICT
+  4003 4205 4218 1    DICT
+  4004 4199 4200 2    BACKBONE|DICT
+  4005 4220 4228 1    BACKBONE|DICT
+  4006 4220 4221 1    BACKBONE|DICT
+  4007 4220 4223 1    DICT
+  4008 4220 4219 1    BACKBONE|DICT
+  4009 4219 4227 1    BACKBONE|DICT
+  4010 4223 4229 1    DICT
+  4011 4223 4230 1    DICT
+  4012 4223 4224 1    DICT
+  4013 4224 4225 2    DICT
+  4014 4224 4226 am   DICT
+  4015 4226 4232 1    DICT
+  4016 4226 4231 1    DICT
+  4017 4221 4222 2    BACKBONE|DICT
+  4018 4234 4240 1    BACKBONE|DICT
+  4019 4234 4235 1    BACKBONE|DICT
+  4020 4234 4237 1    DICT
+  4021 4234 4233 1    BACKBONE|DICT
+  4022 4233 4239 1    BACKBONE|DICT
+  4023 4237 4241 1    DICT
+  4024 4237 4242 1    DICT
+  4025 4237 4238 1    DICT
+  4026 4238 4243 1    DICT
+  4027 4235 4236 2    BACKBONE|DICT
+  4028 4245 4253 1    BACKBONE|DICT
+  4029 4245 4246 1    BACKBONE|DICT
+  4030 4245 4248 1    DICT
+  4031 4245 4244 1    BACKBONE|DICT
+  4032 4244 4252 1    BACKBONE|DICT
+  4033 4248 4254 1    DICT
+  4034 4248 4255 1    DICT
+  4035 4248 4249 1    DICT
+  4036 4249 4256 1    DICT
+  4037 4249 4251 1    DICT
+  4038 4249 4250 1    DICT
+  4039 4250 4257 1    DICT
+  4040 4250 4258 1    DICT
+  4041 4250 4259 1    DICT
+  4042 4251 4260 1    DICT
+  4043 4251 4261 1    DICT
+  4044 4251 4262 1    DICT
+  4045 4246 4247 2    BACKBONE|DICT
+  4046 4264 4269 1    DICT
+  4047 4264 4268 1    BACKBONE|DICT
+  4048 4264 4265 1    BACKBONE|DICT
+  4049 4264 4263 1    BACKBONE|DICT
+  4050 4263 4267 1    BACKBONE|DICT
+  4051 4265 4266 2    BACKBONE|DICT
+  4052 4271 4279 1    BACKBONE|DICT
+  4053 4271 4272 1    BACKBONE|DICT
+  4054 4271 4274 1    DICT
+  4055 4271 4270 1    BACKBONE|DICT
+  4056 4270 4278 1    BACKBONE|DICT
+  4057 4274 4280 1    DICT
+  4058 4274 4281 1    DICT
+  4059 4274 4275 1    DICT
+  4060 4275 4282 1    DICT
+  4061 4275 4283 1    DICT
+  4062 4275 4276 1    DICT
+  4063 4276 4277 1    DICT
+  4064 4277 4284 1    DICT
+  4065 4277 4285 1    DICT
+  4066 4277 4286 1    DICT
+  4067 4272 4273 2    BACKBONE|DICT
+  4068 4288 4296 1    BACKBONE|DICT
+  4069 4288 4289 1    BACKBONE|DICT
+  4070 4288 4291 1    DICT
+  4071 4288 4287 1    BACKBONE|DICT
+  4072 4287 4295 1    BACKBONE|DICT
+  4073 4291 4297 1    DICT
+  4074 4291 4298 1    DICT
+  4075 4291 4292 1    DICT
+  4076 4292 4299 1    DICT
+  4077 4292 4300 1    DICT
+  4078 4292 4293 1    DICT
+  4079 4293 4294 1    DICT
+  4080 4294 4301 1    DICT
+  4081 4294 4302 1    DICT
+  4082 4294 4303 1    DICT
+  4083 4289 4290 2    BACKBONE|DICT
+  4084 4305 4312 1    BACKBONE|DICT
+  4085 4305 4306 1    BACKBONE|DICT
+  4086 4305 4308 1    DICT
+  4087 4305 4304 1    BACKBONE|DICT
+  4088 4304 4311 1    BACKBONE|DICT
+  4089 4308 4313 1    DICT
+  4090 4308 4309 1    DICT
+  4091 4308 4310 1    DICT
+  4092 4310 4317 1    DICT
+  4093 4310 4315 1    DICT
+  4094 4310 4316 1    DICT
+  4095 4309 4314 1    DICT
+  4096 4306 4307 2    BACKBONE|DICT
+  4097 4319 4325 1    BACKBONE|DICT
+  4098 4319 4320 1    BACKBONE|DICT
+  4099 4319 4322 1    DICT
+  4100 4319 4318 1    BACKBONE|DICT
+  4101 4318 4324 1    BACKBONE|DICT
+  4102 4322 4326 1    DICT
+  4103 4322 4327 1    DICT
+  4104 4322 4323 1    DICT
+  4105 4323 4328 1    DICT
+  4106 4320 4321 2    BACKBONE|DICT
+  4107 4330 4337 1    BACKBONE|DICT
+  4108 4330 4331 1    BACKBONE|DICT
+  4109 4330 4333 1    DICT
+  4110 4330 4329 1    BACKBONE|DICT
+  4111 4329 4336 1    BACKBONE|DICT
+  4112 4333 4338 1    DICT
+  4113 4333 4334 1    DICT
+  4114 4333 4335 1    DICT
+  4115 4335 4342 1    DICT
+  4116 4335 4343 1    DICT
+  4117 4335 4344 1    DICT
+  4118 4334 4339 1    DICT
+  4119 4334 4340 1    DICT
+  4120 4334 4341 1    DICT
+  4121 4331 4332 2    BACKBONE|DICT
+  4122 4346 4354 1    BACKBONE|DICT
+  4123 4346 4347 1    BACKBONE|DICT
+  4124 4346 4349 1    DICT
+  4125 4346 4345 1    BACKBONE|DICT
+  4126 4345 4353 1    BACKBONE|DICT
+  4127 4349 4355 1    DICT
+  4128 4349 4356 1    DICT
+  4129 4349 4350 1    DICT
+  4130 4350 4357 1    DICT
+  4131 4350 4352 1    DICT
+  4132 4350 4351 1    DICT
+  4133 4351 4358 1    DICT
+  4134 4351 4359 1    DICT
+  4135 4351 4360 1    DICT
+  4136 4352 4361 1    DICT
+  4137 4352 4362 1    DICT
+  4138 4352 4363 1    DICT
+  4139 4347 4348 2    BACKBONE|DICT
+  4140 4365 4372 1    BACKBONE|DICT
+  4141 4365 4366 1    BACKBONE|DICT
+  4142 4365 4368 1    DICT
+  4143 4365 4364 1    BACKBONE|DICT
+  4144 4364 4371 1    BACKBONE|DICT
+  4145 4368 4373 1    DICT
+  4146 4368 4369 1    DICT
+  4147 4368 4370 1    DICT
+  4148 4370 4377 1    DICT
+  4149 4370 4378 1    DICT
+  4150 4370 4379 1    DICT
+  4151 4369 4374 1    DICT
+  4152 4369 4375 1    DICT
+  4153 4369 4376 1    DICT
+  4154 4366 4367 2    BACKBONE|DICT
+  4155 4381 4387 1    BACKBONE|DICT
+  4156 4381 4382 1    BACKBONE|DICT
+  4157 4381 4384 1    DICT
+  4158 4381 4380 1    BACKBONE|DICT
+  4159 4380 4386 1    BACKBONE|DICT
+  4160 4384 4388 1    DICT
+  4161 4384 4389 1    DICT
+  4162 4384 4385 1    DICT
+  4163 4385 4390 1    DICT
+  4164 4382 4383 2    BACKBONE|DICT
+  4165 4392 4398 1    BACKBONE|DICT
+  4166 4392 4391 1    BACKBONE|DICT
+  4167 4392 4395 1    DICT
+  4168 4392 4393 1    BACKBONE|DICT
+  4169 4393 4394 2    BACKBONE|DICT
+  4170 4395 4399 1    DICT
+  4171 4395 4400 1    DICT
+  4172 4395 4396 1    DICT
+  4173 4396 4402 1    DICT
+  4174 4396 4401 1    DICT
+  4175 4396 4397 1    DICT
+  4176 4397 4404 1    DICT
+  4177 4397 4403 1    DICT
+  4178 4397 4391 1    DICT
+  4179 4406 4414 1    BACKBONE|DICT
+  4180 4406 4407 1    BACKBONE|DICT
+  4181 4406 4409 1    DICT
+  4182 4406 4405 1    BACKBONE|DICT
+  4183 4405 4413 1    BACKBONE|DICT
+  4184 4409 4415 1    DICT
+  4185 4409 4416 1    DICT
+  4186 4409 4410 1    DICT
+  4187 4410 4412 ar   DICT
+  4188 4410 4411 ar   DICT
+  4189 4407 4408 2    BACKBONE|DICT
+  4190 4418 4423 1    DICT
+  4191 4418 4422 1    BACKBONE|DICT
+  4192 4418 4419 1    BACKBONE|DICT
+  4193 4418 4417 1    BACKBONE|DICT
+  4194 4417 4421 1    BACKBONE|DICT
+  4195 4419 4420 2    BACKBONE|DICT
+  4196 4425 4434 1    BACKBONE|DICT
+  4197 4425 4426 1    BACKBONE|DICT
+  4198 4425 4428 1    DICT
+  4199 4425 4424 1    BACKBONE|DICT
+  4200 4424 4433 1    BACKBONE|DICT
+  4201 4428 4435 1    DICT
+  4202 4428 4436 1    DICT
+  4203 4428 4429 1    DICT
+  4204 4429 4437 1    DICT
+  4205 4429 4438 1    DICT
+  4206 4429 4430 1    DICT
+  4207 4430 4439 1    DICT
+  4208 4430 4440 1    DICT
+  4209 4430 4431 1    DICT
+  4210 4431 4441 1    DICT
+  4211 4431 4442 1    DICT
+  4212 4431 4432 1    DICT
+  4213 4432 4443 1    DICT
+  4214 4432 4444 1    DICT
+  4215 4432 4445 1    DICT
+  4216 4426 4427 2    BACKBONE|DICT
+  4217 4447 4454 1    BACKBONE|DICT
+  4218 4447 4448 1    BACKBONE|DICT
+  4219 4447 4450 1    DICT
+  4220 4447 4446 1    BACKBONE|DICT
+  4221 4446 4453 1    BACKBONE|DICT
+  4222 4450 4455 1    DICT
+  4223 4450 4451 1    DICT
+  4224 4450 4452 1    DICT
+  4225 4452 4459 1    DICT
+  4226 4452 4457 1    DICT
+  4227 4452 4458 1    DICT
+  4228 4451 4456 1    DICT
+  4229 4448 4449 2    BACKBONE|DICT
+  4230 4461 4468 1    BACKBONE|DICT
+  4231 4461 4462 1    BACKBONE|DICT
+  4232 4461 4464 1    DICT
+  4233 4461 4460 1    BACKBONE|DICT
+  4234 4460 4467 1    BACKBONE|DICT
+  4235 4464 4469 1    DICT
+  4236 4464 4465 1    DICT
+  4237 4464 4466 1    DICT
+  4238 4466 4473 1    DICT
+  4239 4466 4474 1    DICT
+  4240 4466 4475 1    DICT
+  4241 4465 4470 1    DICT
+  4242 4465 4471 1    DICT
+  4243 4465 4472 1    DICT
+  4244 4462 4463 2    BACKBONE|DICT
+  4245 4477 4486 1    BACKBONE|DICT
+  4246 4477 4478 1    BACKBONE|DICT
+  4247 4477 4480 1    DICT
+  4248 4477 4476 1    BACKBONE|DICT
+  4249 4476 4485 1    BACKBONE|DICT
+  4250 4480 4487 1    DICT
+  4251 4480 4488 1    DICT
+  4252 4480 4481 1    DICT
+  4253 4481 4489 1    DICT
+  4254 4481 4490 1    DICT
+  4255 4481 4482 1    DICT
+  4256 4482 4483 ar   DICT
+  4257 4482 4484 ar   DICT
+  4258 4478 4479 2    BACKBONE|DICT
+  4259 4492 4497 1    BACKBONE|DICT
+  4260 4492 4493 1    BACKBONE|DICT
+  4261 4492 4495 1    DICT
+  4262 4492 4491 1    BACKBONE|DICT
+  4263 4491 4496 1    BACKBONE|DICT
+  4264 4495 4498 1    DICT
+  4265 4495 4499 1    DICT
+  4266 4495 4500 1    DICT
+  4267 4493 4494 2    BACKBONE|DICT
+  4268 4502 4511 1    BACKBONE|DICT
+  4269 4502 4503 1    BACKBONE|DICT
+  4270 4502 4505 1    DICT
+  4271 4502 4501 1    BACKBONE|DICT
+  4272 4501 4510 1    BACKBONE|DICT
+  4273 4505 4512 1    DICT
+  4274 4505 4513 1    DICT
+  4275 4505 4506 1    DICT
+  4276 4506 4514 1    DICT
+  4277 4506 4515 1    DICT
+  4278 4506 4507 1    DICT
+  4279 4507 4508 ar   DICT
+  4280 4507 4509 ar   DICT
+  4281 4508 4516 un   
+  4282 4503 4504 2    BACKBONE|DICT
+  4283 4518 4523 1    BACKBONE|DICT
+  4284 4518 4519 1    BACKBONE|DICT
+  4285 4518 4521 1    DICT
+  4286 4518 4517 1    BACKBONE|DICT
+  4287 4517 4522 1    BACKBONE|DICT
+  4288 4521 4524 1    DICT
+  4289 4521 4525 1    DICT
+  4290 4521 4526 1    DICT
+  4291 4519 4520 2    BACKBONE|DICT
+  4292 4528 4533 1    BACKBONE|DICT
+  4293 4528 4529 1    BACKBONE|DICT
+  4294 4528 4531 1    DICT
+  4295 4528 4527 1    BACKBONE|DICT
+  4296 4527 4532 1    BACKBONE|DICT
+  4297 4531 4534 1    DICT
+  4298 4531 4535 1    DICT
+  4299 4531 4536 1    DICT
+  4300 4529 4530 2    BACKBONE|DICT
+  4301 4538 4548 1    BACKBONE|DICT
+  4302 4538 4539 1    BACKBONE|DICT
+  4303 4538 4541 1    DICT
+  4304 4538 4537 1    BACKBONE|DICT
+  4305 4537 4547 1    BACKBONE|DICT
+  4306 4541 4549 1    DICT
+  4307 4541 4550 1    DICT
+  4308 4541 4542 1    DICT
+  4309 4542 4544 2    DICT
+  4310 4542 4543 1    DICT
+  4311 4543 4551 1    DICT
+  4312 4543 4545 1    DICT
+  4313 4545 4553 1    DICT
+  4314 4545 4546 2    DICT
+  4315 4546 4544 1    DICT
+  4316 4544 4552 1    DICT
+  4317 4539 4540 2    BACKBONE|DICT
+  4318 4555 4560 1    DICT
+  4319 4555 4559 1    BACKBONE|DICT
+  4320 4555 4556 1    BACKBONE|DICT
+  4321 4555 4554 1    BACKBONE|DICT
+  4322 4554 4558 1    BACKBONE|DICT
+  4323 4556 4557 2    BACKBONE|DICT
+  4324 4562 4569 1    BACKBONE|DICT
+  4325 4562 4563 1    BACKBONE|DICT
+  4326 4562 4565 1    DICT
+  4327 4562 4561 1    BACKBONE|DICT
+  4328 4561 4568 1    BACKBONE|DICT
+  4329 4565 4570 1    DICT
+  4330 4565 4566 1    DICT
+  4331 4565 4567 1    DICT
+  4332 4567 4574 1    DICT
+  4333 4567 4572 1    DICT
+  4334 4567 4573 1    DICT
+  4335 4566 4571 1    DICT
+  4336 4563 4564 2    BACKBONE|DICT
+  4337 4576 4583 1    BACKBONE|DICT
+  4338 4576 4577 1    BACKBONE|DICT
+  4339 4576 4579 1    DICT
+  4340 4576 4575 1    BACKBONE|DICT
+  4341 4575 4582 1    BACKBONE|DICT
+  4342 4579 4584 1    DICT
+  4343 4579 4580 1    DICT
+  4344 4579 4581 1    DICT
+  4345 4581 4588 1    DICT
+  4346 4581 4589 1    DICT
+  4347 4581 4590 1    DICT
+  4348 4580 4585 1    DICT
+  4349 4580 4586 1    DICT
+  4350 4580 4587 1    DICT
+  4351 4577 4578 2    BACKBONE|DICT
+  4352 4592 4599 1    BACKBONE|DICT
+  4353 4592 4593 1    BACKBONE|DICT
+  4354 4592 4595 1    DICT
+  4355 4592 4591 1    BACKBONE|DICT
+  4356 4591 4598 1    BACKBONE|DICT
+  4357 4595 4600 1    DICT
+  4358 4595 4596 1    DICT
+  4359 4595 4597 1    DICT
+  4360 4597 4604 1    DICT
+  4361 4597 4602 1    DICT
+  4362 4597 4603 1    DICT
+  4363 4596 4601 1    DICT
+  4364 4593 4594 2    BACKBONE|DICT
+  4365 4606 4617 1    BACKBONE|DICT
+  4366 4606 4607 1    BACKBONE|DICT
+  4367 4606 4609 1    DICT
+  4368 4606 4605 1    BACKBONE|DICT
+  4369 4605 4616 1    BACKBONE|DICT
+  4370 4609 4618 1    DICT
+  4371 4609 4619 1    DICT
+  4372 4609 4610 1    DICT
+  4373 4610 4620 1    DICT
+  4374 4610 4621 1    DICT
+  4375 4610 4611 1    DICT
+  4376 4611 4622 1    DICT
+  4377 4611 4623 1    DICT
+  4378 4611 4612 1    DICT
+  4379 4612 4624 1    DICT
+  4380 4612 4613 ar   DICT
+  4381 4613 4614 ar   DICT
+  4382 4613 4615 ar   DICT
+  4383 4615 4628 1    DICT
+  4384 4615 4627 1    DICT
+  4385 4614 4626 1    DICT
+  4386 4614 4625 1    DICT
+  4387 4607 4608 2    BACKBONE|DICT
+  4388 4630 4640 1    BACKBONE|DICT
+  4389 4630 4631 1    BACKBONE|DICT
+  4390 4630 4633 1    DICT
+  4391 4630 4629 1    BACKBONE|DICT
+  4392 4629 4639 1    BACKBONE|DICT
+  4393 4633 4641 1    DICT
+  4394 4633 4642 1    DICT
+  4395 4633 4634 1    DICT
+  4396 4634 4636 2    DICT
+  4397 4634 4635 1    DICT
+  4398 4635 4643 1    DICT
+  4399 4635 4637 1    DICT
+  4400 4637 4645 1    DICT
+  4401 4637 4638 1    DICT
+  4402 4638 4646 1    DICT
+  4403 4638 4636 1    DICT
+  4404 4636 4644 1    DICT
+  4405 4631 4632 2    BACKBONE|DICT
+  4406 4648 4660 1    BACKBONE|DICT
+  4407 4648 4649 1    BACKBONE|DICT
+  4408 4648 4651 1    DICT
+  4409 4648 4647 1    BACKBONE|DICT
+  4410 4647 4659 1    BACKBONE|DICT
+  4411 4651 4662 1    DICT
+  4412 4651 4661 1    DICT
+  4413 4651 4652 1    DICT
+  4414 4652 4654 ar   DICT
+  4415 4652 4653 ar   DICT
+  4416 4653 4663 1    DICT
+  4417 4653 4655 ar   DICT
+  4418 4655 4665 1    DICT
+  4419 4655 4657 ar   DICT
+  4420 4657 4658 1    DICT
+  4421 4657 4656 ar   DICT
+  4422 4656 4666 1    DICT
+  4423 4656 4654 ar   DICT
+  4424 4654 4664 1    DICT
+  4425 4658 4667 1    DICT
+  4426 4649 4650 2    BACKBONE|DICT
+  4427 4669 4680 1    BACKBONE|DICT
+  4428 4669 4670 1    BACKBONE|DICT
+  4429 4669 4672 1    DICT
+  4430 4669 4668 1    BACKBONE|DICT
+  4431 4668 4679 1    BACKBONE|DICT
+  4432 4672 4681 1    DICT
+  4433 4672 4682 1    DICT
+  4434 4672 4673 1    DICT
+  4435 4673 4683 1    DICT
+  4436 4673 4684 1    DICT
+  4437 4673 4674 1    DICT
+  4438 4674 4685 1    DICT
+  4439 4674 4686 1    DICT
+  4440 4674 4675 1    DICT
+  4441 4675 4687 1    DICT
+  4442 4675 4676 ar   DICT
+  4443 4676 4677 ar   DICT
+  4444 4676 4678 ar   DICT
+  4445 4678 4691 1    DICT
+  4446 4678 4690 1    DICT
+  4447 4677 4689 1    DICT
+  4448 4677 4688 1    DICT
+  4449 4670 4671 2    BACKBONE|DICT
+  4450 4693 4701 1    BACKBONE|DICT
+  4451 4693 4694 1    BACKBONE|DICT
+  4452 4693 4696 1    DICT
+  4453 4693 4692 1    BACKBONE|DICT
+  4454 4692 4700 1    BACKBONE|DICT
+  4455 4696 4702 1    DICT
+  4456 4696 4703 1    DICT
+  4457 4696 4697 1    DICT
+  4458 4697 4704 1    DICT
+  4459 4697 4705 1    DICT
+  4460 4697 4698 1    DICT
+  4461 4698 4699 1    DICT
+  4462 4699 4706 1    DICT
+  4463 4699 4707 1    DICT
+  4464 4699 4708 1    DICT
+  4465 4694 4695 2    BACKBONE|DICT
+  4466 4710 4722 1    BACKBONE|DICT
+  4467 4710 4711 1    BACKBONE|DICT
+  4468 4710 4713 1    DICT
+  4469 4710 4709 1    BACKBONE|DICT
+  4470 4709 4721 1    BACKBONE|DICT
+  4471 4713 4724 1    DICT
+  4472 4713 4723 1    DICT
+  4473 4713 4714 1    DICT
+  4474 4714 4716 ar   DICT
+  4475 4714 4715 ar   DICT
+  4476 4715 4725 1    DICT
+  4477 4715 4717 ar   DICT
+  4478 4717 4727 1    DICT
+  4479 4717 4719 ar   DICT
+  4480 4719 4720 1    DICT
+  4481 4719 4718 ar   DICT
+  4482 4718 4728 1    DICT
+  4483 4718 4716 ar   DICT
+  4484 4716 4726 1    DICT
+  4485 4720 4729 1    DICT
+  4486 4711 4712 2    BACKBONE|DICT
+  4487 4731 4740 1    BACKBONE|DICT
+  4488 4731 4732 1    BACKBONE|DICT
+  4489 4731 4734 1    DICT
+  4490 4731 4730 1    BACKBONE|DICT
+  4491 4730 4739 1    BACKBONE|DICT
+  4492 4734 4741 1    DICT
+  4493 4734 4742 1    DICT
+  4494 4734 4735 1    DICT
+  4495 4735 4743 1    DICT
+  4496 4735 4744 1    DICT
+  4497 4735 4736 1    DICT
+  4498 4736 4737 2    DICT
+  4499 4736 4738 am   DICT
+  4500 4738 4746 1    DICT
+  4501 4738 4745 1    DICT
+  4502 4732 4733 2    BACKBONE|DICT
+  4503 4748 4757 1    BACKBONE|DICT
+  4504 4748 4749 1    BACKBONE|DICT
+  4505 4748 4751 1    DICT
+  4506 4748 4747 1    BACKBONE|DICT
+  4507 4747 4756 1    BACKBONE|DICT
+  4508 4751 4758 1    DICT
+  4509 4751 4759 1    DICT
+  4510 4751 4752 1    DICT
+  4511 4752 4760 1    DICT
+  4512 4752 4761 1    DICT
+  4513 4752 4753 1    DICT
+  4514 4753 4762 1    DICT
+  4515 4753 4763 1    DICT
+  4516 4753 4754 1    DICT
+  4517 4754 4764 1    DICT
+  4518 4754 4765 1    DICT
+  4519 4754 4755 1    DICT
+  4520 4755 4766 1    DICT
+  4521 4755 4767 1    DICT
+  4522 4755 4768 1    DICT
+  4523 4749 4750 2    BACKBONE|DICT
+  4524 4770 4775 1    DICT
+  4525 4770 4774 1    BACKBONE|DICT
+  4526 4770 4771 1    BACKBONE|DICT
+  4527 4770 4769 1    BACKBONE|DICT
+  4528 4769 4773 1    BACKBONE|DICT
+  4529 4771 4772 2    BACKBONE|DICT
+  4530 4777 4786 1    BACKBONE|DICT
+  4531 4777 4778 1    BACKBONE|DICT
+  4532 4777 4780 1    DICT
+  4533 4777 4776 1    BACKBONE|DICT
+  4534 4776 4785 1    BACKBONE|DICT
+  4535 4780 4787 1    DICT
+  4536 4780 4788 1    DICT
+  4537 4780 4781 1    DICT
+  4538 4781 4789 1    DICT
+  4539 4781 4790 1    DICT
+  4540 4781 4782 1    DICT
+  4541 4782 4783 2    DICT
+  4542 4782 4784 am   DICT
+  4543 4784 4792 1    DICT
+  4544 4784 4791 1    DICT
+  4545 4778 4779 2    BACKBONE|DICT
+  4546 4794 4803 1    BACKBONE|DICT
+  4547 4794 4795 1    BACKBONE|DICT
+  4548 4794 4797 1    DICT
+  4549 4794 4793 1    BACKBONE|DICT
+  4550 4793 4802 1    BACKBONE|DICT
+  4551 4797 4804 1    DICT
+  4552 4797 4805 1    DICT
+  4553 4797 4798 1    DICT
+  4554 4798 4806 1    DICT
+  4555 4798 4807 1    DICT
+  4556 4798 4799 1    DICT
+  4557 4799 4800 ar   DICT
+  4558 4799 4801 ar   DICT
+  4559 4795 4796 2    BACKBONE|DICT
+  4560 4809 4816 1    BACKBONE|DICT
+  4561 4809 4810 1    BACKBONE|DICT
+  4562 4809 4812 1    DICT
+  4563 4809 4808 1    BACKBONE|DICT
+  4564 4808 4815 1    BACKBONE|DICT
+  4565 4812 4817 1    DICT
+  4566 4812 4813 1    DICT
+  4567 4812 4814 1    DICT
+  4568 4814 4821 1    DICT
+  4569 4814 4819 1    DICT
+  4570 4814 4820 1    DICT
+  4571 4813 4818 1    DICT
+  4572 4810 4811 2    BACKBONE|DICT
+  4573 4823 4829 1    BACKBONE|DICT
+  4574 4823 4824 1    BACKBONE|DICT
+  4575 4823 4826 1    DICT
+  4576 4823 4822 1    BACKBONE|DICT
+  4577 4822 4828 1    BACKBONE|DICT
+  4578 4826 4830 1    DICT
+  4579 4826 4831 1    DICT
+  4580 4826 4827 1    DICT
+  4581 4827 4832 1    DICT
+  4582 4824 4825 2    BACKBONE|DICT
+  4583 4834 4841 1    BACKBONE|DICT
+  4584 4834 4835 1    BACKBONE|DICT
+  4585 4834 4837 1    DICT
+  4586 4834 4833 1    BACKBONE|DICT
+  4587 4833 4840 1    BACKBONE|DICT
+  4588 4837 4842 1    DICT
+  4589 4837 4838 1    DICT
+  4590 4837 4839 1    DICT
+  4591 4839 4846 1    DICT
+  4592 4839 4844 1    DICT
+  4593 4839 4845 1    DICT
+  4594 4838 4843 1    DICT
+  4595 4835 4836 2    BACKBONE|DICT
+  4596 4848 4856 1    BACKBONE|DICT
+  4597 4848 4849 1    BACKBONE|DICT
+  4598 4848 4851 1    DICT
+  4599 4848 4847 1    BACKBONE|DICT
+  4600 4847 4855 1    BACKBONE|DICT
+  4601 4851 4857 1    DICT
+  4602 4851 4858 1    DICT
+  4603 4851 4852 1    DICT
+  4604 4852 4853 2    DICT
+  4605 4852 4854 am   DICT
+  4606 4854 4860 1    DICT
+  4607 4854 4859 1    DICT
+  4608 4849 4850 2    BACKBONE|DICT
+  4609 4862 4868 1    BACKBONE|DICT
+  4610 4862 4861 1    BACKBONE|DICT
+  4611 4862 4865 1    DICT
+  4612 4862 4863 1    BACKBONE|DICT
+  4613 4863 4864 2    BACKBONE|DICT
+  4614 4865 4869 1    DICT
+  4615 4865 4870 1    DICT
+  4616 4865 4866 1    DICT
+  4617 4866 4872 1    DICT
+  4618 4866 4871 1    DICT
+  4619 4866 4867 1    DICT
+  4620 4867 4874 1    DICT
+  4621 4867 4873 1    DICT
+  4622 4867 4861 1    DICT
+  4623 4876 4884 1    BACKBONE|DICT
+  4624 4876 4877 1    BACKBONE|DICT
+  4625 4876 4879 1    DICT
+  4626 4876 4875 1    BACKBONE|DICT
+  4627 4875 4883 1    BACKBONE|DICT
+  4628 4879 4885 1    DICT
+  4629 4879 4880 1    DICT
+  4630 4879 4881 1    DICT
+  4631 4881 4888 1    DICT
+  4632 4881 4889 1    DICT
+  4633 4881 4890 1    DICT
+  4634 4880 4886 1    DICT
+  4635 4880 4887 1    DICT
+  4636 4880 4882 1    DICT
+  4637 4882 4891 1    DICT
+  4638 4882 4892 1    DICT
+  4639 4882 4893 1    DICT
+  4640 4877 4878 2    BACKBONE|DICT
+  4641 4895 4900 1    BACKBONE|DICT
+  4642 4895 4896 1    BACKBONE|DICT
+  4643 4895 4898 1    DICT
+  4644 4895 4894 1    BACKBONE|DICT
+  4645 4894 4899 1    BACKBONE|DICT
+  4646 4898 4901 1    DICT
+  4647 4898 4902 1    DICT
+  4648 4898 4903 1    DICT
+  4649 4896 4897 2    BACKBONE|DICT
+  4650 4905 4911 1    BACKBONE|DICT
+  4651 4905 4906 1    BACKBONE|DICT
+  4652 4905 4908 1    DICT
+  4653 4905 4904 1    BACKBONE|DICT
+  4654 4904 4910 1    BACKBONE|DICT
+  4655 4908 4912 1    DICT
+  4656 4908 4913 1    DICT
+  4657 4908 4909 1    DICT
+  4658 4909 4914 1    DICT
+  4659 4906 4907 2    BACKBONE|DICT
+  4660 4916 4924 1    BACKBONE|DICT
+  4661 4916 4917 1    BACKBONE|DICT
+  4662 4916 4919 1    DICT
+  4663 4916 4915 1    BACKBONE|DICT
+  4664 4915 4923 1    BACKBONE|DICT
+  4665 4919 4925 1    DICT
+  4666 4919 4920 1    DICT
+  4667 4919 4921 1    DICT
+  4668 4921 4928 1    DICT
+  4669 4921 4929 1    DICT
+  4670 4921 4930 1    DICT
+  4671 4920 4926 1    DICT
+  4672 4920 4927 1    DICT
+  4673 4920 4922 1    DICT
+  4674 4922 4931 1    DICT
+  4675 4922 4932 1    DICT
+  4676 4922 4933 1    DICT
+  4677 4917 4918 2    BACKBONE|DICT
+  4678 4935 4946 1    BACKBONE|DICT
+  4679 4935 4936 1    BACKBONE|DICT
+  4680 4935 4938 1    DICT
+  4681 4935 4934 1    BACKBONE|DICT
+  4682 4934 4945 1    BACKBONE|DICT
+  4683 4938 4947 1    DICT
+  4684 4938 4948 1    DICT
+  4685 4938 4939 1    DICT
+  4686 4939 4941 ar   DICT
+  4687 4939 4940 ar   DICT
+  4688 4940 4949 1    DICT
+  4689 4940 4942 ar   DICT
+  4690 4942 4951 1    DICT
+  4691 4942 4944 ar   DICT
+  4692 4944 4953 1    DICT
+  4693 4944 4943 ar   DICT
+  4694 4943 4952 1    DICT
+  4695 4943 4941 ar   DICT
+  4696 4941 4950 1    DICT
+  4697 4936 4937 2    BACKBONE|DICT
+  4698 4955 4960 1    BACKBONE|DICT
+  4699 4955 4956 1    BACKBONE|DICT
+  4700 4955 4958 1    DICT
+  4701 4955 4954 1    BACKBONE|DICT
+  4702 4954 4959 1    BACKBONE|DICT
+  4703 4958 4961 1    DICT
+  4704 4958 4962 1    DICT
+  4705 4958 4963 1    DICT
+  4706 4956 4957 2    BACKBONE|DICT
+  4707 4965 4979 1    BACKBONE|DICT
+  4708 4965 4966 1    BACKBONE|DICT
+  4709 4965 4968 1    DICT
+  4710 4965 4964 1    BACKBONE|DICT
+  4711 4964 4978 1    BACKBONE|DICT
+  4712 4968 4980 1    DICT
+  4713 4968 4981 1    DICT
+  4714 4968 4969 1    DICT
+  4715 4969 4971 1    DICT
+  4716 4969 4970 2    DICT
+  4717 4970 4982 1    DICT
+  4718 4970 4972 1    DICT
+  4719 4972 4983 1    DICT
+  4720 4972 4973 1    DICT
+  4721 4973 4975 ar   DICT
+  4722 4973 4971 ar   DICT
+  4723 4971 4974 ar   DICT
+  4724 4974 4984 1    DICT
+  4725 4974 4976 ar   DICT
+  4726 4976 4986 1    DICT
+  4727 4976 4977 ar   DICT
+  4728 4977 4987 1    DICT
+  4729 4977 4975 ar   DICT
+  4730 4975 4985 1    DICT
+  4731 4966 4967 2    BACKBONE|DICT
+  4732 4989 4996 1    BACKBONE|DICT
+  4733 4989 4990 1    BACKBONE|DICT
+  4734 4989 4992 1    DICT
+  4735 4989 4988 1    BACKBONE|DICT
+  4736 4988 4995 1    BACKBONE|DICT
+  4737 4992 4997 1    DICT
+  4738 4992 4993 1    DICT
+  4739 4992 4994 1    DICT
+  4740 4994 5001 1    DICT
+  4741 4994 4999 1    DICT
+  4742 4994 5000 1    DICT
+  4743 4993 4998 1    DICT
+  4744 4990 4991 2    BACKBONE|DICT
+  4745 5003 5014 1    BACKBONE|DICT
+  4746 5003 5004 1    BACKBONE|DICT
+  4747 5003 5006 1    DICT
+  4748 5003 5002 1    BACKBONE|DICT
+  4749 5002 5013 1    BACKBONE|DICT
+  4750 5006 5015 1    DICT
+  4751 5006 5016 1    DICT
+  4752 5006 5007 1    DICT
+  4753 5007 5017 1    DICT
+  4754 5007 5018 1    DICT
+  4755 5007 5008 1    DICT
+  4756 5008 5019 1    DICT
+  4757 5008 5020 1    DICT
+  4758 5008 5009 1    DICT
+  4759 5009 5021 1    DICT
+  4760 5009 5010 ar   DICT
+  4761 5010 5011 ar   DICT
+  4762 5010 5012 ar   DICT
+  4763 5012 5025 1    DICT
+  4764 5012 5024 1    DICT
+  4765 5011 5023 1    DICT
+  4766 5011 5022 1    DICT
+  4767 5004 5005 2    BACKBONE|DICT
+  4768 5027 5032 1    DICT
+  4769 5027 5031 1    BACKBONE|DICT
+  4770 5027 5028 1    BACKBONE|DICT
+  4771 5027 5026 1    BACKBONE|DICT
+  4772 5026 5030 1    BACKBONE|DICT
+  4773 5028 5029 2    BACKBONE|DICT
+  4774 5034 5042 1    BACKBONE|DICT
+  4775 5034 5035 1    BACKBONE|DICT
+  4776 5034 5037 1    DICT
+  4777 5034 5033 1    BACKBONE|DICT
+  4778 5033 5041 1    BACKBONE|DICT
+  4779 5037 5043 1    DICT
+  4780 5037 5044 1    DICT
+  4781 5037 5038 1    DICT
+  4782 5038 5045 1    DICT
+  4783 5038 5040 1    DICT
+  4784 5038 5039 1    DICT
+  4785 5039 5046 1    DICT
+  4786 5039 5047 1    DICT
+  4787 5039 5048 1    DICT
+  4788 5040 5049 1    DICT
+  4789 5040 5050 1    DICT
+  4790 5040 5051 1    DICT
+  4791 5035 5036 2    BACKBONE|DICT
+  4792 5053 5058 1    BACKBONE|DICT
+  4793 5053 5054 1    BACKBONE|DICT
+  4794 5053 5056 1    DICT
+  4795 5053 5052 1    BACKBONE|DICT
+  4796 5052 5057 1    BACKBONE|DICT
+  4797 5056 5059 1    DICT
+  4798 5056 5060 1    DICT
+  4799 5056 5061 1    DICT
+  4800 5054 5055 2    BACKBONE|DICT
+  4801 5063 5073 1    BACKBONE|DICT
+  4802 5063 5064 1    BACKBONE|DICT
+  4803 5063 5066 1    DICT
+  4804 5063 5062 1    BACKBONE|DICT
+  4805 5062 5072 1    BACKBONE|DICT
+  4806 5066 5074 1    DICT
+  4807 5066 5075 1    DICT
+  4808 5066 5067 1    DICT
+  4809 5067 5069 2    DICT
+  4810 5067 5068 1    DICT
+  4811 5068 5070 2    DICT
+  4812 5070 5077 1    DICT
+  4813 5070 5071 1    DICT
+  4814 5071 5078 1    DICT
+  4815 5071 5069 1    DICT
+  4816 5069 5076 1    DICT
+  4817 5064 5065 2    BACKBONE|DICT
+  4818 5080 5091 1    BACKBONE|DICT
+  4819 5080 5081 1    BACKBONE|DICT
+  4820 5080 5083 1    DICT
+  4821 5080 5079 1    BACKBONE|DICT
+  4822 5079 5090 1    BACKBONE|DICT
+  4823 5083 5092 1    DICT
+  4824 5083 5093 1    DICT
+  4825 5083 5084 1    DICT
+  4826 5084 5094 1    DICT
+  4827 5084 5095 1    DICT
+  4828 5084 5085 1    DICT
+  4829 5085 5096 1    DICT
+  4830 5085 5097 1    DICT
+  4831 5085 5086 1    DICT
+  4832 5086 5098 1    DICT
+  4833 5086 5087 ar   DICT
+  4834 5087 5088 ar   DICT
+  4835 5087 5089 ar   DICT
+  4836 5089 5102 1    DICT
+  4837 5089 5101 1    DICT
+  4838 5088 5100 1    DICT
+  4839 5088 5099 1    DICT
+  4840 5081 5082 2    BACKBONE|DICT
+  4841 5104 5109 1    BACKBONE|DICT
+  4842 5104 5105 1    BACKBONE|DICT
+  4843 5104 5107 1    DICT
+  4844 5104 5103 1    BACKBONE|DICT
+  4845 5103 5108 1    BACKBONE|DICT
+  4846 5107 5110 1    DICT
+  4847 5107 5111 1    DICT
+  4848 5107 5112 1    DICT
+  4849 5105 5106 2    BACKBONE|DICT
+  4850 5114 5123 1    BACKBONE|DICT
+  4851 5114 5115 1    BACKBONE|DICT
+  4852 5114 5117 1    DICT
+  4853 5114 5113 1    BACKBONE|DICT
+  4854 5113 5122 1    BACKBONE|DICT
+  4855 5117 5124 1    DICT
+  4856 5117 5125 1    DICT
+  4857 5117 5118 1    DICT
+  4858 5118 5126 1    DICT
+  4859 5118 5127 1    DICT
+  4860 5118 5119 1    DICT
+  4861 5119 5128 1    DICT
+  4862 5119 5129 1    DICT
+  4863 5119 5120 1    DICT
+  4864 5120 5130 1    DICT
+  4865 5120 5131 1    DICT
+  4866 5120 5121 1    DICT
+  4867 5121 5132 1    DICT
+  4868 5121 5133 1    DICT
+  4869 5121 5134 1    DICT
+  4870 5115 5116 2    BACKBONE|DICT
+  4871 5136 5144 1    BACKBONE|DICT
+  4872 5136 5137 1    BACKBONE|DICT
+  4873 5136 5139 1    DICT
+  4874 5136 5135 1    BACKBONE|DICT
+  4875 5135 5143 1    BACKBONE|DICT
+  4876 5139 5145 1    DICT
+  4877 5139 5146 1    DICT
+  4878 5139 5140 1    DICT
+  4879 5140 5147 1    DICT
+  4880 5140 5142 1    DICT
+  4881 5140 5141 1    DICT
+  4882 5141 5148 1    DICT
+  4883 5141 5149 1    DICT
+  4884 5141 5150 1    DICT
+  4885 5142 5151 1    DICT
+  4886 5142 5152 1    DICT
+  4887 5142 5153 1    DICT
+  4888 5137 5138 2    BACKBONE|DICT
+  4889 5155 5163 1    BACKBONE|DICT
+  4890 5155 5156 1    BACKBONE|DICT
+  4891 5155 5158 1    DICT
+  4892 5155 5154 1    BACKBONE|DICT
+  4893 5154 5162 1    BACKBONE|DICT
+  4894 5158 5164 1    DICT
+  4895 5158 5165 1    DICT
+  4896 5158 5159 1    DICT
+  4897 5159 5161 ar   DICT
+  4898 5159 5160 ar   DICT
+  4899 5156 5157 2    BACKBONE|DICT
+  4900 5167 5175 1    BACKBONE|DICT
+  4901 5167 5168 1    BACKBONE|DICT
+  4902 5167 5170 1    DICT
+  4903 5167 5166 1    BACKBONE|DICT
+  4904 5166 5174 1    BACKBONE|DICT
+  4905 5170 5176 1    DICT
+  4906 5170 5177 1    DICT
+  4907 5170 5171 1    DICT
+  4908 5171 5172 2    DICT
+  4909 5171 5173 am   DICT
+  4910 5173 5179 1    DICT
+  4911 5173 5178 1    DICT
+  4912 5168 5169 2    BACKBONE|DICT
+  4913 5181 5189 1    BACKBONE|DICT
+  4914 5181 5182 1    BACKBONE|DICT
+  4915 5181 5184 1    DICT
+  4916 5181 5180 1    BACKBONE|DICT
+  4917 5180 5188 1    BACKBONE|DICT
+  4918 5184 5190 1    DICT
+  4919 5184 5191 1    DICT
+  4920 5184 5185 1    DICT
+  4921 5185 5186 2    DICT
+  4922 5185 5187 am   DICT
+  4923 5187 5193 1    DICT
+  4924 5187 5192 1    DICT
+  4925 5182 5183 2    BACKBONE|DICT
+  4926 5195 5204 1    BACKBONE|DICT
+  4927 5195 5196 1    BACKBONE|DICT
+  4928 5195 5198 1    DICT
+  4929 5195 5194 1    BACKBONE|DICT
+  4930 5194 5203 1    BACKBONE|DICT
+  4931 5198 5205 1    DICT
+  4932 5198 5206 1    DICT
+  4933 5198 5199 1    DICT
+  4934 5199 5207 1    DICT
+  4935 5199 5208 1    DICT
+  4936 5199 5200 1    DICT
+  4937 5200 5209 1    DICT
+  4938 5200 5210 1    DICT
+  4939 5200 5201 1    DICT
+  4940 5201 5211 1    DICT
+  4941 5201 5212 1    DICT
+  4942 5201 5202 1    DICT
+  4943 5202 5213 1    DICT
+  4944 5202 5214 1    DICT
+  4945 5202 5215 1    DICT
+  4946 5196 5197 2    BACKBONE|DICT
+  4947 5217 5226 1    BACKBONE|DICT
+  4948 5217 5218 1    BACKBONE|DICT
+  4949 5217 5220 1    DICT
+  4950 5217 5216 1    BACKBONE|DICT
+  4951 5216 5225 1    BACKBONE|DICT
+  4952 5220 5227 1    DICT
+  4953 5220 5228 1    DICT
+  4954 5220 5221 1    DICT
+  4955 5221 5229 1    DICT
+  4956 5221 5230 1    DICT
+  4957 5221 5222 1    DICT
+  4958 5222 5223 ar   DICT
+  4959 5222 5224 ar   DICT
+  4960 5218 5219 2    BACKBONE|DICT
+  4961 5232 5240 1    BACKBONE|DICT
+  4962 5232 5233 1    BACKBONE|DICT
+  4963 5232 5235 1    DICT
+  4964 5232 5231 1    BACKBONE|DICT
+  4965 5231 5239 1    BACKBONE|DICT
+  4966 5235 5241 1    DICT
+  4967 5235 5242 1    DICT
+  4968 5235 5236 1    DICT
+  4969 5236 5243 1    DICT
+  4970 5236 5238 1    DICT
+  4971 5236 5237 1    DICT
+  4972 5237 5244 1    DICT
+  4973 5237 5245 1    DICT
+  4974 5237 5246 1    DICT
+  4975 5238 5247 1    DICT
+  4976 5238 5248 1    DICT
+  4977 5238 5249 1    DICT
+  4978 5233 5234 2    BACKBONE|DICT
+  4979 5251 5256 1    BACKBONE|DICT
+  4980 5251 5252 1    BACKBONE|DICT
+  4981 5251 5254 1    DICT
+  4982 5251 5250 1    BACKBONE|DICT
+  4983 5250 5255 1    BACKBONE|DICT
+  4984 5254 5257 1    DICT
+  4985 5254 5258 1    DICT
+  4986 5254 5259 1    DICT
+  4987 5252 5253 2    BACKBONE|DICT
+  4988 5261 5272 1    BACKBONE|DICT
+  4989 5261 5262 1    BACKBONE|DICT
+  4990 5261 5264 1    DICT
+  4991 5261 5260 1    BACKBONE|DICT
+  4992 5260 5271 1    BACKBONE|DICT
+  4993 5264 5273 1    DICT
+  4994 5264 5274 1    DICT
+  4995 5264 5265 1    DICT
+  4996 5265 5267 ar   DICT
+  4997 5265 5266 ar   DICT
+  4998 5266 5275 1    DICT
+  4999 5266 5268 ar   DICT
+  5000 5268 5277 1    DICT
+  5001 5268 5270 ar   DICT
+  5002 5270 5279 1    DICT
+  5003 5270 5269 ar   DICT
+  5004 5269 5278 1    DICT
+  5005 5269 5267 ar   DICT
+  5006 5267 5276 1    DICT
+  5007 5262 5263 2    BACKBONE|DICT
+  5008 5281 5292 1    BACKBONE|DICT
+  5009 5281 5282 1    BACKBONE|DICT
+  5010 5281 5284 1    DICT
+  5011 5281 5280 1    BACKBONE|DICT
+  5012 5280 5291 1    BACKBONE|DICT
+  5013 5284 5293 1    DICT
+  5014 5284 5294 1    DICT
+  5015 5284 5285 1    DICT
+  5016 5285 5287 ar   DICT
+  5017 5285 5286 ar   DICT
+  5018 5286 5295 1    DICT
+  5019 5286 5288 ar   DICT
+  5020 5288 5297 1    DICT
+  5021 5288 5290 ar   DICT
+  5022 5290 5299 1    DICT
+  5023 5290 5289 ar   DICT
+  5024 5289 5298 1    DICT
+  5025 5289 5287 ar   DICT
+  5026 5287 5296 1    DICT
+  5027 5282 5283 2    BACKBONE|DICT
+  5028 5301 5306 1    BACKBONE|DICT
+  5029 5301 5302 1    BACKBONE|DICT
+  5030 5301 5304 1    DICT
+  5031 5301 5300 1    BACKBONE|DICT
+  5032 5300 5305 1    BACKBONE|DICT
+  5033 5304 5307 1    DICT
+  5034 5304 5308 1    DICT
+  5035 5304 5309 1    DICT
+  5036 5302 5303 2    BACKBONE|DICT
+  5037 5311 5319 1    BACKBONE|DICT
+  5038 5311 5312 1    BACKBONE|DICT
+  5039 5311 5314 1    DICT
+  5040 5311 5310 1    BACKBONE|DICT
+  5041 5310 5318 1    BACKBONE|DICT
+  5042 5314 5320 1    DICT
+  5043 5314 5321 1    DICT
+  5044 5314 5315 1    DICT
+  5045 5315 5316 2    DICT
+  5046 5315 5317 am   DICT
+  5047 5317 5323 1    DICT
+  5048 5317 5322 1    DICT
+  5049 5312 5313 2    BACKBONE|DICT
+  5050 5325 5330 1    BACKBONE|DICT
+  5051 5325 5326 1    BACKBONE|DICT
+  5052 5325 5328 1    DICT
+  5053 5325 5324 1    BACKBONE|DICT
+  5054 5324 5329 1    BACKBONE|DICT
+  5055 5328 5331 1    DICT
+  5056 5328 5332 1    DICT
+  5057 5328 5333 1    DICT
+  5058 5326 5327 2    BACKBONE|DICT
+  5059 5335 5343 1    BACKBONE|DICT
+  5060 5335 5336 1    BACKBONE|DICT
+  5061 5335 5338 1    DICT
+  5062 5335 5334 1    BACKBONE|DICT
+  5063 5334 5342 1    BACKBONE|DICT
+  5064 5338 5344 1    DICT
+  5065 5338 5345 1    DICT
+  5066 5338 5339 1    DICT
+  5067 5339 5346 1    DICT
+  5068 5339 5341 1    DICT
+  5069 5339 5340 1    DICT
+  5070 5340 5347 1    DICT
+  5071 5340 5348 1    DICT
+  5072 5340 5349 1    DICT
+  5073 5341 5350 1    DICT
+  5074 5341 5351 1    DICT
+  5075 5341 5352 1    DICT
+  5076 5336 5337 2    BACKBONE|DICT
+  5077 5354 5363 1    BACKBONE|DICT
+  5078 5354 5355 1    BACKBONE|DICT
+  5079 5354 5357 1    DICT
+  5080 5354 5353 1    BACKBONE|DICT
+  5081 5353 5362 1    BACKBONE|DICT
+  5082 5357 5364 1    DICT
+  5083 5357 5365 1    DICT
+  5084 5357 5358 1    DICT
+  5085 5358 5366 1    DICT
+  5086 5358 5367 1    DICT
+  5087 5358 5359 1    DICT
+  5088 5359 5360 ar   DICT
+  5089 5359 5361 ar   DICT
+  5090 5355 5356 2    BACKBONE|DICT
+  5091 5369 5378 1    BACKBONE|DICT
+  5092 5369 5370 1    BACKBONE|DICT
+  5093 5369 5372 1    DICT
+  5094 5369 5368 1    BACKBONE|DICT
+  5095 5368 5377 1    BACKBONE|DICT
+  5096 5372 5379 1    DICT
+  5097 5372 5380 1    DICT
+  5098 5372 5373 1    DICT
+  5099 5373 5381 1    DICT
+  5100 5373 5382 1    DICT
+  5101 5373 5374 1    DICT
+  5102 5374 5375 ar   DICT
+  5103 5374 5376 ar   DICT
+  5104 5370 5371 2    BACKBONE|DICT
+  5105 5384 5391 1    BACKBONE|DICT
+  5106 5384 5385 1    BACKBONE|DICT
+  5107 5384 5387 1    DICT
+  5108 5384 5383 1    BACKBONE|DICT
+  5109 5383 5390 1    BACKBONE|DICT
+  5110 5387 5392 1    DICT
+  5111 5387 5388 1    DICT
+  5112 5387 5389 1    DICT
+  5113 5389 5396 1    DICT
+  5114 5389 5397 1    DICT
+  5115 5389 5398 1    DICT
+  5116 5388 5393 1    DICT
+  5117 5388 5394 1    DICT
+  5118 5388 5395 1    DICT
+  5119 5385 5386 2    BACKBONE|DICT
+  5120 5400 5406 1    BACKBONE|DICT
+  5121 5400 5401 1    BACKBONE|DICT
+  5122 5400 5403 1    DICT
+  5123 5400 5399 1    BACKBONE|DICT
+  5124 5399 5405 1    BACKBONE|DICT
+  5125 5403 5407 1    DICT
+  5126 5403 5408 1    DICT
+  5127 5403 5404 1    DICT
+  5128 5404 5409 1    DICT
+  5129 5401 5402 2    BACKBONE|DICT
+  5130 5411 5419 1    BACKBONE|DICT
+  5131 5411 5412 1    BACKBONE|DICT
+  5132 5411 5414 1    DICT
+  5133 5411 5410 1    BACKBONE|DICT
+  5134 5410 5418 1    BACKBONE|DICT
+  5135 5414 5420 1    DICT
+  5136 5414 5415 1    DICT
+  5137 5414 5416 1    DICT
+  5138 5416 5423 1    DICT
+  5139 5416 5424 1    DICT
+  5140 5416 5425 1    DICT
+  5141 5415 5421 1    DICT
+  5142 5415 5422 1    DICT
+  5143 5415 5417 1    DICT
+  5144 5417 5426 1    DICT
+  5145 5417 5427 1    DICT
+  5146 5417 5428 1    DICT
+  5147 5412 5413 2    BACKBONE|DICT
+  5148 5430 5439 1    BACKBONE|DICT
+  5149 5430 5431 1    BACKBONE|DICT
+  5150 5430 5433 1    DICT
+  5151 5430 5429 1    BACKBONE|DICT
+  5152 5429 5438 1    BACKBONE|DICT
+  5153 5433 5440 1    DICT
+  5154 5433 5441 1    DICT
+  5155 5433 5434 1    DICT
+  5156 5434 5442 1    DICT
+  5157 5434 5443 1    DICT
+  5158 5434 5435 1    DICT
+  5159 5435 5436 ar   DICT
+  5160 5435 5437 ar   DICT
+  5161 5431 5432 2    BACKBONE|DICT
+  5162 5445 5452 1    BACKBONE|DICT
+  5163 5445 5446 1    BACKBONE|DICT
+  5164 5445 5448 1    DICT
+  5165 5445 5444 1    BACKBONE|DICT
+  5166 5444 5451 1    BACKBONE|DICT
+  5167 5448 5453 1    DICT
+  5168 5448 5449 1    DICT
+  5169 5448 5450 1    DICT
+  5170 5450 5457 1    DICT
+  5171 5450 5455 1    DICT
+  5172 5450 5456 1    DICT
+  5173 5449 5454 1    DICT
+  5174 5446 5447 2    BACKBONE|DICT
+  5175 5459 5467 1    BACKBONE|DICT
+  5176 5459 5460 1    BACKBONE|DICT
+  5177 5459 5462 1    DICT
+  5178 5459 5458 1    BACKBONE|DICT
+  5179 5458 5466 1    BACKBONE|DICT
+  5180 5462 5468 1    DICT
+  5181 5462 5463 1    DICT
+  5182 5462 5464 1    DICT
+  5183 5464 5471 1    DICT
+  5184 5464 5472 1    DICT
+  5185 5464 5473 1    DICT
+  5186 5463 5469 1    DICT
+  5187 5463 5470 1    DICT
+  5188 5463 5465 1    DICT
+  5189 5465 5474 1    DICT
+  5190 5465 5475 1    DICT
+  5191 5465 5476 1    DICT
+  5192 5460 5461 2    BACKBONE|DICT
+  5193 5478 5487 1    BACKBONE|DICT
+  5194 5478 5479 1    BACKBONE|DICT
+  5195 5478 5481 1    DICT
+  5196 5478 5477 1    BACKBONE|DICT
+  5197 5477 5486 1    BACKBONE|DICT
+  5198 5481 5488 1    DICT
+  5199 5481 5489 1    DICT
+  5200 5481 5482 1    DICT
+  5201 5482 5490 1    DICT
+  5202 5482 5491 1    DICT
+  5203 5482 5483 1    DICT
+  5204 5483 5484 ar   DICT
+  5205 5483 5485 ar   DICT
+  5206 5479 5480 2    BACKBONE|DICT
+  5207 5493 5498 1    BACKBONE|DICT
+  5208 5493 5494 1    BACKBONE|DICT
+  5209 5493 5496 1    DICT
+  5210 5493 5492 1    BACKBONE|DICT
+  5211 5492 5497 1    BACKBONE|DICT
+  5212 5496 5499 1    DICT
+  5213 5496 5500 1    DICT
+  5214 5496 5501 1    DICT
+  5215 5494 5495 2    BACKBONE|DICT
+  5216 5503 5508 1    DICT
+  5217 5503 5507 1    BACKBONE|DICT
+  5218 5503 5504 1    BACKBONE|DICT
+  5219 5503 5502 1    BACKBONE|DICT
+  5220 5502 5506 1    BACKBONE|DICT
+  5221 5504 5505 2    BACKBONE|DICT
+  5222 5510 5521 1    BACKBONE|DICT
+  5223 5510 5511 1    BACKBONE|DICT
+  5224 5510 5513 1    DICT
+  5225 5510 5509 1    BACKBONE|DICT
+  5226 5509 5520 1    BACKBONE|DICT
+  5227 5513 5522 1    DICT
+  5228 5513 5523 1    DICT
+  5229 5513 5514 1    DICT
+  5230 5514 5516 ar   DICT
+  5231 5514 5515 ar   DICT
+  5232 5515 5524 1    DICT
+  5233 5515 5517 ar   DICT
+  5234 5517 5526 1    DICT
+  5235 5517 5519 ar   DICT
+  5236 5519 5528 1    DICT
+  5237 5519 5518 ar   DICT
+  5238 5518 5527 1    DICT
+  5239 5518 5516 ar   DICT
+  5240 5516 5525 1    DICT
+  5241 5511 5512 2    BACKBONE|DICT
+  5242 5530 5538 1    BACKBONE|DICT
+  5243 5530 5531 1    BACKBONE|DICT
+  5244 5530 5533 1    DICT
+  5245 5530 5529 1    BACKBONE|DICT
+  5246 5529 5537 1    BACKBONE|DICT
+  5247 5533 5539 1    DICT
+  5248 5533 5540 1    DICT
+  5249 5533 5534 1    DICT
+  5250 5534 5541 1    DICT
+  5251 5534 5542 1    DICT
+  5252 5534 5535 1    DICT
+  5253 5535 5536 1    DICT
+  5254 5536 5543 1    DICT
+  5255 5536 5544 1    DICT
+  5256 5536 5545 1    DICT
+  5257 5531 5532 2    BACKBONE|DICT
+  5258 5547 5554 1    BACKBONE|DICT
+  5259 5547 5548 1    BACKBONE|DICT
+  5260 5547 5550 1    DICT
+  5261 5547 5546 1    BACKBONE|DICT
+  5262 5546 5553 1    BACKBONE|DICT
+  5263 5550 5555 1    DICT
+  5264 5550 5551 1    DICT
+  5265 5550 5552 1    DICT
+  5266 5552 5559 1    DICT
+  5267 5552 5557 1    DICT
+  5268 5552 5558 1    DICT
+  5269 5551 5556 1    DICT
+  5270 5548 5549 2    BACKBONE|DICT
+  5271 5561 5570 1    BACKBONE|DICT
+  5272 5561 5562 1    BACKBONE|DICT
+  5273 5561 5564 1    DICT
+  5274 5561 5560 1    BACKBONE|DICT
+  5275 5560 5569 1    BACKBONE|DICT
+  5276 5564 5571 1    DICT
+  5277 5564 5572 1    DICT
+  5278 5564 5565 1    DICT
+  5279 5565 5573 1    DICT
+  5280 5565 5574 1    DICT
+  5281 5565 5566 1    DICT
+  5282 5566 5575 1    DICT
+  5283 5566 5576 1    DICT
+  5284 5566 5567 1    DICT
+  5285 5567 5577 1    DICT
+  5286 5567 5578 1    DICT
+  5287 5567 5568 1    DICT
+  5288 5568 5579 1    DICT
+  5289 5568 5580 1    DICT
+  5290 5568 5581 1    DICT
+  5291 5562 5563 2    BACKBONE|DICT
+  5292 5583 5591 1    BACKBONE|DICT
+  5293 5583 5584 1    BACKBONE|DICT
+  5294 5583 5586 1    DICT
+  5295 5583 5582 1    BACKBONE|DICT
+  5296 5582 5590 1    BACKBONE|DICT
+  5297 5586 5592 1    DICT
+  5298 5586 5593 1    DICT
+  5299 5586 5587 1    DICT
+  5300 5587 5589 ar   DICT
+  5301 5587 5588 ar   DICT
+  5302 5584 5585 2    BACKBONE|DICT
+  5303 5595 5603 1    BACKBONE|DICT
+  5304 5595 5596 1    BACKBONE|DICT
+  5305 5595 5598 1    DICT
+  5306 5595 5594 1    BACKBONE|DICT
+  5307 5594 5602 1    BACKBONE|DICT
+  5308 5598 5604 1    DICT
+  5309 5598 5605 1    DICT
+  5310 5598 5599 1    DICT
+  5311 5599 5606 1    DICT
+  5312 5599 5601 1    DICT
+  5313 5599 5600 1    DICT
+  5314 5600 5607 1    DICT
+  5315 5600 5608 1    DICT
+  5316 5600 5609 1    DICT
+  5317 5601 5610 1    DICT
+  5318 5601 5611 1    DICT
+  5319 5601 5612 1    DICT
+  5320 5596 5597 2    BACKBONE|DICT
+  5321 5614 5619 1    BACKBONE|DICT
+  5322 5614 5615 1    BACKBONE|DICT
+  5323 5614 5617 1    DICT
+  5324 5614 5613 1    BACKBONE|DICT
+  5325 5613 5618 1    BACKBONE|DICT
+  5326 5617 5620 1    DICT
+  5327 5617 5621 1    DICT
+  5328 5617 5622 1    DICT
+  5329 5615 5616 2    BACKBONE|DICT
+  5330 5624 5629 1    BACKBONE|DICT
+  5331 5624 5625 1    BACKBONE|DICT
+  5332 5624 5627 1    DICT
+  5333 5624 5623 1    BACKBONE|DICT
+  5334 5623 5628 1    BACKBONE|DICT
+  5335 5627 5630 1    DICT
+  5336 5627 5631 1    DICT
+  5337 5627 5632 1    DICT
+  5338 5625 5626 2    BACKBONE|DICT
+  5339 5634 5640 1    BACKBONE|DICT
+  5340 5634 5635 1    BACKBONE|DICT
+  5341 5634 5637 1    DICT
+  5342 5634 5633 1    BACKBONE|DICT
+  5343 5633 5639 1    BACKBONE|DICT
+  5344 5637 5641 1    DICT
+  5345 5637 5642 1    DICT
+  5346 5637 5638 1    DICT
+  5347 5638 5643 1    DICT
+  5348 5635 5636 2    BACKBONE|DICT
+  5349 5645 5653 1    BACKBONE|DICT
+  5350 5645 5646 1    BACKBONE|DICT
+  5351 5645 5648 1    DICT
+  5352 5645 5644 1    BACKBONE|DICT
+  5353 5644 5652 1    BACKBONE|DICT
+  5354 5648 5654 1    DICT
+  5355 5648 5649 1    DICT
+  5356 5648 5650 1    DICT
+  5357 5650 5657 1    DICT
+  5358 5650 5658 1    DICT
+  5359 5650 5659 1    DICT
+  5360 5649 5655 1    DICT
+  5361 5649 5656 1    DICT
+  5362 5649 5651 1    DICT
+  5363 5651 5660 1    DICT
+  5364 5651 5661 1    DICT
+  5365 5651 5662 1    DICT
+  5366 5646 5647 2    BACKBONE|DICT
+  5367 5664 5673 1    BACKBONE|DICT
+  5368 5664 5665 1    BACKBONE|DICT
+  5369 5664 5667 1    DICT
+  5370 5664 5663 1    BACKBONE|DICT
+  5371 5663 5672 1    BACKBONE|DICT
+  5372 5667 5674 1    DICT
+  5373 5667 5675 1    DICT
+  5374 5667 5668 1    DICT
+  5375 5668 5676 1    DICT
+  5376 5668 5677 1    DICT
+  5377 5668 5669 1    DICT
+  5378 5669 5678 1    DICT
+  5379 5669 5679 1    DICT
+  5380 5669 5670 1    DICT
+  5381 5670 5680 1    DICT
+  5382 5670 5681 1    DICT
+  5383 5670 5671 1    DICT
+  5384 5671 5682 1    DICT
+  5385 5671 5683 1    DICT
+  5386 5671 5684 1    DICT
+  5387 5665 5666 2    BACKBONE|DICT
+  5388 5686 5691 1    DICT
+  5389 5686 5690 1    BACKBONE|DICT
+  5390 5686 5687 1    BACKBONE|DICT
+  5391 5686 5685 1    BACKBONE|DICT
+  5392 5685 5689 1    BACKBONE|DICT
+  5393 5687 5688 2    BACKBONE|DICT
+  5394 5693 5701 1    BACKBONE|DICT
+  5395 5693 5694 1    BACKBONE|DICT
+  5396 5693 5696 1    DICT
+  5397 5693 5692 1    BACKBONE|DICT
+  5398 5692 5700 1    BACKBONE|DICT
+  5399 5696 5702 1    DICT
+  5400 5696 5703 1    DICT
+  5401 5696 5697 1    DICT
+  5402 5697 5704 1    DICT
+  5403 5697 5699 1    DICT
+  5404 5697 5698 1    DICT
+  5405 5698 5705 1    DICT
+  5406 5698 5706 1    DICT
+  5407 5698 5707 1    DICT
+  5408 5699 5708 1    DICT
+  5409 5699 5709 1    DICT
+  5410 5699 5710 1    DICT
+  5411 5694 5695 2    BACKBONE|DICT
+  5412 5712 5718 1    BACKBONE|DICT
+  5413 5712 5711 1    BACKBONE|DICT
+  5414 5712 5715 1    DICT
+  5415 5712 5713 1    BACKBONE|DICT
+  5416 5713 5714 2    BACKBONE|DICT
+  5417 5715 5719 1    DICT
+  5418 5715 5720 1    DICT
+  5419 5715 5716 1    DICT
+  5420 5716 5722 1    DICT
+  5421 5716 5721 1    DICT
+  5422 5716 5717 1    DICT
+  5423 5717 5724 1    DICT
+  5424 5717 5723 1    DICT
+  5425 5717 5711 1    DICT
+  5426 5726 5734 1    BACKBONE|DICT
+  5427 5726 5727 1    BACKBONE|DICT
+  5428 5726 5729 1    DICT
+  5429 5726 5725 1    BACKBONE|DICT
+  5430 5725 5733 1    BACKBONE|DICT
+  5431 5729 5735 1    DICT
+  5432 5729 5736 1    DICT
+  5433 5729 5730 1    DICT
+  5434 5730 5731 2    DICT
+  5435 5730 5732 am   DICT
+  5436 5732 5738 1    DICT
+  5437 5732 5737 1    DICT
+  5438 5727 5728 2    BACKBONE|DICT
+  5439 5740 5747 1    BACKBONE|DICT
+  5440 5740 5741 1    BACKBONE|DICT
+  5441 5740 5743 1    DICT
+  5442 5740 5739 1    BACKBONE|DICT
+  5443 5739 5746 1    BACKBONE|DICT
+  5444 5743 5748 1    DICT
+  5445 5743 5744 1    DICT
+  5446 5743 5745 1    DICT
+  5447 5745 5752 1    DICT
+  5448 5745 5753 1    DICT
+  5449 5745 5754 1    DICT
+  5450 5744 5749 1    DICT
+  5451 5744 5750 1    DICT
+  5452 5744 5751 1    DICT
+  5453 5741 5742 2    BACKBONE|DICT
+  5454 5756 5765 1    BACKBONE|DICT
+  5455 5756 5757 1    BACKBONE|DICT
+  5456 5756 5759 1    DICT
+  5457 5756 5755 1    BACKBONE|DICT
+  5458 5755 5764 1    BACKBONE|DICT
+  5459 5759 5766 1    DICT
+  5460 5759 5767 1    DICT
+  5461 5759 5760 1    DICT
+  5462 5760 5768 1    DICT
+  5463 5760 5769 1    DICT
+  5464 5760 5761 1    DICT
+  5465 5761 5762 2    DICT
+  5466 5761 5763 am   DICT
+  5467 5763 5771 1    DICT
+  5468 5763 5770 1    DICT
+  5469 5757 5758 2    BACKBONE|DICT
+  5470 5773 5784 1    BACKBONE|DICT
+  5471 5773 5774 1    BACKBONE|DICT
+  5472 5773 5776 1    DICT
+  5473 5773 5772 1    BACKBONE|DICT
+  5474 5772 5783 1    BACKBONE|DICT
+  5475 5776 5785 1    DICT
+  5476 5776 5786 1    DICT
+  5477 5776 5777 1    DICT
+  5478 5777 5787 1    DICT
+  5479 5777 5788 1    DICT
+  5480 5777 5778 1    DICT
+  5481 5778 5789 1    DICT
+  5482 5778 5790 1    DICT
+  5483 5778 5779 1    DICT
+  5484 5779 5791 1    DICT
+  5485 5779 5780 ar   DICT
+  5486 5780 5781 ar   DICT
+  5487 5780 5782 ar   DICT
+  5488 5782 5795 1    DICT
+  5489 5782 5794 1    DICT
+  5490 5781 5793 1    DICT
+  5491 5781 5792 1    DICT
+  5492 5774 5775 2    BACKBONE|DICT
+  5493 5797 5803 1    BACKBONE|DICT
+  5494 5797 5798 1    BACKBONE|DICT
+  5495 5797 5800 1    DICT
+  5496 5797 5796 1    BACKBONE|DICT
+  5497 5796 5802 1    BACKBONE|DICT
+  5498 5800 5804 1    DICT
+  5499 5800 5805 1    DICT
+  5500 5800 5801 1    DICT
+  5501 5801 5806 1    DICT
+  5502 5798 5799 2    BACKBONE|DICT
+  5503 5808 5816 1    BACKBONE|DICT
+  5504 5808 5809 1    BACKBONE|DICT
+  5505 5808 5811 1    DICT
+  5506 5808 5807 1    BACKBONE|DICT
+  5507 5807 5815 1    BACKBONE|DICT
+  5508 5811 5817 1    DICT
+  5509 5811 5818 1    DICT
+  5510 5811 5812 1    DICT
+  5511 5812 5814 ar   DICT
+  5512 5812 5813 ar   DICT
+  5513 5809 5810 2    BACKBONE|DICT
+  5514 5820 5832 1    BACKBONE|DICT
+  5515 5820 5821 1    BACKBONE|DICT
+  5516 5820 5823 1    DICT
+  5517 5820 5819 1    BACKBONE|DICT
+  5518 5819 5831 1    BACKBONE|DICT
+  5519 5823 5834 1    DICT
+  5520 5823 5833 1    DICT
+  5521 5823 5824 1    DICT
+  5522 5824 5826 ar   DICT
+  5523 5824 5825 ar   DICT
+  5524 5825 5835 1    DICT
+  5525 5825 5827 ar   DICT
+  5526 5827 5837 1    DICT
+  5527 5827 5829 ar   DICT
+  5528 5829 5830 1    DICT
+  5529 5829 5828 ar   DICT
+  5530 5828 5838 1    DICT
+  5531 5828 5826 ar   DICT
+  5532 5826 5836 1    DICT
+  5533 5830 5839 1    DICT
+  5534 5821 5822 2    BACKBONE|DICT
+  5535 5841 5849 1    BACKBONE|DICT
+  5536 5841 5842 1    BACKBONE|DICT
+  5537 5841 5844 1    DICT
+  5538 5841 5840 1    BACKBONE|DICT
+  5539 5840 5848 1    BACKBONE|DICT
+  5540 5844 5850 1    DICT
+  5541 5844 5851 1    DICT
+  5542 5844 5845 1    DICT
+  5543 5845 5852 1    DICT
+  5544 5845 5847 1    DICT
+  5545 5845 5846 1    DICT
+  5546 5846 5853 1    DICT
+  5547 5846 5854 1    DICT
+  5548 5846 5855 1    DICT
+  5549 5847 5856 1    DICT
+  5550 5847 5857 1    DICT
+  5551 5847 5858 1    DICT
+  5552 5842 5843 2    BACKBONE|DICT
+  5553 5860 5868 1    BACKBONE|DICT
+  5554 5860 5861 1    BACKBONE|DICT
+  5555 5860 5863 1    DICT
+  5556 5860 5859 1    BACKBONE|DICT
+  5557 5859 5867 1    BACKBONE|DICT
+  5558 5863 5869 1    DICT
+  5559 5863 5870 1    DICT
+  5560 5863 5864 1    DICT
+  5561 5864 5865 2    DICT
+  5562 5864 5866 am   DICT
+  5563 5866 5872 1    DICT
+  5564 5866 5871 1    DICT
+  5565 5861 5862 2    BACKBONE|DICT
+  5566 5874 5881 1    BACKBONE|DICT
+  5567 5874 5875 1    BACKBONE|DICT
+  5568 5874 5877 1    DICT
+  5569 5874 5873 1    BACKBONE|DICT
+  5570 5873 5880 1    BACKBONE|DICT
+  5571 5877 5882 1    DICT
+  5572 5877 5878 1    DICT
+  5573 5877 5879 1    DICT
+  5574 5879 5886 1    DICT
+  5575 5879 5884 1    DICT
+  5576 5879 5885 1    DICT
+  5577 5878 5883 1    DICT
+  5578 5875 5876 2    BACKBONE|DICT
+  5579 5888 5899 1    BACKBONE|DICT
+  5580 5888 5889 1    BACKBONE|DICT
+  5581 5888 5891 1    DICT
+  5582 5888 5887 1    BACKBONE|DICT
+  5583 5887 5898 1    BACKBONE|DICT
+  5584 5891 5900 1    DICT
+  5585 5891 5901 1    DICT
+  5586 5891 5892 1    DICT
+  5587 5892 5894 ar   DICT
+  5588 5892 5893 ar   DICT
+  5589 5893 5902 1    DICT
+  5590 5893 5895 ar   DICT
+  5591 5895 5904 1    DICT
+  5592 5895 5897 ar   DICT
+  5593 5897 5906 1    DICT
+  5594 5897 5896 ar   DICT
+  5595 5896 5905 1    DICT
+  5596 5896 5894 ar   DICT
+  5597 5894 5903 1    DICT
+  5598 5889 5890 2    BACKBONE|DICT
+  5599 5908 5917 1    BACKBONE|DICT
+  5600 5908 5909 1    BACKBONE|DICT
+  5601 5908 5911 1    DICT
+  5602 5908 5907 1    BACKBONE|DICT
+  5603 5907 5916 1    BACKBONE|DICT
+  5604 5911 5918 1    DICT
+  5605 5911 5919 1    DICT
+  5606 5911 5912 1    DICT
+  5607 5912 5920 1    DICT
+  5608 5912 5921 1    DICT
+  5609 5912 5913 1    DICT
+  5610 5913 5914 ar   DICT
+  5611 5913 5915 ar   DICT
+  5612 5909 5910 2    BACKBONE|DICT
+  5613 5923 5934 1    BACKBONE|DICT
+  5614 5923 5924 1    BACKBONE|DICT
+  5615 5923 5926 1    DICT
+  5616 5923 5922 1    BACKBONE|DICT
+  5617 5922 5933 1    BACKBONE|DICT
+  5618 5926 5935 1    DICT
+  5619 5926 5936 1    DICT
+  5620 5926 5927 1    DICT
+  5621 5927 5929 ar   DICT
+  5622 5927 5928 ar   DICT
+  5623 5928 5937 1    DICT
+  5624 5928 5930 ar   DICT
+  5625 5930 5939 1    DICT
+  5626 5930 5932 ar   DICT
+  5627 5932 5941 1    DICT
+  5628 5932 5931 ar   DICT
+  5629 5931 5940 1    DICT
+  5630 5931 5929 ar   DICT
+  5631 5929 5938 1    DICT
+  5632 5924 5925 2    BACKBONE|DICT
+  5633 5943 5951 1    BACKBONE|DICT
+  5634 5943 5944 1    BACKBONE|DICT
+  5635 5943 5946 1    DICT
+  5636 5943 5942 1    BACKBONE|DICT
+  5637 5942 5950 1    BACKBONE|DICT
+  5638 5946 5952 1    DICT
+  5639 5946 5953 1    DICT
+  5640 5946 5947 1    DICT
+  5641 5947 5954 1    DICT
+  5642 5947 5955 1    DICT
+  5643 5947 5948 1    DICT
+  5644 5948 5949 1    DICT
+  5645 5949 5956 1    DICT
+  5646 5949 5957 1    DICT
+  5647 5949 5958 1    DICT
+  5648 5944 5945 2    BACKBONE|DICT
+  5649 5960 5968 1    BACKBONE|DICT
+  5650 5960 5961 1    BACKBONE|DICT
+  5651 5960 5963 1    DICT
+  5652 5960 5959 1    BACKBONE|DICT
+  5653 5959 5967 1    BACKBONE|DICT
+  5654 5963 5969 1    DICT
+  5655 5963 5970 1    DICT
+  5656 5963 5964 1    DICT
+  5657 5964 5966 ar   DICT
+  5658 5964 5965 ar   DICT
+  5659 5961 5962 2    BACKBONE|DICT
+  5660 5972 5981 1    BACKBONE|DICT
+  5661 5972 5973 1    BACKBONE|DICT
+  5662 5972 5975 1    DICT
+  5663 5972 5971 1    BACKBONE|DICT
+  5664 5971 5980 1    BACKBONE|DICT
+  5665 5975 5982 1    DICT
+  5666 5975 5983 1    DICT
+  5667 5975 5976 1    DICT
+  5668 5976 5984 1    DICT
+  5669 5976 5985 1    DICT
+  5670 5976 5977 1    DICT
+  5671 5977 5986 1    DICT
+  5672 5977 5987 1    DICT
+  5673 5977 5978 1    DICT
+  5674 5978 5988 1    DICT
+  5675 5978 5989 1    DICT
+  5676 5978 5979 1    DICT
+  5677 5979 5990 1    DICT
+  5678 5979 5991 1    DICT
+  5679 5979 5992 1    DICT
+  5680 5973 5974 2    BACKBONE|DICT
+  5681 5994 6002 1    BACKBONE|DICT
+  5682 5994 5995 1    BACKBONE|DICT
+  5683 5994 5997 1    DICT
+  5684 5994 5993 1    BACKBONE|DICT
+  5685 5993 6001 1    BACKBONE|DICT
+  5686 5997 6003 1    DICT
+  5687 5997 6004 1    DICT
+  5688 5997 5998 1    DICT
+  5689 5998 6005 1    DICT
+  5690 5998 6000 1    DICT
+  5691 5998 5999 1    DICT
+  5692 5999 6006 1    DICT
+  5693 5999 6007 1    DICT
+  5694 5999 6008 1    DICT
+  5695 6000 6009 1    DICT
+  5696 6000 6010 1    DICT
+  5697 6000 6011 1    DICT
+  5698 5995 5996 2    BACKBONE|DICT
+  5699 6013 6018 1    DICT
+  5700 6013 6017 1    BACKBONE|DICT
+  5701 6013 6014 1    BACKBONE|DICT
+  5702 6013 6012 1    BACKBONE|DICT
+  5703 6012 6016 1    BACKBONE|DICT
+  5704 6014 6015 2    BACKBONE|DICT
+  5705 6020 6029 1    BACKBONE|DICT
+  5706 6020 6021 1    BACKBONE|DICT
+  5707 6020 6023 1    DICT
+  5708 6020 6019 1    BACKBONE|DICT
+  5709 6019 6028 1    BACKBONE|DICT
+  5710 6023 6030 1    DICT
+  5711 6023 6031 1    DICT
+  5712 6023 6024 1    DICT
+  5713 6024 6032 1    DICT
+  5714 6024 6033 1    DICT
+  5715 6024 6025 1    DICT
+  5716 6025 6026 ar   DICT
+  5717 6025 6027 ar   DICT
+  5718 6021 6022 2    BACKBONE|DICT
+  5719 6035 6043 1    BACKBONE|DICT
+  5720 6035 6036 1    BACKBONE|DICT
+  5721 6035 6038 1    DICT
+  5722 6035 6034 1    BACKBONE|DICT
+  5723 6034 6042 1    BACKBONE|DICT
+  5724 6038 6044 1    DICT
+  5725 6038 6045 1    DICT
+  5726 6038 6039 1    DICT
+  5727 6039 6040 2    DICT
+  5728 6039 6041 am   DICT
+  5729 6041 6047 1    DICT
+  5730 6041 6046 1    DICT
+  5731 6036 6037 2    BACKBONE|DICT
+  5732 6049 6057 1    BACKBONE|DICT
+  5733 6049 6050 1    BACKBONE|DICT
+  5734 6049 6052 1    DICT
+  5735 6049 6048 1    BACKBONE|DICT
+  5736 6048 6056 1    BACKBONE|DICT
+  5737 6052 6058 1    DICT
+  5738 6052 6059 1    DICT
+  5739 6052 6053 1    DICT
+  5740 6053 6060 1    DICT
+  5741 6053 6055 1    DICT
+  5742 6053 6054 1    DICT
+  5743 6054 6061 1    DICT
+  5744 6054 6062 1    DICT
+  5745 6054 6063 1    DICT
+  5746 6055 6064 1    DICT
+  5747 6055 6065 1    DICT
+  5748 6055 6066 1    DICT
+  5749 6050 6051 2    BACKBONE|DICT
+  5750 6068 6077 1    BACKBONE|DICT
+  5751 6068 6069 1    BACKBONE|DICT
+  5752 6068 6071 1    DICT
+  5753 6068 6067 1    BACKBONE|DICT
+  5754 6067 6076 1    BACKBONE|DICT
+  5755 6071 6078 1    DICT
+  5756 6071 6079 1    DICT
+  5757 6071 6072 1    DICT
+  5758 6072 6080 1    DICT
+  5759 6072 6081 1    DICT
+  5760 6072 6073 1    DICT
+  5761 6073 6082 1    DICT
+  5762 6073 6083 1    DICT
+  5763 6073 6074 1    DICT
+  5764 6074 6084 1    DICT
+  5765 6074 6085 1    DICT
+  5766 6074 6075 1    DICT
+  5767 6075 6086 1    DICT
+  5768 6075 6087 1    DICT
+  5769 6075 6088 1    DICT
+  5770 6069 6070 2    BACKBONE|DICT
+  5771 6090 6098 1    BACKBONE|DICT
+  5772 6090 6091 1    BACKBONE|DICT
+  5773 6090 6093 1    DICT
+  5774 6090 6089 1    BACKBONE|DICT
+  5775 6089 6097 1    BACKBONE|DICT
+  5776 6093 6099 1    DICT
+  5777 6093 6094 1    DICT
+  5778 6093 6095 1    DICT
+  5779 6095 6102 1    DICT
+  5780 6095 6103 1    DICT
+  5781 6095 6104 1    DICT
+  5782 6094 6100 1    DICT
+  5783 6094 6101 1    DICT
+  5784 6094 6096 1    DICT
+  5785 6096 6105 1    DICT
+  5786 6096 6106 1    DICT
+  5787 6096 6107 1    DICT
+  5788 6091 6092 2    BACKBONE|DICT
+  5789 6109 6118 1    BACKBONE|DICT
+  5790 6109 6110 1    BACKBONE|DICT
+  5791 6109 6112 1    DICT
+  5792 6109 6108 1    BACKBONE|DICT
+  5793 6108 6117 1    BACKBONE|DICT
+  5794 6112 6119 1    DICT
+  5795 6112 6120 1    DICT
+  5796 6112 6113 1    DICT
+  5797 6113 6121 1    DICT
+  5798 6113 6122 1    DICT
+  5799 6113 6114 1    DICT
+  5800 6114 6123 1    DICT
+  5801 6114 6124 1    DICT
+  5802 6114 6115 1    DICT
+  5803 6115 6125 1    DICT
+  5804 6115 6126 1    DICT
+  5805 6115 6116 1    DICT
+  5806 6116 6127 1    DICT
+  5807 6116 6128 1    DICT
+  5808 6116 6129 1    DICT
+  5809 6110 6111 2    BACKBONE|DICT
+  5810 6131 6139 1    BACKBONE|DICT
+  5811 6131 6132 1    BACKBONE|DICT
+  5812 6131 6134 1    DICT
+  5813 6131 6130 1    BACKBONE|DICT
+  5814 6130 6138 1    BACKBONE|DICT
+  5815 6134 6140 1    DICT
+  5816 6134 6141 1    DICT
+  5817 6134 6135 1    DICT
+  5818 6135 6142 1    DICT
+  5819 6135 6137 1    DICT
+  5820 6135 6136 1    DICT
+  5821 6136 6143 1    DICT
+  5822 6136 6144 1    DICT
+  5823 6136 6145 1    DICT
+  5824 6137 6146 1    DICT
+  5825 6137 6147 1    DICT
+  5826 6137 6148 1    DICT
+  5827 6132 6133 2    BACKBONE|DICT
+  5828 6150 6155 1    BACKBONE|DICT
+  5829 6150 6151 1    BACKBONE|DICT
+  5830 6150 6153 1    DICT
+  5831 6150 6149 1    BACKBONE|DICT
+  5832 6149 6154 1    BACKBONE|DICT
+  5833 6153 6156 1    DICT
+  5834 6153 6157 1    DICT
+  5835 6153 6158 1    DICT
+  5836 6151 6152 2    BACKBONE|DICT
+  5837 6160 6169 1    BACKBONE|DICT
+  5838 6160 6161 1    BACKBONE|DICT
+  5839 6160 6163 1    DICT
+  5840 6160 6159 1    BACKBONE|DICT
+  5841 6159 6168 1    BACKBONE|DICT
+  5842 6163 6170 1    DICT
+  5843 6163 6171 1    DICT
+  5844 6163 6164 1    DICT
+  5845 6164 6172 1    DICT
+  5846 6164 6173 1    DICT
+  5847 6164 6165 1    DICT
+  5848 6165 6166 2    DICT
+  5849 6165 6167 am   DICT
+  5850 6167 6175 1    DICT
+  5851 6167 6174 1    DICT
+  5852 6161 6162 2    BACKBONE|DICT
+  5853 6177 6182 1    BACKBONE|DICT
+  5854 6177 6178 1    BACKBONE|DICT
+  5855 6177 6180 1    DICT
+  5856 6177 6176 1    BACKBONE|DICT
+  5857 6176 6181 1    BACKBONE|DICT
+  5858 6180 6183 1    DICT
+  5859 6180 6184 1    DICT
+  5860 6180 6185 1    DICT
+  5861 6178 6179 2    BACKBONE|DICT
+  5862    3   23 am   BACKBONE|DICT|INTERRES
+  5863   25   45 am   BACKBONE|DICT|INTERRES
+  5864   47   64 am   BACKBONE|DICT|INTERRES
+  5865   66   75 am   BACKBONE|DICT|INTERRES
+  5866   77   82 am   BACKBONE|DICT|INTERRES
+  5867   84   89 am   BACKBONE|DICT|INTERRES
+  5868   91  100 am   BACKBONE|DICT|INTERRES
+  5869  102  116 am   BACKBONE|DICT|INTERRES
+  5870  118  132 am   BACKBONE|DICT|INTERRES
+  5871  134  147 am   BACKBONE|DICT|INTERRES
+  5872  149  164 am   BACKBONE|DICT|INTERRES
+  5873  166  181 am   BACKBONE|DICT|INTERRES
+  5874  183  188 am   BACKBONE|DICT|INTERRES
+  5875  190  200 am   BACKBONE|DICT|INTERRES
+  5876  202  215 am   BACKBONE|DICT|INTERRES
+  5877  217  232 am   BACKBONE|DICT|INTERRES
+  5878  234  246 am   BACKBONE|DICT|INTERRES
+  5879  248  270 am   BACKBONE|DICT|INTERRES
+  5880  272  289 am   BACKBONE|DICT|INTERRES
+  5881  291  308 am   BACKBONE|DICT|INTERRES
+  5882  310  332 am   BACKBONE|DICT|INTERRES
+  5883  334  347 am   BACKBONE|DICT|INTERRES
+  5884  349  366 am   BACKBONE|DICT|INTERRES
+  5885  368  385 am   BACKBONE|DICT|INTERRES
+  5886  387  407 am   BACKBONE|DICT|INTERRES
+  5887  409  422 am   BACKBONE|DICT|INTERRES
+  5888  424  444 am   BACKBONE|DICT|INTERRES
+  5889  446  463 am   BACKBONE|DICT|INTERRES
+  5890  465  482 am   BACKBONE|DICT|INTERRES
+  5891  484  502 am   BACKBONE|DICT|INTERRES
+  5892  504  516 am   BACKBONE|DICT|INTERRES
+  5893  518  537 am   BACKBONE|DICT|INTERRES
+  5894  539  553 am   BACKBONE|DICT|INTERRES
+  5895  555  568 am   BACKBONE|DICT|INTERRES
+  5896  570  587 am   BACKBONE|DICT|INTERRES
+  5897  589  599 am   BACKBONE|DICT|INTERRES
+  5898  601  618 am   BACKBONE|DICT|INTERRES
+  5899  620  635 am   BACKBONE|DICT|INTERRES
+  5900  637  646 am   BACKBONE|DICT|INTERRES
+  5901  648  667 am   BACKBONE|DICT|INTERRES
+  5902  669  679 am   BACKBONE|DICT|INTERRES
+  5903  681  698 am   BACKBONE|DICT|INTERRES
+  5904  700  705 am   BACKBONE|DICT|INTERRES
+  5905  707  724 am   BACKBONE|DICT|INTERRES
+  5906  726  739 am   BACKBONE|DICT|INTERRES
+  5907  741  753 am   BACKBONE|DICT|INTERRES
+  5908  755  777 am   BACKBONE|DICT|INTERRES
+  5909  779  789 am   BACKBONE|DICT|INTERRES
+  5910  791  799 am   BACKBONE|DICT|INTERRES
+  5911  801  813 am   BACKBONE|DICT|INTERRES
+  5912  815  827 am   BACKBONE|DICT|INTERRES
+  5913  829  839 am   BACKBONE|DICT|INTERRES
+  5914  841  856 am   BACKBONE|DICT|INTERRES
+  5915  858  872 am   BACKBONE|DICT|INTERRES
+  5916  874  886 am   BACKBONE|DICT|INTERRES
+  5917  888  908 am   BACKBONE|DICT|INTERRES
+  5918  910  920 am   BACKBONE|DICT|INTERRES
+  5919  922  930 am   BACKBONE|DICT|INTERRES
+  5920  932  940 am   BACKBONE|DICT|INTERRES
+  5921  942  955 am   BACKBONE|DICT|INTERRES
+  5922  957  965 am   BACKBONE|DICT|INTERRES
+  5923  967  984 am   BACKBONE|DICT|INTERRES
+  5924  986 1006 am   BACKBONE|DICT|INTERRES
+  5925 1008 1028 am   BACKBONE|DICT|INTERRES
+  5926 1030 1045 am   BACKBONE|DICT|INTERRES
+  5927 1047 1059 am   BACKBONE|DICT|INTERRES
+  5928 1061 1075 am   BACKBONE|DICT|INTERRES
+  5929 1077 1082 am   BACKBONE|DICT|INTERRES
+  5930 1084 1098 am   BACKBONE|DICT|INTERRES
+  5931 1100 1120 am   BACKBONE|DICT|INTERRES
+  5932 1122 1131 am   BACKBONE|DICT|INTERRES
+  5933 1133 1141 am   BACKBONE|DICT|INTERRES
+  5934 1143 1155 am   BACKBONE|DICT|INTERRES
+  5935 1157 1174 am   BACKBONE|DICT|INTERRES
+  5936 1176 1188 am   BACKBONE|DICT|INTERRES
+  5937 1190 1202 am   BACKBONE|DICT|INTERRES
+  5938 1204 1214 am   BACKBONE|DICT|INTERRES
+  5939 1216 1229 am   BACKBONE|DICT|INTERRES
+  5940 1231 1251 am   BACKBONE|DICT|INTERRES
+  5941 1253 1275 am   BACKBONE|DICT|INTERRES
+  5942 1277 1291 am   BACKBONE|DICT|INTERRES
+  5943 1293 1306 am   BACKBONE|DICT|INTERRES
+  5944 1308 1321 am   BACKBONE|DICT|INTERRES
+  5945 1323 1341 am   BACKBONE|DICT|INTERRES
+  5946 1343 1363 am   BACKBONE|DICT|INTERRES
+  5947 1365 1382 am   BACKBONE|DICT|INTERRES
+  5948 1384 1404 am   BACKBONE|DICT|INTERRES
+  5949 1406 1421 am   BACKBONE|DICT|INTERRES
+  5950 1423 1438 am   BACKBONE|DICT|INTERRES
+  5951 1440 1462 am   BACKBONE|DICT|INTERRES
+  5952 1464 1484 am   BACKBONE|DICT|INTERRES
+  5953 1486 1495 am   BACKBONE|DICT|INTERRES
+  5954 1497 1509 am   BACKBONE|DICT|INTERRES
+  5955 1511 1523 am   BACKBONE|DICT|INTERRES
+  5956 1525 1530 am   BACKBONE|DICT|INTERRES
+  5957 1532 1544 am   BACKBONE|DICT|INTERRES
+  5958 1546 1563 am   BACKBONE|DICT|INTERRES
+  5959 1565 1587 am   BACKBONE|DICT|INTERRES
+  5960 1589 1601 am   BACKBONE|DICT|INTERRES
+  5961 1603 1620 am   BACKBONE|DICT|INTERRES
+  5962 1622 1639 am   BACKBONE|DICT|INTERRES
+  5963 1641 1646 am   BACKBONE|DICT|INTERRES
+  5964 1648 1653 am   BACKBONE|DICT|INTERRES
+  5965 1655 1667 am   BACKBONE|DICT|INTERRES
+  5966 1669 1683 am   BACKBONE|DICT|INTERRES
+  5967 1685 1703 am   BACKBONE|DICT|INTERRES
+  5968 1705 1727 am   BACKBONE|DICT|INTERRES
+  5969 1729 1742 am   BACKBONE|DICT|INTERRES
+  5970 1744 1752 am   BACKBONE|DICT|INTERRES
+  5971 1754 1771 am   BACKBONE|DICT|INTERRES
+  5972 1773 1790 am   BACKBONE|DICT|INTERRES
+  5973 1792 1801 am   BACKBONE|DICT|INTERRES
+  5974 1803 1823 am   BACKBONE|DICT|INTERRES
+  5975 1825 1837 am   BACKBONE|DICT|INTERRES
+  5976 1839 1856 am   BACKBONE|DICT|INTERRES
+  5977 1858 1870 am   BACKBONE|DICT|INTERRES
+  5978 1872 1894 am   BACKBONE|DICT|INTERRES
+  5979 1896 1913 am   BACKBONE|DICT|INTERRES
+  5980 1915 1929 am   BACKBONE|DICT|INTERRES
+  5981 1931 1940 am   BACKBONE|DICT|INTERRES
+  5982 1942 1947 am   BACKBONE|DICT|INTERRES
+  5983 1949 1971 am   BACKBONE|DICT|INTERRES
+  5984 1973 1987 am   BACKBONE|DICT|INTERRES
+  5985 1989 2009 am   BACKBONE|DICT|INTERRES
+  5986 2011 2023 am   BACKBONE|DICT|INTERRES
+  5987 2025 2042 am   BACKBONE|DICT|INTERRES
+  5988 2044 2061 am   BACKBONE|DICT|INTERRES
+  5989 2063 2080 am   BACKBONE|DICT|INTERRES
+  5990 2082 2087 am   BACKBONE|DICT|INTERRES
+  5991 2089 2104 am   BACKBONE|DICT|INTERRES
+  5992 2106 2121 am   BACKBONE|DICT|INTERRES
+  5993 2133 2155 am   BACKBONE|DICT|INTERRES
+  5994 2157 2165 am   BACKBONE|DICT|INTERRES
+  5995 2167 2179 am   BACKBONE|DICT|INTERRES
+  5996 2181 2191 am   BACKBONE|DICT|INTERRES
+  5997 2193 2211 am   BACKBONE|DICT|INTERRES
+  5998 2213 2227 am   BACKBONE|DICT|INTERRES
+  5999 2229 2243 am   BACKBONE|DICT|INTERRES
+  6000 2245 2257 am   BACKBONE|DICT|INTERRES
+  6001 2259 2264 am   BACKBONE|DICT|INTERRES
+  6002 2266 2278 am   BACKBONE|DICT|INTERRES
+  6003 2280 2285 am   BACKBONE|DICT|INTERRES
+  6004 2287 2307 am   BACKBONE|DICT|INTERRES
+  6005 2309 2323 am   BACKBONE|DICT|INTERRES
+  6006 2325 2338 am   BACKBONE|DICT|INTERRES
+  6007 2340 2357 am   BACKBONE|DICT|INTERRES
+  6008 2359 2371 am   BACKBONE|DICT|INTERRES
+  6009 2373 2392 am   BACKBONE|DICT|INTERRES
+  6010 2394 2406 am   BACKBONE|DICT|INTERRES
+  6011 2408 2420 am   BACKBONE|DICT|INTERRES
+  6012 2422 2431 am   BACKBONE|DICT|INTERRES
+  6013 2433 2443 am   BACKBONE|DICT|INTERRES
+  6014 2445 2450 am   BACKBONE|DICT|INTERRES
+  6015 2452 2464 am   BACKBONE|DICT|INTERRES
+  6016 2466 2481 am   BACKBONE|DICT|INTERRES
+  6017 2483 2503 am   BACKBONE|DICT|INTERRES
+  6018 2505 2519 am   BACKBONE|DICT|INTERRES
+  6019 2521 2533 am   BACKBONE|DICT|INTERRES
+  6020 2535 2554 am   BACKBONE|DICT|INTERRES
+  6021 2556 2573 am   BACKBONE|DICT|INTERRES
+  6022 2575 2589 am   BACKBONE|DICT|INTERRES
+  6023 2591 2606 am   BACKBONE|DICT|INTERRES
+  6024 2608 2620 am   BACKBONE|DICT|INTERRES
+  6025 2622 2640 am   BACKBONE|DICT|INTERRES
+  6026 2642 2655 am   BACKBONE|DICT|INTERRES
+  6027 2657 2670 am   BACKBONE|DICT|INTERRES
+  6028 2672 2677 am   BACKBONE|DICT|INTERRES
+  6029 2679 2684 am   BACKBONE|DICT|INTERRES
+  6030 2686 2691 am   BACKBONE|DICT|INTERRES
+  6031 2693 2707 am   BACKBONE|DICT|INTERRES
+  6032 2709 2717 am   BACKBONE|DICT|INTERRES
+  6033 2719 2734 am   BACKBONE|DICT|INTERRES
+  6034 2736 2741 am   BACKBONE|DICT|INTERRES
+  6035 2743 2758 am   BACKBONE|DICT|INTERRES
+  6036 2760 2779 am   BACKBONE|DICT|INTERRES
+  6037 2781 2793 am   BACKBONE|DICT|INTERRES
+  6038 2795 2810 am   BACKBONE|DICT|INTERRES
+  6039 2812 2822 am   BACKBONE|DICT|INTERRES
+  6040 2824 2844 am   BACKBONE|DICT|INTERRES
+  6041 2846 2855 am   BACKBONE|DICT|INTERRES
+  6042 2857 2874 am   BACKBONE|DICT|INTERRES
+  6043 2876 2889 am   BACKBONE|DICT|INTERRES
+  6044 2891 2901 am   BACKBONE|DICT|INTERRES
+  6045 2903 2921 am   BACKBONE|DICT|INTERRES
+  6046 2923 2931 am   BACKBONE|DICT|INTERRES
+  6047 2933 2948 am   BACKBONE|DICT|INTERRES
+  6048 2950 2959 am   BACKBONE|DICT|INTERRES
+  6049 2961 2970 am   BACKBONE|DICT|INTERRES
+  6050 2972 2990 am   BACKBONE|DICT|INTERRES
+  6051 2992 3007 am   BACKBONE|DICT|INTERRES
+  6052 3009 3024 am   BACKBONE|DICT|INTERRES
+  6053 3026 3034 am   BACKBONE|DICT|INTERRES
+  6054 3036 3053 am   BACKBONE|DICT|INTERRES
+  6055 3055 3064 am   BACKBONE|DICT|INTERRES
+  6056 3066 3086 am   BACKBONE|DICT|INTERRES
+  6057 3088 3093 am   BACKBONE|DICT|INTERRES
+  6058 3095 3117 am   BACKBONE|DICT|INTERRES
+  6059 3119 3131 am   BACKBONE|DICT|INTERRES
+  6060 3133 3150 am   BACKBONE|DICT|INTERRES
+  6061 3152 3171 am   BACKBONE|DICT|INTERRES
+  6062 3173 3190 am   BACKBONE|DICT|INTERRES
+  6063 3192 3201 am   BACKBONE|DICT|INTERRES
+  6064 3203 3215 am   BACKBONE|DICT|INTERRES
+  6065 3217 3237 am   BACKBONE|DICT|INTERRES
+  6066 3239 3251 am   BACKBONE|DICT|INTERRES
+  6067 3253 3265 am   BACKBONE|DICT|INTERRES
+  6068 3267 3284 am   BACKBONE|DICT|INTERRES
+  6069 3286 3303 am   BACKBONE|DICT|INTERRES
+  6070 3305 3325 am   BACKBONE|DICT|INTERRES
+  6071 3327 3347 am   BACKBONE|DICT|INTERRES
+  6072 3349 3368 am   BACKBONE|DICT|INTERRES
+  6073 3370 3380 am   BACKBONE|DICT|INTERRES
+  6074 3382 3387 am   BACKBONE|DICT|INTERRES
+  6075 3389 3411 am   BACKBONE|DICT|INTERRES
+  6076 3413 3431 am   BACKBONE|DICT|INTERRES
+  6077 3433 3453 am   BACKBONE|DICT|INTERRES
+  6078 3455 3465 am   BACKBONE|DICT|INTERRES
+  6079 3467 3484 am   BACKBONE|DICT|INTERRES
+  6080 3486 3504 am   BACKBONE|DICT|INTERRES
+  6081 3506 3521 am   BACKBONE|DICT|INTERRES
+  6082 3523 3536 am   BACKBONE|DICT|INTERRES
+  6083 3538 3555 am   BACKBONE|DICT|INTERRES
+  6084 3557 3576 am   BACKBONE|DICT|INTERRES
+  6085 3578 3588 am   BACKBONE|DICT|INTERRES
+  6086 3590 3610 am   BACKBONE|DICT|INTERRES
+  6087 3612 3627 am   BACKBONE|DICT|INTERRES
+  6088 3629 3648 am   BACKBONE|DICT|INTERRES
+  6089 3650 3670 am   BACKBONE|DICT|INTERRES
+  6090 3672 3681 am   BACKBONE|DICT|INTERRES
+  6091 3683 3698 am   BACKBONE|DICT|INTERRES
+  6092 3700 3718 am   BACKBONE|DICT|INTERRES
+  6093 3720 3733 am   BACKBONE|DICT|INTERRES
+  6094 3735 3743 am   BACKBONE|DICT|INTERRES
+  6095 3745 3760 am   BACKBONE|DICT|INTERRES
+  6096 3762 3782 am   BACKBONE|DICT|INTERRES
+  6097 3784 3801 am   BACKBONE|DICT|INTERRES
+  6098 3803 3825 am   BACKBONE|DICT|INTERRES
+  6099 3827 3846 am   BACKBONE|DICT|INTERRES
+  6100 3848 3861 am   BACKBONE|DICT|INTERRES
+  6101 3863 3878 am   BACKBONE|DICT|INTERRES
+  6102 3880 3902 am   BACKBONE|DICT|INTERRES
+  6103 3904 3921 am   BACKBONE|DICT|INTERRES
+  6104 3923 3940 am   BACKBONE|DICT|INTERRES
+  6105 3942 3952 am   BACKBONE|DICT|INTERRES
+  6106 3954 3964 am   BACKBONE|DICT|INTERRES
+  6107 3966 3981 am   BACKBONE|DICT|INTERRES
+  6108 3983 3997 am   BACKBONE|DICT|INTERRES
+  6109 3999 4007 am   BACKBONE|DICT|INTERRES
+  6110 4009 4024 am   BACKBONE|DICT|INTERRES
+  6111 4026 4034 am   BACKBONE|DICT|INTERRES
+  6112 4036 4051 am   BACKBONE|DICT|INTERRES
+  6113 4053 4073 am   BACKBONE|DICT|INTERRES
+  6114 4075 4084 am   BACKBONE|DICT|INTERRES
+  6115 4086 4099 am   BACKBONE|DICT|INTERRES
+  6116 4101 4106 am   BACKBONE|DICT|INTERRES
+  6117 4108 4113 am   BACKBONE|DICT|INTERRES
+  6118 4115 4133 am   BACKBONE|DICT|INTERRES
+  6119 4135 4152 am   BACKBONE|DICT|INTERRES
+  6120 4154 4176 am   BACKBONE|DICT|INTERRES
+  6121 4178 4186 am   BACKBONE|DICT|INTERRES
+  6122 4188 4197 am   BACKBONE|DICT|INTERRES
+  6123 4199 4219 am   BACKBONE|DICT|INTERRES
+  6124 4235 4244 am   BACKBONE|DICT|INTERRES
+  6125 4246 4263 am   BACKBONE|DICT|INTERRES
+  6126 4265 4270 am   BACKBONE|DICT|INTERRES
+  6127 4272 4287 am   BACKBONE|DICT|INTERRES
+  6128 4289 4304 am   BACKBONE|DICT|INTERRES
+  6129 4306 4318 am   BACKBONE|DICT|INTERRES
+  6130 4320 4329 am   BACKBONE|DICT|INTERRES
+  6131 4331 4345 am   BACKBONE|DICT|INTERRES
+  6132 4347 4364 am   BACKBONE|DICT|INTERRES
+  6133 4366 4380 am   BACKBONE|DICT|INTERRES
+  6134 4382 4391 am   BACKBONE|DICT|INTERRES
+  6135 4393 4405 am   BACKBONE|DICT|INTERRES
+  6136 4407 4417 am   BACKBONE|DICT|INTERRES
+  6137 4419 4424 am   BACKBONE|DICT|INTERRES
+  6138 4426 4446 am   BACKBONE|DICT|INTERRES
+  6139 4448 4460 am   BACKBONE|DICT|INTERRES
+  6140 4462 4476 am   BACKBONE|DICT|INTERRES
+  6141 4478 4491 am   BACKBONE|DICT|INTERRES
+  6142 4493 4501 am   BACKBONE|DICT|INTERRES
+  6143 4503 4517 am   BACKBONE|DICT|INTERRES
+  6144 4519 4527 am   BACKBONE|DICT|INTERRES
+  6145 4529 4537 am   BACKBONE|DICT|INTERRES
+  6146 4539 4554 am   BACKBONE|DICT|INTERRES
+  6147 4556 4561 am   BACKBONE|DICT|INTERRES
+  6148 4563 4575 am   BACKBONE|DICT|INTERRES
+  6149 4577 4591 am   BACKBONE|DICT|INTERRES
+  6150 4593 4605 am   BACKBONE|DICT|INTERRES
+  6151 4607 4629 am   BACKBONE|DICT|INTERRES
+  6152 4631 4647 am   BACKBONE|DICT|INTERRES
+  6153 4649 4668 am   BACKBONE|DICT|INTERRES
+  6154 4670 4692 am   BACKBONE|DICT|INTERRES
+  6155 4694 4709 am   BACKBONE|DICT|INTERRES
+  6156 4711 4730 am   BACKBONE|DICT|INTERRES
+  6157 4732 4747 am   BACKBONE|DICT|INTERRES
+  6158 4749 4769 am   BACKBONE|DICT|INTERRES
+  6159 4771 4776 am   BACKBONE|DICT|INTERRES
+  6160 4778 4793 am   BACKBONE|DICT|INTERRES
+  6161 4795 4808 am   BACKBONE|DICT|INTERRES
+  6162 4810 4822 am   BACKBONE|DICT|INTERRES
+  6163 4824 4833 am   BACKBONE|DICT|INTERRES
+  6164 4835 4847 am   BACKBONE|DICT|INTERRES
+  6165 4849 4861 am   BACKBONE|DICT|INTERRES
+  6166 4863 4875 am   BACKBONE|DICT|INTERRES
+  6167 4877 4894 am   BACKBONE|DICT|INTERRES
+  6168 4896 4904 am   BACKBONE|DICT|INTERRES
+  6169 4906 4915 am   BACKBONE|DICT|INTERRES
+  6170 4917 4934 am   BACKBONE|DICT|INTERRES
+  6171 4936 4954 am   BACKBONE|DICT|INTERRES
+  6172 4956 4964 am   BACKBONE|DICT|INTERRES
+  6173 4966 4988 am   BACKBONE|DICT|INTERRES
+  6174 4990 5002 am   BACKBONE|DICT|INTERRES
+  6175 5004 5026 am   BACKBONE|DICT|INTERRES
+  6176 5028 5033 am   BACKBONE|DICT|INTERRES
+  6177 5035 5052 am   BACKBONE|DICT|INTERRES
+  6178 5054 5062 am   BACKBONE|DICT|INTERRES
+  6179 5064 5079 am   BACKBONE|DICT|INTERRES
+  6180 5081 5103 am   BACKBONE|DICT|INTERRES
+  6181 5105 5113 am   BACKBONE|DICT|INTERRES
+  6182 5115 5135 am   BACKBONE|DICT|INTERRES
+  6183 5137 5154 am   BACKBONE|DICT|INTERRES
+  6184 5156 5166 am   BACKBONE|DICT|INTERRES
+  6185 5168 5180 am   BACKBONE|DICT|INTERRES
+  6186 5182 5194 am   BACKBONE|DICT|INTERRES
+  6187 5196 5216 am   BACKBONE|DICT|INTERRES
+  6188 5218 5231 am   BACKBONE|DICT|INTERRES
+  6189 5233 5250 am   BACKBONE|DICT|INTERRES
+  6190 5252 5260 am   BACKBONE|DICT|INTERRES
+  6191 5262 5280 am   BACKBONE|DICT|INTERRES
+  6192 5282 5300 am   BACKBONE|DICT|INTERRES
+  6193 5302 5310 am   BACKBONE|DICT|INTERRES
+  6194 5312 5324 am   BACKBONE|DICT|INTERRES
+  6195 5326 5334 am   BACKBONE|DICT|INTERRES
+  6196 5336 5353 am   BACKBONE|DICT|INTERRES
+  6197 5355 5368 am   BACKBONE|DICT|INTERRES
+  6198 5370 5383 am   BACKBONE|DICT|INTERRES
+  6199 5385 5399 am   BACKBONE|DICT|INTERRES
+  6200 5401 5410 am   BACKBONE|DICT|INTERRES
+  6201 5412 5429 am   BACKBONE|DICT|INTERRES
+  6202 5431 5444 am   BACKBONE|DICT|INTERRES
+  6203 5446 5458 am   BACKBONE|DICT|INTERRES
+  6204 5460 5477 am   BACKBONE|DICT|INTERRES
+  6205 5479 5492 am   BACKBONE|DICT|INTERRES
+  6206 5494 5502 am   BACKBONE|DICT|INTERRES
+  6207 5504 5509 am   BACKBONE|DICT|INTERRES
+  6208 5511 5529 am   BACKBONE|DICT|INTERRES
+  6209 5531 5546 am   BACKBONE|DICT|INTERRES
+  6210 5548 5560 am   BACKBONE|DICT|INTERRES
+  6211 5562 5582 am   BACKBONE|DICT|INTERRES
+  6212 5584 5594 am   BACKBONE|DICT|INTERRES
+  6213 5596 5613 am   BACKBONE|DICT|INTERRES
+  6214 5615 5623 am   BACKBONE|DICT|INTERRES
+  6215 5625 5633 am   BACKBONE|DICT|INTERRES
+  6216 5635 5644 am   BACKBONE|DICT|INTERRES
+  6217 5646 5663 am   BACKBONE|DICT|INTERRES
+  6218 5665 5685 am   BACKBONE|DICT|INTERRES
+  6219 5687 5692 am   BACKBONE|DICT|INTERRES
+  6220 5694 5711 am   BACKBONE|DICT|INTERRES
+  6221 5713 5725 am   BACKBONE|DICT|INTERRES
+  6222 5727 5739 am   BACKBONE|DICT|INTERRES
+  6223 5741 5755 am   BACKBONE|DICT|INTERRES
+  6224 5757 5772 am   BACKBONE|DICT|INTERRES
+  6225 5774 5796 am   BACKBONE|DICT|INTERRES
+  6226 5798 5807 am   BACKBONE|DICT|INTERRES
+  6227 5809 5819 am   BACKBONE|DICT|INTERRES
+  6228 5821 5840 am   BACKBONE|DICT|INTERRES
+  6229 5842 5859 am   BACKBONE|DICT|INTERRES
+  6230 5861 5873 am   BACKBONE|DICT|INTERRES
+  6231 5875 5887 am   BACKBONE|DICT|INTERRES
+  6232 5889 5907 am   BACKBONE|DICT|INTERRES
+  6233 5909 5922 am   BACKBONE|DICT|INTERRES
+  6234 5924 5942 am   BACKBONE|DICT|INTERRES
+  6235 5944 5959 am   BACKBONE|DICT|INTERRES
+  6236 5961 5971 am   BACKBONE|DICT|INTERRES
+  6237 5973 5993 am   BACKBONE|DICT|INTERRES
+  6238 5995 6012 am   BACKBONE|DICT|INTERRES
+  6239 6014 6019 am   BACKBONE|DICT|INTERRES
+  6240 6021 6034 am   BACKBONE|DICT|INTERRES
+  6241 6036 6048 am   BACKBONE|DICT|INTERRES
+  6242 6050 6067 am   BACKBONE|DICT|INTERRES
+  6243 6069 6089 am   BACKBONE|DICT|INTERRES
+  6244 6091 6108 am   BACKBONE|DICT|INTERRES
+  6245 6110 6130 am   BACKBONE|DICT|INTERRES
+  6246 6132 6149 am   BACKBONE|DICT|INTERRES
+  6247 6151 6159 am   BACKBONE|DICT|INTERRES
+  6248 6161 6176 am   BACKBONE|DICT|INTERRES
+@<TRIPOS>SUBSTRUCTURE
+     1 LYS3        2 RESIDUE           4 B     LYS     1 ROOT LYS B   3
+     2 LYS4       24 RESIDUE           4 B     LYS     2 **** LYS B   4
+     3 ILE5       46 RESIDUE           4 B     ILE     2 **** ILE B   5
+     4 SER6       65 RESIDUE           4 B     SER     2 **** SER B   6
+     5 GLY7       76 RESIDUE           4 B     GLY     2 **** GLY B   7
+     6 GLY8       83 RESIDUE           4 B     GLY     2 **** GLY B   8
+     7 SER9       90 RESIDUE           4 B     SER     2 **** SER B   9
+     8 VAL10     101 RESIDUE           4 B     VAL     2 **** VAL B  10
+     9 VAL11     117 RESIDUE           4 B     VAL     2 **** VAL B  11
+    10 GLU12     133 RESIDUE           4 B     GLU     2 **** GLU B  12
+    11 MET13     148 RESIDUE           4 B     MET     2 **** MET B  13
+    12 GLN14     165 RESIDUE           4 B     GLN     2 **** GLN B  14
+    13 GLY15     182 RESIDUE           4 B     GLY     2 **** GLY B  15
+    14 ASP16     189 RESIDUE           4 B     ASP     2 **** ASP B  16
+    15 GLU17     201 RESIDUE           4 B     GLU     2 **** GLU B  17
+    16 MET18     216 RESIDUE           4 B     MET     2 **** MET B  18
+    17 THR19     233 RESIDUE           4 B     THR     2 **** THR B  19
+    18 ARG20     247 RESIDUE           4 B     ARG     2 **** ARG B  20
+    19 ILE21     271 RESIDUE           4 B     ILE     2 **** ILE B  21
+    20 ILE22     290 RESIDUE           4 B     ILE     2 **** ILE B  22
+    21 TRP23     309 RESIDUE           4 B     TRP     2 **** TRP B  23
+    22 GLU24     333 RESIDUE           4 B     GLU     2 **** GLU B  24
+    23 LEU25     348 RESIDUE           4 B     LEU     2 **** LEU B  25
+    24 ILE26     367 RESIDUE           4 B     ILE     2 **** ILE B  26
+    25 LYS27     386 RESIDUE           4 B     LYS     2 **** LYS B  27
+    26 GLU28     408 RESIDUE           4 B     GLU     2 **** GLU B  28
+    27 LYS29     423 RESIDUE           4 B     LYS     2 **** LYS B  29
+    28 LEU30     445 RESIDUE           4 B     LEU     2 **** LEU B  30
+    29 ILE31     464 RESIDUE           4 B     ILE     2 **** ILE B  31
+    30 PHE32     483 RESIDUE           4 B     PHE     2 **** PHE B  32
+    31 PRO33     503 RESIDUE           4 B     PRO     2 **** PRO B  33
+    32 TYR34     517 RESIDUE           4 B     TYR     2 **** TYR B  34
+    33 VAL35     538 RESIDUE           4 B     VAL     2 **** VAL B  35
+    34 GLU36     554 RESIDUE           4 B     GLU     2 **** GLU B  36
+    35 LEU37     569 RESIDUE           4 B     LEU     2 **** LEU B  37
+    36 ASP38     588 RESIDUE           4 B     ASP     2 **** ASP B  38
+    37 LEU39     600 RESIDUE           4 B     LEU     2 **** LEU B  39
+    38 HIS40     619 RESIDUE           4 B     HIS     2 **** HIS B  40
+    39 SER41     636 RESIDUE           4 B     SER     2 **** SER B  41
+    40 TYR42     647 RESIDUE           4 B     TYR     2 **** TYR B  42
+    41 ASP43     668 RESIDUE           4 B     ASP     2 **** ASP B  43
+    42 LEU44     680 RESIDUE           4 B     LEU     2 **** LEU B  44
+    43 GLY45     699 RESIDUE           4 B     GLY     2 **** GLY B  45
+    44 ILE46     706 RESIDUE           4 B     ILE     2 **** ILE B  46
+    45 GLU47     725 RESIDUE           4 B     GLU     2 **** GLU B  47
+    46 ASN48     740 RESIDUE           4 B     ASN     2 **** ASN B  48
+    47 ARG49     754 RESIDUE           4 B     ARG     2 **** ARG B  49
+    48 ASP50     778 RESIDUE           4 B     ASP     2 **** ASP B  50
+    49 ALA51     790 RESIDUE           4 B     ALA     2 **** ALA B  51
+    50 THR52     800 RESIDUE           4 B     THR     2 **** THR B  52
+    51 ASN53     814 RESIDUE           4 B     ASN     2 **** ASN B  53
+    52 ASP54     828 RESIDUE           4 B     ASP     2 **** ASP B  54
+    53 GLN55     840 RESIDUE           4 B     GLN     2 **** GLN B  55
+    54 VAL56     857 RESIDUE           4 B     VAL     2 **** VAL B  56
+    55 THR57     873 RESIDUE           4 B     THR     2 **** THR B  57
+    56 LYS58     887 RESIDUE           4 B     LYS     2 **** LYS B  58
+    57 ASP59     909 RESIDUE           4 B     ASP     2 **** ASP B  59
+    58 ALA60     921 RESIDUE           4 B     ALA     2 **** ALA B  60
+    59 ALA61     931 RESIDUE           4 B     ALA     2 **** ALA B  61
+    60 GLU62     941 RESIDUE           4 B     GLU     2 **** GLU B  62
+    61 ALA63     956 RESIDUE           4 B     ALA     2 **** ALA B  63
+    62 ILE64     966 RESIDUE           4 B     ILE     2 **** ILE B  64
+    63 LYS65     985 RESIDUE           4 B     LYS     2 **** LYS B  65
+    64 LYS66    1007 RESIDUE           4 B     LYS     2 **** LYS B  66
+    65 HIS67    1029 RESIDUE           4 B     HIS     2 **** HIS B  67
+    66 ASN68    1046 RESIDUE           4 B     ASN     2 **** ASN B  68
+    67 VAL69    1060 RESIDUE           4 B     VAL     2 **** VAL B  69
+    68 GLY70    1076 RESIDUE           4 B     GLY     2 **** GLY B  70
+    69 VAL71    1083 RESIDUE           4 B     VAL     2 **** VAL B  71
+    70 LYS72    1099 RESIDUE           4 B     LYS     2 **** LYS B  72
+    71 CYS73    1121 RESIDUE           4 B     CYS     2 **** CYS B  73
+    72 ALA74    1132 RESIDUE           4 B     ALA     2 **** ALA B  74
+    73 THR75    1142 RESIDUE           4 B     THR     2 **** THR B  75
+    74 ILE76    1156 RESIDUE           4 B     ILE     2 **** ILE B  76
+    75 THR77    1175 RESIDUE           4 B     THR     2 **** THR B  77
+    76 PRO78    1189 RESIDUE           4 B     PRO     2 **** PRO B  78
+    77 ASP79    1203 RESIDUE           4 B     ASP     2 **** ASP B  79
+    78 GLU80    1215 RESIDUE           4 B     GLU     2 **** GLU B  80
+    79 LYS81    1230 RESIDUE           4 B     LYS     2 **** LYS B  81
+    80 ARG82    1252 RESIDUE           4 B     ARG     2 **** ARG B  82
+    81 VAL83    1276 RESIDUE           4 B     VAL     2 **** VAL B  83
+    82 GLU84    1292 RESIDUE           4 B     GLU     2 **** GLU B  84
+    83 GLU85    1307 RESIDUE           4 B     GLU     2 **** GLU B  85
+    84 PHE86    1322 RESIDUE           4 B     PHE     2 **** PHE B  86
+    85 LYS87    1342 RESIDUE           4 B     LYS     2 **** LYS B  87
+    86 LEU88    1364 RESIDUE           4 B     LEU     2 **** LEU B  88
+    87 LYS89    1383 RESIDUE           4 B     LYS     2 **** LYS B  89
+    88 GLN90    1405 RESIDUE           4 B     GLN     2 **** GLN B  90
+    89 MET91    1422 RESIDUE           4 B     MET     2 **** MET B  91
+    90 TRP92    1439 RESIDUE           4 B     TRP     2 **** TRP B  92
+    91 LYS93    1463 RESIDUE           4 B     LYS     2 **** LYS B  93
+    92 SER94    1485 RESIDUE           4 B     SER     2 **** SER B  94
+    93 PRO95    1496 RESIDUE           4 B     PRO     2 **** PRO B  95
+    94 ASN96    1510 RESIDUE           4 B     ASN     2 **** ASN B  96
+    95 GLY97    1524 RESIDUE           4 B     GLY     2 **** GLY B  97
+    96 THR98    1531 RESIDUE           4 B     THR     2 **** THR B  98
+    97 ILE99    1545 RESIDUE           4 B     ILE     2 **** ILE B  99
+    98 ARG100   1564 RESIDUE           4 B     ARG     2 **** ARG B 100
+    99 ASN101   1588 RESIDUE           4 B     ASN     2 **** ASN B 101
+   100 ILE102   1602 RESIDUE           4 B     ILE     2 **** ILE B 102
+   101 LEU103   1621 RESIDUE           4 B     LEU     2 **** LEU B 103
+   102 GLY104   1640 RESIDUE           4 B     GLY     2 **** GLY B 104
+   103 GLY105   1647 RESIDUE           4 B     GLY     2 **** GLY B 105
+   104 THR106   1654 RESIDUE           4 B     THR     2 **** THR B 106
+   105 VAL107   1668 RESIDUE           4 B     VAL     2 **** VAL B 107
+   106 PHE108   1684 RESIDUE           4 B     PHE     2 **** PHE B 108
+   107 ARG109   1704 RESIDUE           4 B     ARG     2 **** ARG B 109
+   108 GLU110   1728 RESIDUE           4 B     GLU     2 **** GLU B 110
+   109 ALA111   1743 RESIDUE           4 B     ALA     2 **** ALA B 111
+   110 ILE112   1753 RESIDUE           4 B     ILE     2 **** ILE B 112
+   111 ILE113   1772 RESIDUE           4 B     ILE     2 **** ILE B 113
+   112 CYS114   1791 RESIDUE           4 B     CYS     2 **** CYS B 114
+   113 LYS115   1802 RESIDUE           4 B     LYS     2 **** LYS B 115
+   114 ASN116   1824 RESIDUE           4 B     ASN     2 **** ASN B 116
+   115 ILE117   1838 RESIDUE           4 B     ILE     2 **** ILE B 117
+   116 PRO118   1857 RESIDUE           4 B     PRO     2 **** PRO B 118
+   117 ARG119   1871 RESIDUE           4 B     ARG     2 **** ARG B 119
+   118 LEU120   1895 RESIDUE           4 B     LEU     2 **** LEU B 120
+   119 VAL121   1914 RESIDUE           4 B     VAL     2 **** VAL B 121
+   120 SER122   1930 RESIDUE           4 B     SER     2 **** SER B 122
+   121 GLY123   1941 RESIDUE           4 B     GLY     2 **** GLY B 123
+   122 TRP124   1948 RESIDUE           4 B     TRP     2 **** TRP B 124
+   123 VAL125   1972 RESIDUE           4 B     VAL     2 **** VAL B 125
+   124 LYS126   1988 RESIDUE           4 B     LYS     2 **** LYS B 126
+   125 PRO127   2010 RESIDUE           4 B     PRO     2 **** PRO B 127
+   126 ILE128   2024 RESIDUE           4 B     ILE     2 **** ILE B 128
+   127 ILE129   2043 RESIDUE           4 B     ILE     2 **** ILE B 129
+   128 ILE130   2062 RESIDUE           4 B     ILE     2 **** ILE B 130
+   129 GLY131   2081 RESIDUE           4 B     GLY     2 **** GLY B 131
+   130 HIS132   2088 RESIDUE           4 B     HIS     2 **** HIS B 132
+   131 HIS133   2105 RESIDUE           4 B     HIS     2 **** HIS B 133
+   132 ALA134   2122 RESIDUE           4 B     ALA     1 **** ALA B 134
+   133 ARG140   2132 RESIDUE           4 B     ARG     1 ROOT ARG B 140
+   134 ALA141   2156 RESIDUE           4 B     ALA     2 **** ALA B 141
+   135 THR142   2166 RESIDUE           4 B     THR     2 **** THR B 142
+   136 ASP143   2180 RESIDUE           4 B     ASP     2 **** ASP B 143
+   137 PHE144   2192 RESIDUE           4 B     PHE     2 **** PHE B 144
+   138 VAL145   2212 RESIDUE           4 B     VAL     2 **** VAL B 145
+   139 VAL146   2228 RESIDUE           4 B     VAL     2 **** VAL B 146
+   140 PRO147   2244 RESIDUE           4 B     PRO     2 **** PRO B 147
+   141 GLY148   2258 RESIDUE           4 B     GLY     2 **** GLY B 148
+   142 PRO149   2265 RESIDUE           4 B     PRO     2 **** PRO B 149
+   143 GLY150   2279 RESIDUE           4 B     GLY     2 **** GLY B 150
+   144 LYS151   2286 RESIDUE           4 B     LYS     2 **** LYS B 151
+   145 VAL152   2308 RESIDUE           4 B     VAL     2 **** VAL B 152
+   146 GLU153   2324 RESIDUE           4 B     GLU     2 **** GLU B 153
+   147 ILE154   2339 RESIDUE           4 B     ILE     2 **** ILE B 154
+   148 THR155   2358 RESIDUE           4 B     THR     2 **** THR B 155
+   149 TYR156   2372 RESIDUE           4 B     TYR     2 **** TYR B 156
+   150 THR157   2393 RESIDUE           4 B     THR     2 **** THR B 157
+   151 PRO158   2407 RESIDUE           4 B     PRO     2 **** PRO B 158
+   152 SER159   2421 RESIDUE           4 B     SER     2 **** SER B 159
+   153 ASP160   2432 RESIDUE           4 B     ASP     2 **** ASP B 160
+   154 GLY161   2444 RESIDUE           4 B     GLY     2 **** GLY B 161
+   155 THR162   2451 RESIDUE           4 B     THR     2 **** THR B 162
+   156 GLN163   2465 RESIDUE           4 B     GLN     2 **** GLN B 163
+   157 LYS164   2482 RESIDUE           4 B     LYS     2 **** LYS B 164
+   158 VAL165   2504 RESIDUE           4 B     VAL     2 **** VAL B 165
+   159 THR166   2520 RESIDUE           4 B     THR     2 **** THR B 166
+   160 TYR167   2534 RESIDUE           4 B     TYR     2 **** TYR B 167
+   161 LEU168   2555 RESIDUE           4 B     LEU     2 **** LEU B 168
+   162 VAL169   2574 RESIDUE           4 B     VAL     2 **** VAL B 169
+   163 HIS170   2590 RESIDUE           4 B     HIS     2 **** HIS B 170
+   164 ASN171   2607 RESIDUE           4 B     ASN     2 **** ASN B 171
+   165 PHE172   2621 RESIDUE           4 B     PHE     2 **** PHE B 172
+   166 GLU173   2641 RESIDUE           4 B     GLU     2 **** GLU B 173
+   167 GLU174   2656 RESIDUE           4 B     GLU     2 **** GLU B 174
+   168 GLY175   2671 RESIDUE           4 B     GLY     2 **** GLY B 175
+   169 GLY176   2678 RESIDUE           4 B     GLY     2 **** GLY B 176
+   170 GLY177   2685 RESIDUE           4 B     GLY     2 **** GLY B 177
+   171 VAL178   2692 RESIDUE           4 B     VAL     2 **** VAL B 178
+   172 ALA179   2708 RESIDUE           4 B     ALA     2 **** ALA B 179
+   173 MET180   2718 RESIDUE           4 B     MET     2 **** MET B 180
+   174 GLY181   2735 RESIDUE           4 B     GLY     2 **** GLY B 181
+   175 MET182   2742 RESIDUE           4 B     MET     2 **** MET B 182
+   176 TYR183   2759 RESIDUE           4 B     TYR     2 **** TYR B 183
+   177 ASN184   2780 RESIDUE           4 B     ASN     2 **** ASN B 184
+   178 GLN185   2794 RESIDUE           4 B     GLN     2 **** GLN B 185
+   179 ASP186   2811 RESIDUE           4 B     ASP     2 **** ASP B 186
+   180 LYS187   2823 RESIDUE           4 B     LYS     2 **** LYS B 187
+   181 SER188   2845 RESIDUE           4 B     SER     2 **** SER B 188
+   182 ILE189   2856 RESIDUE           4 B     ILE     2 **** ILE B 189
+   183 GLU190   2875 RESIDUE           4 B     GLU     2 **** GLU B 190
+   184 ASP191   2890 RESIDUE           4 B     ASP     2 **** ASP B 191
+   185 PHE192   2902 RESIDUE           4 B     PHE     2 **** PHE B 192
+   186 ALA193   2922 RESIDUE           4 B     ALA     2 **** ALA B 193
+   187 HIS194   2932 RESIDUE           4 B     HIS     2 **** HIS B 194
+   188 SER195   2949 RESIDUE           4 B     SER     2 **** SER B 195
+   189 SER196   2960 RESIDUE           4 B     SER     2 **** SER B 196
+   190 PHE197   2971 RESIDUE           4 B     PHE     2 **** PHE B 197
+   191 GLN198   2991 RESIDUE           4 B     GLN     2 **** GLN B 198
+   192 MET199   3008 RESIDUE           4 B     MET     2 **** MET B 199
+   193 ALA200   3025 RESIDUE           4 B     ALA     2 **** ALA B 200
+   194 LEU201   3035 RESIDUE           4 B     LEU     2 **** LEU B 201
+   195 SER202   3054 RESIDUE           4 B     SER     2 **** SER B 202
+   196 LYS203   3065 RESIDUE           4 B     LYS     2 **** LYS B 203
+   197 GLY204   3087 RESIDUE           4 B     GLY     2 **** GLY B 204
+   198 TRP205   3094 RESIDUE           4 B     TRP     2 **** TRP B 205
+   199 PRO206   3118 RESIDUE           4 B     PRO     2 **** PRO B 206
+   200 LEU207   3132 RESIDUE           4 B     LEU     2 **** LEU B 207
+   201 TYR208   3151 RESIDUE           4 B     TYR     2 **** TYR B 208
+   202 LEU209   3172 RESIDUE           4 B     LEU     2 **** LEU B 209
+   203 SER210   3191 RESIDUE           4 B     SER     2 **** SER B 210
+   204 THR211   3202 RESIDUE           4 B     THR     2 **** THR B 211
+   205 LYS212   3216 RESIDUE           4 B     LYS     2 **** LYS B 212
+   206 ASN213   3238 RESIDUE           4 B     ASN     2 **** ASN B 213
+   207 THR214   3252 RESIDUE           4 B     THR     2 **** THR B 214
+   208 ILE215   3266 RESIDUE           4 B     ILE     2 **** ILE B 215
+   209 LEU216   3285 RESIDUE           4 B     LEU     2 **** LEU B 216
+   210 LYS217   3304 RESIDUE           4 B     LYS     2 **** LYS B 217
+   211 LYS218   3326 RESIDUE           4 B     LYS     2 **** LYS B 218
+   212 TYR219   3348 RESIDUE           4 B     TYR     2 **** TYR B 219
+   213 ASP220   3369 RESIDUE           4 B     ASP     2 **** ASP B 220
+   214 GLY221   3381 RESIDUE           4 B     GLY     2 **** GLY B 221
+   215 ARG222   3388 RESIDUE           4 B     ARG     2 **** ARG B 222
+   216 PHE223   3412 RESIDUE           4 B     PHE     2 **** PHE B 223
+   217 LYS224   3432 RESIDUE           4 B     LYS     2 **** LYS B 224
+   218 ASP225   3454 RESIDUE           4 B     ASP     2 **** ASP B 225
+   219 ILE226   3466 RESIDUE           4 B     ILE     2 **** ILE B 226
+   220 PHE227   3485 RESIDUE           4 B     PHE     2 **** PHE B 227
+   221 GLN228   3505 RESIDUE           4 B     GLN     2 **** GLN B 228
+   222 GLU229   3522 RESIDUE           4 B     GLU     2 **** GLU B 229
+   223 ILE230   3537 RESIDUE           4 B     ILE     2 **** ILE B 230
+   224 TYR231   3556 RESIDUE           4 B     TYR     2 **** TYR B 231
+   225 ASP232   3577 RESIDUE           4 B     ASP     2 **** ASP B 232
+   226 LYS233   3589 RESIDUE           4 B     LYS     2 **** LYS B 233
+   227 GLN234   3611 RESIDUE           4 B     GLN     2 **** GLN B 234
+   228 TYR235   3628 RESIDUE           4 B     TYR     2 **** TYR B 235
+   229 LYS236   3649 RESIDUE           4 B     LYS     2 **** LYS B 236
+   230 SER237   3671 RESIDUE           4 B     SER     2 **** SER B 237
+   231 GLN238   3682 RESIDUE           4 B     GLN     2 **** GLN B 238
+   232 PHE239   3699 RESIDUE           4 B     PHE     2 **** PHE B 239
+   233 GLU240   3719 RESIDUE           4 B     GLU     2 **** GLU B 240
+   234 ALA241   3734 RESIDUE           4 B     ALA     2 **** ALA B 241
+   235 GLN242   3744 RESIDUE           4 B     GLN     2 **** GLN B 242
+   236 LYS243   3761 RESIDUE           4 B     LYS     2 **** LYS B 243
+   237 ILE244   3783 RESIDUE           4 B     ILE     2 **** ILE B 244
+   238 TRP245   3802 RESIDUE           4 B     TRP     2 **** TRP B 245
+   239 TYR246   3826 RESIDUE           4 B     TYR     2 **** TYR B 246
+   240 GLU247   3847 RESIDUE           4 B     GLU     2 **** GLU B 247
+   241 HIS248   3862 RESIDUE           4 B     HIS     2 **** HIS B 248
+   242 ARG249   3879 RESIDUE           4 B     ARG     2 **** ARG B 249
+   243 LEU250   3903 RESIDUE           4 B     LEU     2 **** LEU B 250
+   244 ILE251   3922 RESIDUE           4 B     ILE     2 **** ILE B 251
+   245 ASP252   3941 RESIDUE           4 B     ASP     2 **** ASP B 252
+   246 ASP253   3953 RESIDUE           4 B     ASP     2 **** ASP B 253
+   247 MET254   3965 RESIDUE           4 B     MET     2 **** MET B 254
+   248 VAL255   3982 RESIDUE           4 B     VAL     2 **** VAL B 255
+   249 ALA256   3998 RESIDUE           4 B     ALA     2 **** ALA B 256
+   250 GLN257   4008 RESIDUE           4 B     GLN     2 **** GLN B 257
+   251 ALA258   4025 RESIDUE           4 B     ALA     2 **** ALA B 258
+   252 MET259   4035 RESIDUE           4 B     MET     2 **** MET B 259
+   253 LYS260   4052 RESIDUE           4 B     LYS     2 **** LYS B 260
+   254 SER261   4074 RESIDUE           4 B     SER     2 **** SER B 261
+   255 GLU262   4085 RESIDUE           4 B     GLU     2 **** GLU B 262
+   256 GLY263   4100 RESIDUE           4 B     GLY     2 **** GLY B 263
+   257 GLY264   4107 RESIDUE           4 B     GLY     2 **** GLY B 264
+   258 PHE265   4114 RESIDUE           4 B     PHE     2 **** PHE B 265
+   259 ILE266   4134 RESIDUE           4 B     ILE     2 **** ILE B 266
+   260 TRP267   4153 RESIDUE           4 B     TRP     2 **** TRP B 267
+   261 ALA268   4177 RESIDUE           4 B     ALA     2 **** ALA B 268
+   262 CYS269   4187 RESIDUE           4 B     CYS     2 **** CYS B 269
+   263 LYS270   4198 RESIDUE           4 B     LYS     2 **** LYS B 270
+   264 ASN271   4220 RESIDUE           4 B     ASN     1 **** ASN B 271
+   265 SER287   4234 RESIDUE           4 B     SER     1 ROOT SER B 287
+   266 LEU288   4245 RESIDUE           4 B     LEU     2 **** LEU B 288
+   267 GLY289   4264 RESIDUE           4 B     GLY     2 **** GLY B 289
+   268 MET290   4271 RESIDUE           4 B     MET     2 **** MET B 290
+   269 MET291   4288 RESIDUE           4 B     MET     2 **** MET B 291
+   270 THR292   4305 RESIDUE           4 B     THR     2 **** THR B 292
+   271 SER293   4319 RESIDUE           4 B     SER     2 **** SER B 293
+   272 VAL294   4330 RESIDUE           4 B     VAL     2 **** VAL B 294
+   273 LEU295   4346 RESIDUE           4 B     LEU     2 **** LEU B 295
+   274 VAL296   4365 RESIDUE           4 B     VAL     2 **** VAL B 296
+   275 CYS297   4381 RESIDUE           4 B     CYS     2 **** CYS B 297
+   276 PRO298   4392 RESIDUE           4 B     PRO     2 **** PRO B 298
+   277 ASP299   4406 RESIDUE           4 B     ASP     2 **** ASP B 299
+   278 GLY300   4418 RESIDUE           4 B     GLY     2 **** GLY B 300
+   279 LYS301   4425 RESIDUE           4 B     LYS     2 **** LYS B 301
+   280 THR302   4447 RESIDUE           4 B     THR     2 **** THR B 302
+   281 VAL303   4461 RESIDUE           4 B     VAL     2 **** VAL B 303
+   282 GLU304   4477 RESIDUE           4 B     GLU     2 **** GLU B 304
+   283 ALA305   4492 RESIDUE           4 B     ALA     2 **** ALA B 305
+   284 GLU306   4502 RESIDUE           4 B     GLU     2 **** GLU B 306
+   285 ALA307   4518 RESIDUE           4 B     ALA     2 **** ALA B 307
+   286 ALA308   4528 RESIDUE           4 B     ALA     2 **** ALA B 308
+   287 HIS309   4538 RESIDUE           4 B     HIS     2 **** HIS B 309
+   288 GLY310   4555 RESIDUE           4 B     GLY     2 **** GLY B 310
+   289 THR311   4562 RESIDUE           4 B     THR     2 **** THR B 311
+   290 VAL312   4576 RESIDUE           4 B     VAL     2 **** VAL B 312
+   291 THR313   4592 RESIDUE           4 B     THR     2 **** THR B 313
+   292 ARG314   4606 RESIDUE           4 B     ARG     2 **** ARG B 314
+   293 HIS315   4630 RESIDUE           4 B     HIS     2 **** HIS B 315
+   294 TYR316   4648 RESIDUE           4 B     TYR     2 **** TYR B 316
+   295 ARG317   4669 RESIDUE           4 B     ARG     2 **** ARG B 317
+   296 MET318   4693 RESIDUE           4 B     MET     2 **** MET B 318
+   297 TYR319   4710 RESIDUE           4 B     TYR     2 **** TYR B 319
+   298 GLN320   4731 RESIDUE           4 B     GLN     2 **** GLN B 320
+   299 LYS321   4748 RESIDUE           4 B     LYS     2 **** LYS B 321
+   300 GLY322   4770 RESIDUE           4 B     GLY     2 **** GLY B 322
+   301 GLN323   4777 RESIDUE           4 B     GLN     2 **** GLN B 323
+   302 GLU324   4794 RESIDUE           4 B     GLU     2 **** GLU B 324
+   303 THR325   4809 RESIDUE           4 B     THR     2 **** THR B 325
+   304 SER326   4823 RESIDUE           4 B     SER     2 **** SER B 326
+   305 THR327   4834 RESIDUE           4 B     THR     2 **** THR B 327
+   306 ASN328   4848 RESIDUE           4 B     ASN     2 **** ASN B 328
+   307 PRO329   4862 RESIDUE           4 B     PRO     2 **** PRO B 329
+   308 ILE330   4876 RESIDUE           4 B     ILE     2 **** ILE B 330
+   309 ALA331   4895 RESIDUE           4 B     ALA     2 **** ALA B 331
+   310 SER332   4905 RESIDUE           4 B     SER     2 **** SER B 332
+   311 ILE333   4916 RESIDUE           4 B     ILE     2 **** ILE B 333
+   312 PHE334   4935 RESIDUE           4 B     PHE     2 **** PHE B 334
+   313 ALA335   4955 RESIDUE           4 B     ALA     2 **** ALA B 335
+   314 TRP336   4965 RESIDUE           4 B     TRP     2 **** TRP B 336
+   315 THR337   4989 RESIDUE           4 B     THR     2 **** THR B 337
+   316 ARG338   5003 RESIDUE           4 B     ARG     2 **** ARG B 338
+   317 GLY339   5027 RESIDUE           4 B     GLY     2 **** GLY B 339
+   318 LEU340   5034 RESIDUE           4 B     LEU     2 **** LEU B 340
+   319 ALA341   5053 RESIDUE           4 B     ALA     2 **** ALA B 341
+   320 HIS342   5063 RESIDUE           4 B     HIS     2 **** HIS B 342
+   321 ARG343   5080 RESIDUE           4 B     ARG     2 **** ARG B 343
+   322 ALA344   5104 RESIDUE           4 B     ALA     2 **** ALA B 344
+   323 LYS345   5114 RESIDUE           4 B     LYS     2 **** LYS B 345
+   324 LEU346   5136 RESIDUE           4 B     LEU     2 **** LEU B 346
+   325 ASP347   5155 RESIDUE           4 B     ASP     2 **** ASP B 347
+   326 ASN348   5167 RESIDUE           4 B     ASN     2 **** ASN B 348
+   327 ASN349   5181 RESIDUE           4 B     ASN     2 **** ASN B 349
+   328 LYS350   5195 RESIDUE           4 B     LYS     2 **** LYS B 350
+   329 GLU351   5217 RESIDUE           4 B     GLU     2 **** GLU B 351
+   330 LEU352   5232 RESIDUE           4 B     LEU     2 **** LEU B 352
+   331 ALA353   5251 RESIDUE           4 B     ALA     2 **** ALA B 353
+   332 PHE354   5261 RESIDUE           4 B     PHE     2 **** PHE B 354
+   333 PHE355   5281 RESIDUE           4 B     PHE     2 **** PHE B 355
+   334 ALA356   5301 RESIDUE           4 B     ALA     2 **** ALA B 356
+   335 ASN357   5311 RESIDUE           4 B     ASN     2 **** ASN B 357
+   336 ALA358   5325 RESIDUE           4 B     ALA     2 **** ALA B 358
+   337 LEU359   5335 RESIDUE           4 B     LEU     2 **** LEU B 359
+   338 GLU360   5354 RESIDUE           4 B     GLU     2 **** GLU B 360
+   339 GLU361   5369 RESIDUE           4 B     GLU     2 **** GLU B 361
+   340 VAL362   5384 RESIDUE           4 B     VAL     2 **** VAL B 362
+   341 SER363   5400 RESIDUE           4 B     SER     2 **** SER B 363
+   342 ILE364   5411 RESIDUE           4 B     ILE     2 **** ILE B 364
+   343 GLU365   5430 RESIDUE           4 B     GLU     2 **** GLU B 365
+   344 THR366   5445 RESIDUE           4 B     THR     2 **** THR B 366
+   345 ILE367   5459 RESIDUE           4 B     ILE     2 **** ILE B 367
+   346 GLU368   5478 RESIDUE           4 B     GLU     2 **** GLU B 368
+   347 ALA369   5493 RESIDUE           4 B     ALA     2 **** ALA B 369
+   348 GLY370   5503 RESIDUE           4 B     GLY     2 **** GLY B 370
+   349 PHE371   5510 RESIDUE           4 B     PHE     2 **** PHE B 371
+   350 MET372   5530 RESIDUE           4 B     MET     2 **** MET B 372
+   351 THR373   5547 RESIDUE           4 B     THR     2 **** THR B 373
+   352 LYS374   5561 RESIDUE           4 B     LYS     2 **** LYS B 374
+   353 ASP375   5583 RESIDUE           4 B     ASP     2 **** ASP B 375
+   354 LEU376   5595 RESIDUE           4 B     LEU     2 **** LEU B 376
+   355 ALA377   5614 RESIDUE           4 B     ALA     2 **** ALA B 377
+   356 ALA378   5624 RESIDUE           4 B     ALA     2 **** ALA B 378
+   357 CYS379   5634 RESIDUE           4 B     CYS     2 **** CYS B 379
+   358 ILE380   5645 RESIDUE           4 B     ILE     2 **** ILE B 380
+   359 LYS381   5664 RESIDUE           4 B     LYS     2 **** LYS B 381
+   360 GLY382   5686 RESIDUE           4 B     GLY     2 **** GLY B 382
+   361 LEU383   5693 RESIDUE           4 B     LEU     2 **** LEU B 383
+   362 PRO384   5712 RESIDUE           4 B     PRO     2 **** PRO B 384
+   363 ASN385   5726 RESIDUE           4 B     ASN     2 **** ASN B 385
+   364 VAL386   5740 RESIDUE           4 B     VAL     2 **** VAL B 386
+   365 GLN387   5756 RESIDUE           4 B     GLN     2 **** GLN B 387
+   366 ARG388   5773 RESIDUE           4 B     ARG     2 **** ARG B 388
+   367 SER389   5797 RESIDUE           4 B     SER     2 **** SER B 389
+   368 ASP390   5808 RESIDUE           4 B     ASP     2 **** ASP B 390
+   369 TYR391   5820 RESIDUE           4 B     TYR     2 **** TYR B 391
+   370 LEU392   5841 RESIDUE           4 B     LEU     2 **** LEU B 392
+   371 ASN393   5860 RESIDUE           4 B     ASN     2 **** ASN B 393
+   372 THR394   5874 RESIDUE           4 B     THR     2 **** THR B 394
+   373 PHE395   5888 RESIDUE           4 B     PHE     2 **** PHE B 395
+   374 GLU396   5908 RESIDUE           4 B     GLU     2 **** GLU B 396
+   375 PHE397   5923 RESIDUE           4 B     PHE     2 **** PHE B 397
+   376 MET398   5943 RESIDUE           4 B     MET     2 **** MET B 398
+   377 ASP399   5960 RESIDUE           4 B     ASP     2 **** ASP B 399
+   378 LYS400   5972 RESIDUE           4 B     LYS     2 **** LYS B 400
+   379 LEU401   5994 RESIDUE           4 B     LEU     2 **** LEU B 401
+   380 GLY402   6013 RESIDUE           4 B     GLY     2 **** GLY B 402
+   381 GLU403   6020 RESIDUE           4 B     GLU     2 **** GLU B 403
+   382 ASN404   6035 RESIDUE           4 B     ASN     2 **** ASN B 404
+   383 LEU405   6049 RESIDUE           4 B     LEU     2 **** LEU B 405
+   384 LYS406   6068 RESIDUE           4 B     LYS     2 **** LYS B 406
+   385 ILE407   6090 RESIDUE           4 B     ILE     2 **** ILE B 407
+   386 LYS408   6109 RESIDUE           4 B     LYS     2 **** LYS B 408
+   387 LEU409   6131 RESIDUE           4 B     LEU     2 **** LEU B 409
+   388 ALA410   6150 RESIDUE           4 B     ALA     2 **** ALA B 410
+   389 GLN411   6160 RESIDUE           4 B     GLN     2 **** GLN B 411
+   390 ALA412   6177 RESIDUE           4 B     ALA     1 **** ALA B 412
+@<TRIPOS>SET
+CHAIN_HEAD      STATIC     SUBSTS   AMSOM    **** 
+1 2
+CHAIN_TAIL      STATIC     SUBSTS   AMSOM    **** 
+1 6177
+@<TRIPOS>NORMAL
+@<TRIPOS>RENDERING_ATTRS
+ANTIALIASED_LINES 
+*

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -420,11 +420,11 @@ TORSDOF 5
                 self.assertEqual(outline.rstrip('\r\n'), cofline.rstrip('\r\n'))
                 
     def testReadMOL2(self):
-        '''This is a regression test for a segfault, but could put 
+        '''This is a regression test for a segfault, but could put
         other mol2 test here'''
         mol2file = self.getTestFile('5sun_protein.mol2')
-        output, error = run_exec( "obabel -imol2 %s -osdf" % mol2file)
-        self.assertTrue(len(output) > 0, "Did not generate output")
+        outputerr = run_exec( "obabel -imol2 %s -osdf" % mol2file)
+        self.assertTrue(len(outputerr[0]) > 0, "Did not generate output")
 
 
 if __name__ == "__main__":

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -55,6 +55,9 @@ def run_exec(*args):
                   stdout=PIPE, stderr=PIPE, bufsize=-1)
         stdout, stderr = p.communicate()
 
+    if p.returncode and len(stderr) == 0:
+        #should never exit with an error without an error message
+        raise CalledProcessError(p.returncode,commandline,stdout.decode())
     return stdout.decode(), stderr.decode()
 
 def executable(name):
@@ -112,6 +115,9 @@ class TestOBabel(BaseTest):
         """Ensure that this does not segfault (PR#1818)"""
         self.canFindExecutable("obabel")
         output, error = run_exec("obabel -i")
+        self.assertTrue(len(output) > 1, "Did not generate output")
+        self.assertTrue(len(error) > 1, "Did not generate error message")
+        
 
     def testSMItoInChI(self):
         self.canFindExecutable("obabel")
@@ -412,6 +418,14 @@ TORSDOF 5
             self.assertEqual(len(outdata), len(cofdata))
             for outline, cofline in zip(outdata, cofdata):
                 self.assertEqual(outline.rstrip('\r\n'), cofline.rstrip('\r\n'))
+                
+    def testReadMOL2(self):
+        '''This is a regression test for a segfault, but could put 
+        other mol2 test here'''
+        mol2file = self.getTestFile('5sun_protein.mol2')
+        output, error = run_exec( "obabel -imol2 %s -osdf" % mol2file)
+        self.assertTrue(len(output) > 0, "Did not generate output")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -418,7 +418,7 @@ TORSDOF 5
             self.assertEqual(len(outdata), len(cofdata))
             for outline, cofline in zip(outdata, cofdata):
                 self.assertEqual(outline.rstrip('\r\n'), cofline.rstrip('\r\n'))
-                
+
     def testReadMOL2(self):
         '''This is a regression test for a segfault, but could put
         other mol2 test here'''


### PR DESCRIPTION
Generally speaking, it is better to check if a pointer is NULL _before_
dereferencing it rather than after.