### PR TITLE
Fix tautomer code

### DIFF
--- a/src/tautomer.cpp
+++ b/src/tautomer.cpp
@@ -805,8 +805,6 @@ namespace OpenBabel {
       FOR_BONDS_OF_MOL (bond, mol)
         bondOrders.push_back(bond->GetBondOrder());
 
-      // FIXME: move canLabels inside...
-      std::vector<unsigned int> canonLabels;
       if (canonical) {
         // Set all unassigned bonds to single
         FOR_BONDS_OF_MOL (bond, mol)
@@ -818,6 +816,8 @@ namespace OpenBabel {
         std::vector<unsigned int> symmetryClasses;
         OBGraphSym gs(mol);
         gs.GetSymmetry(symmetryClasses);
+
+        std::vector<unsigned int> canonLabels;
         CanonicalLabels(mol, symmetryClasses, canonLabels);
 
         m_canonAtoms.resize(mol->NumAtoms());

--- a/src/tautomer.cpp
+++ b/src/tautomer.cpp
@@ -1,7 +1,7 @@
 /**********************************************************************
 tautomer.cpp - Tautomer support
 
-  Copyright (C) 2011 by Tim Vandermeersch
+  Copyright (C) 2011,2020 by Tim Vandermeersch
 
 This file is part of the Open Babel project.
 For more information, see <http://openbabel.org/>
@@ -25,8 +25,11 @@ GNU General Public License for more details.
 #include <openbabel/canon.h>
 #include <openbabel/obconversion.h>
 #include <cassert>
+#include <algorithm>
 
 namespace OpenBabel {
+
+
 
 //#define DEBUG 1
 
@@ -35,6 +38,50 @@ namespace OpenBabel {
    */
   struct TautomerImpl
   {
+
+#ifdef DEBUG
+    static std::string indentation(int n)
+    {
+      return std::string(n * 4, ' ');
+    }
+
+    // Use RAII to keep track of enetering and leaving a function
+    class EnterExit
+    {
+      public:
+        EnterExit(const std::string &function, int indent = 0) : m_function(function), m_indent(indent)
+        {
+          std::cout << ::OpenBabel::TautomerImpl::indentation(m_indent) << "Enter " << m_function << "()..." << std::endl;
+        }
+
+        ~EnterExit()
+        {
+          std::cout << ::OpenBabel::TautomerImpl::indentation(m_indent) << "Exit " << m_function << "()..." << std::endl;
+        }
+
+        std::string indentation() const
+        {
+          return ::OpenBabel::TautomerImpl::indentation(m_indent + 1);
+        }
+
+      private:
+        std::string m_function;
+        int m_indent;
+    };
+#endif
+
+    /*   H
+     *   |        nitrogen donor
+     * --N--
+     *
+     * ==N--      nitrogen acceptor
+     *
+     * --O--H     oxygen(*) donor
+     *
+     * ==O        oxygen(*) acceptor
+     *
+     * (*) sulfur, selenium and tellurium behave the same as oxygen
+     */
     enum AtomNumber {
       Carbon = 6,
       Nitrogen = 7,
@@ -55,83 +102,248 @@ namespace OpenBabel {
       Double
     };
 
+    /**
+     * Use RAII in the backtracking algoirthm to reduce bugs.
+     */
+    class AssignDonorRAII
+    {
+      public:
+        AssignDonorRAII(std::vector<Type> &atomTypes, int &hydrogenCounter, OBAtom *atom) : m_atomTypes(atomTypes), m_atom(atom), m_hydrogenCounter(hydrogenCounter)
+        {
+          redo(atom);
+        }
+
+        ~AssignDonorRAII()
+        {
+          undo();
+        }
+
+        void redo(OBAtom *atom)
+        {
+#ifdef DEBUG
+          std::cout << "AssignDonorRAII::redo(" << atom->GetIndex() << ")" << std::endl;
+#endif
+          assert(m_hydrogenCounter >= 1);
+          m_atom = atom;
+          m_atomTypes[m_atom->GetIndex()] = Donor;
+          m_atom->SetImplicitHCount(m_atom->GetImplicitHCount() + 1);
+          --m_hydrogenCounter;
+        }
+
+        void undo()
+        {
+          if (!m_atom)
+            return;
+#ifdef DEBUG
+          std::cout << "AssignDonorRAII::undo(" << m_atom->GetIndex() << ")" << std::endl;
+#endif
+          m_atomTypes[m_atom->GetIndex()] = Unassigned;
+          m_atom->SetImplicitHCount(m_atom->GetImplicitHCount() - 1);
+          ++m_hydrogenCounter;
+          m_atom = 0;
+        }
+
+        /**
+         * For the canonical tautomer we do not use the functor and exit search
+         * with canonical tautomer. Therefore, the action from redo (increment
+         * implicit hydrogen count) should not be undone. In other words, we
+         * release or "leak" the resource.
+         */
+        void release()
+        {
+          m_atom = 0;
+        }
+
+      private:
+        std::vector<Type> &m_atomTypes;
+        OBAtom *m_atom;
+        int &m_hydrogenCounter;
+    };
+
+    /**
+     * Use RAII in the backtracking algoirthm to reduce bugs.
+     */
+    class AssignAcceptorRAII
+    {
+      public:
+        AssignAcceptorRAII(std::vector<Type> &atomTypes, OBAtom *atom) : m_atomTypes(atomTypes), m_atom(atom)
+        {
+          redo(atom);
+        }
+
+        ~AssignAcceptorRAII()
+        {
+          undo();
+        }
+
+        void redo(OBAtom *atom)
+        {
+#ifdef DEBUG
+          std::cout << "AssignAcceptorRAII::redo(" << atom->GetIndex() << ")" << std::endl;
+#endif
+          m_atom = atom;
+          m_atomTypes[m_atom->GetIndex()] = Acceptor;
+        }
+
+        void undo()
+        {
+          if (!m_atom)
+            return;
+#ifdef DEBUG
+          std::cout << "AssignAcceptorRAII::undo(" << m_atom->GetIndex() << ")" << std::endl;
+#endif
+          m_atomTypes[m_atom->GetIndex()] = Unassigned;
+          m_atom = 0;
+        }
+
+      private:
+        std::vector<Type> &m_atomTypes;
+        OBAtom *m_atom;
+    };
+
+    /**
+     * Use RAII in the backtracking algoirthm to reduce bugs.
+     */
+    class PropagationRAII
+    {
+      public:
+        PropagationRAII(std::vector<Type> &atomTypes, std::vector<Type> &bondTypes, int &hydrogenCounter)
+          : m_atomTypes(atomTypes), m_bondTypes(bondTypes), m_hydrogenCounter(hydrogenCounter)
+        {
+        }
+
+        ~PropagationRAII()
+        {
+          // donors
+          for (std::size_t i = 0; i < m_donors.size(); ++i) {
+            m_atomTypes[m_donors[i]->GetIndex()] = Unassigned;
+            m_donors[i]->SetImplicitHCount(m_donors[i]->GetImplicitHCount() - 1);
+          }
+          m_hydrogenCounter += m_donors.size();
+          // acceptors
+          for (std::size_t i = 0; i < m_acceptors.size(); ++i)
+            m_atomTypes[m_acceptors[i]->GetIndex()] = Unassigned;
+          // bonds
+          for (std::size_t i = 0; i < m_bonds.size(); ++i)
+            m_bondTypes[m_bonds[i]->GetIdx()] = Unassigned;
+        }
+
+        void assignDonor(OBAtom *atom)
+        {
+          assert(m_hydrogenCounter >= 1);
+          m_donors.push_back(atom);
+          m_atomTypes[atom->GetIndex()] = Donor;
+          atom->SetImplicitHCount(atom->GetImplicitHCount() + 1);
+          --m_hydrogenCounter;
+        }
+
+        void assignAcceptor(OBAtom *atom)
+        {
+          m_acceptors.push_back(atom);
+          m_atomTypes[atom->GetIndex()] = Acceptor;
+        }
+
+        void assignBond(OBBond *bond, Type type)
+        {
+          m_bonds.push_back(bond);
+          m_bondTypes[bond->GetIdx()] = type;
+        }
+
+        // see AssignDonorRAII::release()
+        void release()
+        {
+          std::copy(m_donors.begin(), m_donors.end(), std::back_inserter(m_acceptors));
+          m_donors.clear();
+        }
+
+      private:
+        std::vector<Type> &m_atomTypes;
+        std::vector<Type> &m_bondTypes;
+        std::vector<OBAtom*> m_acceptors; //!< propagated atoms
+        std::vector<OBAtom*> m_donors; //!< propagated atoms
+        std::vector<OBBond*> m_bonds; //!< propagated bonds
+        int &m_hydrogenCounter; //!< global hydrogen counter
+    };
+
+
     bool m_canonical, m_foundLeafNode;
+    std::vector<OBAtom*> m_canonAtoms;
 
-    // debug
-    void print_atom_types(const std::vector<Type> &types)
+#ifdef DEBUG
+    void PrintAtomTypes(const std::vector<Type> &atomTypes, int indent = 0)
     {
-      std::cout << "Atom Types:" << std::endl;
-      for(std::size_t i = 0; i < types.size(); ++i) {
-        std::cout << "  " << i << ": ";
-
-        switch (types[i]) {
-          case Assigned:
-            std::cout << "Assigned" << std::endl;
-            break;
-          case Single:
-            std::cout << "Single" << std::endl;
-            break;
-          case Double:
-            std::cout << "Double" << std::endl;
-            break;
+      std::cout << indentation(indent);
+      for(std::size_t i = 0; i < atomTypes.size(); ++i) {
+        std::cout << i;
+        switch (atomTypes[i]) {
           case Donor:
-            std::cout << "Donor" << std::endl;
+            std::cout << "D ";
             break;
           case Acceptor:
-            std::cout << "Acceptor" << std::endl;
+            std::cout << "A ";
             break;
           case Hybridized:
-            std::cout << "Hybridized" << std::endl;
+            std::cout << "H ";
             break;
           case Other:
-            std::cout << "Other" << std::endl;
+            std::cout << "O ";
             break;
           case Unassigned:
-            std::cout << "Unassigned" << std::endl;
+            std::cout << "? ";
             break;
+          default:
+            assert(0);
         }
       }
+      std::cout << std::endl;
     }
 
-    // debug
-    void print_bond_types(const std::vector<Type> &types)
+    void PrintBondTypes(OBMol *mol, const std::vector<Type> &bondTypes, int indent = 0)
     {
-      std::cout << "Bond Types:" << std::endl;
-      for(std::size_t i = 0; i < types.size(); ++i) {
-        std::cout << "  " << i << ": ";
+      std::cout << indentation(indent);
+      for(std::size_t i = 0; i < bondTypes.size(); ++i) {
+        OBBond *bond = mol->GetBond(i);
+        std::cout << bond->GetBeginAtomIdx() - 1;
 
-        switch (types[i]) {
+        switch (bondTypes[i]) {
           case Assigned:
-            std::cout << "Assigned" << std::endl;
+            switch (bond->GetBondOrder()) {
+              case 1:
+                std::cout << "-";
+                break;
+              case 2:
+                std::cout << "=";
+                break;
+              case 3:
+                std::cout << "#";
+                break;
+              default:
+                assert(0);
+            }
             break;
           case Single:
-            std::cout << "Single" << std::endl;
+            std::cout << "-";
             break;
           case Double:
-            std::cout << "Double" << std::endl;
-            break;
-          case Donor:
-            std::cout << "Donor" << std::endl;
-            break;
-          case Acceptor:
-            std::cout << "Acceptor" << std::endl;
-            break;
-          case Hybridized:
-            std::cout << "Hybridized" << std::endl;
-            break;
-          case Other:
-            std::cout << "Other" << std::endl;
+            std::cout << "=";
             break;
           case Unassigned:
-            std::cout << "Unassigned" << std::endl;
+            std::cout << "?";
             break;
+          default:
+            assert(0);
         }
+
+        std::cout << bond->GetEndAtomIdx() - 1 << " ";
       }
+      std::cout << std::endl;
     }
+#endif
 
-
-    void AssignAtomTypes(OBMol *mol, std::vector<Type> &types)
+    std::vector<Type> InitializeAtomTypes(OBMol *mol)
     {
+      std::vector<Type> types;
+
       FOR_ATOMS_OF_MOL (atom, mol) {
         switch (atom->GetAtomicNum()) {
           case Carbon:
@@ -142,9 +354,9 @@ namespace OpenBabel {
             break;
 
           case Nitrogen:
-            if (atom->HasDoubleBond())
+            if (atom->HasDoubleBond() && atom->GetTotalValence() == 3)
               types.push_back(Acceptor);
-            else if (atom->GetImplicitHCount())
+            else if (atom->GetImplicitHCount() && atom->GetTotalValence() == 3)
               types.push_back(Donor);
             else
               types.push_back(Other);
@@ -154,111 +366,101 @@ namespace OpenBabel {
           case Sulfur:
           case Selenium:
           case Tellurium:
-            if (atom->HasDoubleBond())
+            if (atom->HasDoubleBond() && atom->GetTotalValence() == 2)
               types.push_back(Acceptor);
-            else if (atom->GetImplicitHCount())
+            else if (atom->GetImplicitHCount() && atom->GetTotalValence() == 2)
               types.push_back(Donor);
             else
               types.push_back(Other);
             break;
 
           default:
-            types.push_back(Other);        
+            types.push_back(Other);
         }
       }
 
       assert( types.size() == mol->NumAtoms() );
+      return types;
     }
 
-    void AssignBondTypes(OBMol *mol, const std::vector<Type> &atomTypes, std::vector<Type> &bondTypes)
+    std::vector<Type> InitializeBondTypes(OBMol *mol, const std::vector<Type> &atomTypes)
     {
+      std::vector<Type> bondTypes;
+
       FOR_BONDS_OF_MOL (bond, mol) {
         assert( bond->GetBeginAtomIdx() <= mol->NumAtoms() );
         assert( bond->GetEndAtomIdx() <= mol->NumAtoms() );
         if (atomTypes[bond->GetBeginAtomIdx()-1] != Other && atomTypes[bond->GetEndAtomIdx()-1] != Other)
           bondTypes.push_back(Unassigned);
-        else 
+        else
           bondTypes.push_back(Assigned);
       }
+
+      return bondTypes;
     }
 
-    struct Level 
+    bool IsPropagationValid(OBMol *mol, const std::vector<Type> &atomTypes, const std::vector<Type> &bondTypes, int depth)
     {
-      OBAtom *assigned;
-      std::vector<OBAtom*> propagatedAtoms;
-      std::vector<OBBond*> propagatedBonds;
-    };
-
-    static void SanityCheckHydrogens(OBAtom *atom)
-    {
-      OBMol* mol = atom->GetParent();
-      unsigned int totH = 0;
-      FOR_ATOMS_OF_MOL(atm, mol) {
-        totH += atm->GetImplicitHCount();
-      }
-      printf("Total no. of hydrogens in molecule: %d\n", totH);
-    }
-
-    static void DecrementImplicitHCount(OBAtom* atom)
-    {
-      atom->SetImplicitHCount(atom->GetImplicitHCount() - 1);
-#ifdef DEBUG
-      printf("Decremented %d (%d) to %d\n", atom->GetIndex(), atom->GetAtomicNum(), atom->GetImplicitHCount());
-      SanityCheckHydrogens(atom);
-#endif
-    }
-
-    static void IncrementImplicitHCount(OBAtom* atom)
-    {
-      atom->SetImplicitHCount(atom->GetImplicitHCount() + 1);
-#ifdef DEBUG
-      printf("Incremented %d (%d) to %d\n", atom->GetIndex(), atom->GetAtomicNum(), atom->GetImplicitHCount());
-      SanityCheckHydrogens(atom);
-#endif
-    }
-
-    void print_assigned(const std::vector<Level> &levels, const std::vector<Type> &atomTypes)
-    {
-      for (std::size_t i = 0; i < levels.size(); ++i)
-        std::cout << levels[i].assigned->GetIndex() << " ";
-      std::cout << std::endl;
-      for (std::size_t i = 0; i < levels.size(); ++i)
-        if (atomTypes[levels[i].assigned->GetIndex()] == Donor)
-          std::cout << "D ";
-        else
-          std::cout << "A ";
-      std::cout << std::endl;
-    }
-
-    void Backtrack(std::vector<Type> &atomTypes, std::vector<Type> &bondTypes, std::vector<Level> &levels, int &numHydrogens)
-    {
-      OBAtom *lastAtom = levels.back().assigned;
-#ifdef DEBUG
-      std::cout << "  Backtrack... " << lastAtom->GetIndex() << std::endl;
-#endif
-      if (atomTypes[lastAtom->GetIndex()] == Donor)
-        DecrementImplicitHCount(lastAtom); // Noel: Why no need for accompanying numHydrogens++?
-      atomTypes[lastAtom->GetIndex()] = Unassigned;
-
-      std::vector<OBAtom*> &propagatedAtoms = levels.back().propagatedAtoms;
-      for (std::size_t i = 0; i < propagatedAtoms.size(); ++i) {
-        if (atomTypes[propagatedAtoms[i]->GetIndex()] == Donor) {
-          DecrementImplicitHCount(propagatedAtoms[i]);
-          numHydrogens++;
+      FOR_ATOMS_OF_MOL (atom, mol) {
+        // Count atom's bond types
+        int numSingleBond = 0, numDoubleBond = 0, numUnassigned = 0;
+        FOR_BONDS_OF_ATOM (bond, &*atom) {
+          if (bondTypes[bond->GetIdx()] == Single)
+            numSingleBond++;
+          if (bondTypes[bond->GetIdx()] == Double)
+            numDoubleBond++;
+          if (bondTypes[bond->GetIdx()] == Unassigned)
+            numUnassigned++;
         }
-        atomTypes[propagatedAtoms[i]->GetIndex()] = Unassigned;
+
+        // A donor can not have any double bonds
+        if (atomTypes[atom->GetIndex()] == Donor)
+          if (numDoubleBond) {
+#ifdef DEBUG
+            std::cout << indentation(depth) << "invalid Donor" << std::endl;
+#endif
+            return false;
+          }
+
+        // An acceptor or hybridized atom should:
+        if (atomTypes[atom->GetIndex()] == Acceptor || atomTypes[atom->GetIndex()] == Hybridized) {
+          // have at least one unassigned or double bond
+          if (!numUnassigned && !numDoubleBond) {
+#ifdef DEBUG
+            std::cout << indentation(depth) << "invalid Acceptor/Hybridized [no unassigned/double bond] for atom " << atom->GetIndex() << std::endl;
+#endif
+            return false;
+          }
+          // have no more than one double bond
+          if (numDoubleBond > 1) {
+#ifdef DEBUG
+            std::cout << indentation(depth) << "invalid Acceptor/Hybridized [multiple double bonds] for atom " << atom->GetIndex() << std::endl;
+#endif
+            return false;
+          }
+        }
       }
 
-      std::vector<OBBond*> &propagatedBonds = levels.back().propagatedBonds;
-      for (std::size_t i = 0; i < propagatedBonds.size(); ++i)
-        bondTypes[propagatedBonds[i]->GetIdx()] = Unassigned;
-
-      levels.pop_back();
+      return true;
     }
 
-    void AssignmentPropagation(OBMol *mol, std::vector<Type> &atomTypes, std::vector<Type> &bondTypes, const std::vector<OBAtom*> &canonAtoms,
-        int &numHydrogens, std::vector<Level> &levels, TautomerFunctor &functor)
+    bool IsLeafNode(const std::vector<Type> &atomTypes) const
     {
+      // Check to see if we are at a leaf node (i.e. no unassigned atoms left)
+      for (std::size_t i = 0; i < atomTypes.size(); ++i)
+        if (atomTypes[i] == Unassigned)
+          return false;
+      return true;
+    }
+
+    void AssignmentPropagation(OBMol *mol, std::vector<Type> &atomTypes, std::vector<Type> &bondTypes,
+        int &numHydrogens, TautomerFunctor &functor, int depth)
+    {
+#ifdef DEBUG
+      EnterExit ee("AssignmentPropagation", depth);
+#endif
+      PropagationRAII propagation(atomTypes, bondTypes, numHydrogens);
+
       bool changed = true;
       while (changed) {
         changed = false;
@@ -268,11 +470,10 @@ namespace OpenBabel {
           if (atomTypes[atom->GetIndex()] == Donor) {
             FOR_BONDS_OF_ATOM (bond, &*atom) {
               if (bondTypes[bond->GetIdx()] == Unassigned) {
-                bondTypes[bond->GetIdx()] = Single;
-                levels.back().propagatedBonds.push_back(&*bond);
+                propagation.assignBond(&*bond, Single);
                 changed = true;
 #ifdef DEBUG
-                std::cout << "    -> Rule 1: Assign " << bond->GetBeginAtomIdx()-1 << "-" << bond->GetEndAtomIdx()-1 << " Single" << std::endl;
+                std::cout << ee.indentation() << "-> Rule 1: Assign " << bond->GetBeginAtomIdx()-1 << "-" << bond->GetEndAtomIdx()-1 << " Single" << std::endl;
 #endif
               }
             }
@@ -280,26 +481,25 @@ namespace OpenBabel {
         }
 
         // Any unassigned atom that has all of its bonds assigned single, must be assigned a donor
-        FOR_ATOMS_OF_MOL (atom, mol) {
-          if (atomTypes[atom->GetIndex()] != Unassigned)
-            continue;
-          bool allBondsSingle = true;
-          FOR_BONDS_OF_ATOM (bond, &*atom) {
-            if (bondTypes[bond->GetIdx()] != Single) {
-              allBondsSingle = false;
-              break;
+        if (numHydrogens) {
+          FOR_ATOMS_OF_MOL (atom, mol) {
+            if (atomTypes[atom->GetIndex()] != Unassigned)
+              continue;
+            bool allBondsSingle = true;
+            FOR_BONDS_OF_ATOM (bond, &*atom) {
+              if (bondTypes[bond->GetIdx()] != Single) {
+                allBondsSingle = false;
+                break;
+              }
             }
-          }
 
-          if (allBondsSingle) {
-            atomTypes[atom->GetIndex()] = Donor; 
-            IncrementImplicitHCount(&*atom);
-            numHydrogens--;
-            levels.back().propagatedAtoms.push_back(&*atom);
-            changed = true;
+            if (allBondsSingle) {
+              propagation.assignDonor(&*atom);
+              changed = true;
 #ifdef DEBUG
-            std::cout << "    -> Rule 2: Assign " << atom->GetIndex() << " Donor" << std::endl;
+              std::cout << ee.indentation() << "-> Rule 2: Assign " << atom->GetIndex() << " Donor" << std::endl;
 #endif
+            }
           }
         }
 
@@ -316,11 +516,10 @@ namespace OpenBabel {
           }
 
           if (hasDoubleBond) {
-            atomTypes[atom->GetIndex()] = Acceptor;
-            levels.back().propagatedAtoms.push_back(&*atom);
+            propagation.assignAcceptor(&*atom);
             changed = true;
 #ifdef DEBUG
-            std::cout << "    -> Rule 3: Assign " << atom->GetIndex() << " Acceptor" << std::endl;
+            std::cout << ee.indentation() << "-> Rule 3: Assign " << atom->GetIndex() << " Acceptor" << std::endl;
 #endif
           }
         }
@@ -340,11 +539,10 @@ namespace OpenBabel {
           if (hasDoubleBond) {
             FOR_BONDS_OF_ATOM (bond, &*atom) {
               if (bondTypes[bond->GetIdx()] == Unassigned) {
-                bondTypes[bond->GetIdx()] = Single;
-                levels.back().propagatedBonds.push_back(&*bond);
+                propagation.assignBond(&*bond, Single);
                 changed = true;
 #ifdef DEBUG
-                std::cout << "    -> Rule 4: Assign " << bond->GetBeginAtomIdx()-1 << "-" << bond->GetEndAtomIdx()-1 << " Single" << std::endl;
+                std::cout << ee.indentation() << "-> Rule 4: Assign " << bond->GetBeginAtomIdx()-1 << "-" << bond->GetEndAtomIdx()-1 << " Single" << std::endl;
 #endif
               }
             }
@@ -364,14 +562,14 @@ namespace OpenBabel {
               numUnassigned++;
           }
 
+
           if (!hasDoubleBond && numUnassigned == 1) {
             FOR_BONDS_OF_ATOM (bond, &*atom) {
               if (bondTypes[bond->GetIdx()] == Unassigned) {
-                bondTypes[bond->GetIdx()] = Double;
-                levels.back().propagatedBonds.push_back(&*bond);
+                propagation.assignBond(&*bond, Double);
                 changed = true;
 #ifdef DEBUG
-                std::cout << "    -> Rule 5: Assign " << bond->GetBeginAtomIdx()-1 << "-" << bond->GetEndAtomIdx()-1 << " Double" << std::endl;
+                std::cout << ee.indentation() << "-> Rule 5: Assign " << bond->GetBeginAtomIdx()-1 << "-" << bond->GetEndAtomIdx()-1 << " Double" << std::endl;
 #endif
               }
             }
@@ -381,191 +579,174 @@ namespace OpenBabel {
       } // while (changed)
 
       // An invalid atom type causes the search to backtrack
-      bool invalid = false;
-      FOR_ATOMS_OF_MOL (atom, mol) {
-          int numSingleBond = 0, numDoubleBond = 0, numUnassigned = 0;
-          FOR_BONDS_OF_ATOM (bond, &*atom) {
-            if (bondTypes[bond->GetIdx()] == Single)
-              numSingleBond++;
-            if (bondTypes[bond->GetIdx()] == Double)
-              numDoubleBond++;
-            if (bondTypes[bond->GetIdx()] == Unassigned)
-              numUnassigned++;
-          }
-
-
-        if (atomTypes[atom->GetIndex()] == Donor)
-          if (numDoubleBond) {
-            invalid = true;
-#ifdef DEBUG
-            std::cout << "invalid Donor" << std::endl;
-#endif
-          }
-
-        if (atomTypes[atom->GetIndex()] == Acceptor || atomTypes[atom->GetIndex()] == Hybridized) {
-          if (!numUnassigned && !numDoubleBond) {
-            invalid = true;
-#ifdef DEBUG
-            std::cout << "invalid Acceptor/Hybridized 1" << std::endl;
-#endif
-          }
-          if (numDoubleBond > 1) {
-            invalid = true;
-#ifdef DEBUG
-            std::cout << "invalid Acceptor/Hybridized 2" << std::endl;
-#endif
-          }
-        }
-      }
+      if (!IsPropagationValid(mol, atomTypes, bondTypes, depth + 1))
+        return;
 
       // Check to see if we are at a leaf node (i.e. no unassigned atoms left)
-      bool leafNode = true;
-      for (std::size_t i = 0; i < atomTypes.size(); ++i)
-        if (atomTypes[i] == Unassigned) {
-          leafNode = false;
-          break;
-        }
+      if (IsLeafNode(atomTypes)) {
 
-      if (leafNode) {
         // Check to make sure there are no unassigned bonds remaining
         // This happens for phenyl rings...
         bool unassignedBonds = false;
         for (std::size_t i = 0; i < bondTypes.size(); ++i)
-        if (bondTypes[i] == Unassigned) {
-          unassignedBonds = true;
-          // Randomly assign a single bond, the other bonds will be propagated
-          bondTypes[i] = Single;
-          break;
-        }
+          if (bondTypes[i] == Unassigned) {
+            unassignedBonds = true;
+            // Randomly assign a single bond, the other bonds will be propagated
+            OBBond *bond = mol->GetBond(i);
+            propagation.assignBond(bond, Single);
+#ifdef DEBUG
+            std::cout << ee.indentation() << "-> Unasigned bonds remaining, assigning " << bond->GetBeginAtomIdx()-1 << "-" << bond->GetEndAtomIdx()-1 << " Single" << std::endl;
+#endif
+            break;
+          }
 
         if (unassignedBonds) {
-          AssignmentPropagation(mol, atomTypes, bondTypes, canonAtoms, numHydrogens, levels, functor);
+          AssignmentPropagation(mol, atomTypes, bondTypes, numHydrogens, functor, depth + 1);
+          if (m_canonical && m_foundLeafNode)
+            propagation.release();
           return;
         }
 
-      }
+        //
+        if (!numHydrogens) {
+          m_foundLeafNode = true;
 
-      if (!invalid) {
-        if (leafNode) {
+#ifdef DEBUG
+          std::cout << ee.indentation() << "  --> LeafNode reached..." << std::endl;
+#endif
+          // Copy information to mol and reset aromaticity
+          FOR_ATOMS_OF_MOL (atom, mol)
+            atom->SetAromatic(false);
+
           FOR_BONDS_OF_MOL (bond, mol) {
             if (bondTypes[bond->GetIdx()] == Single)
               bond->SetBondOrder(1);
             if (bondTypes[bond->GetIdx()] == Double)
               bond->SetBondOrder(2);
+            bond->SetAromatic(false);
           }
-          if (!numHydrogens) {
-#ifdef DEBUG
-            std::cout << "  --> LeafNode reached..." << std::endl;
-#endif
-            m_foundLeafNode = true;
-            
-            mol->BeginModify();
-            mol->EndModify();
-            functor(mol);
-          }
-        } else
-          // Go to the next unassigned atom
-          EnumerateRecursive(mol, atomTypes, bondTypes, canonAtoms, numHydrogens, levels, functor);
-      }
+          mol->SetAromaticPerceived(false);
 
-    }
-
-    void EnumerateRecursive(OBMol *mol, std::vector<Type> &atomTypes, std::vector<Type> &bondTypes, const std::vector<OBAtom*> &canonAtoms,
-        int numHydrogens, std::vector<Level> &levels, TautomerFunctor &functor)
-    {
-      if (m_canonical && m_foundLeafNode)
-        return;
-#ifdef DEBUG
-      std::cout << "EnumerateRecursive" << std::endl;
-#endif
-      // Select next lowest canonical unassigned atom
-      for (std::size_t i = 0; i < canonAtoms.size(); ++i)
-        if (atomTypes[canonAtoms[i]->GetIndex()] == Unassigned) {
-          if (numHydrogens) {
-            // Assign it a hydrogen if there are hydrogens left
-            atomTypes[canonAtoms[i]->GetIndex()] = Donor;
-            IncrementImplicitHCount(canonAtoms[i]);
-            numHydrogens--;
-#ifdef DEBUG
-            std::cout << "  Assigned " << canonAtoms[i]->GetIndex() << " Donor" << std::endl;
-#endif
-          } else {
-            // Assign it acceptor otherwise
-            atomTypes[canonAtoms[i]->GetIndex()] = Acceptor;
-#ifdef DEBUG
-            std::cout << "  Assigned " << canonAtoms[i]->GetIndex() << " Acceptor" << std::endl;
-#endif
-          }
-
-          // store the atom for backtracking later
-          levels.push_back(Level());
-          levels.back().assigned = canonAtoms[i];
-          break;
+          // Call functor with tautomer
+          functor(mol);
         }
 
+      } else { // IsLeafNode
+        // Go to the next unassigned atom
+        EnumerateRecursive(mol, atomTypes, bondTypes,numHydrogens, functor, depth + 1);
+      }
 
+      if (m_canonical && m_foundLeafNode)
+        propagation.release();
+    }
+
+    OBAtom *SelectNextAtom(const std::vector<Type> &atomTypes) const
+    {
+      // Select next lowest canonical unassigned atom
+      for (std::size_t i = 0; i < m_canonAtoms.size(); ++i)
+        if (atomTypes[m_canonAtoms[i]->GetIndex()] == Unassigned)
+          return m_canonAtoms[i];
+      return 0;
+    }
+
+    bool HasTooManyHydrogensLeft(const std::vector<Type> &atomTypes, int numHydrogens) const
+    {
       // Check to ensure there are at least enough unassigned atoms left to assign hydrogens to
-      int numUnassigned = 0;
-      for (std::size_t i = 0; i < canonAtoms.size(); ++i)
-        if (atomTypes[canonAtoms[i]->GetIndex()] == Unassigned)
-          numUnassigned++;
-      if (numUnassigned < numHydrogens) {
-        // Backtrack
+      return std::count(atomTypes.begin(), atomTypes.end(), Unassigned) < numHydrogens;
+    }
+
+    void EnumerateRecursive(OBMol *mol, std::vector<Type> &atomTypes, std::vector<Type> &bondTypes,
+        int numHydrogens, TautomerFunctor &functor, int depth)
+    {
 #ifdef DEBUG
-        std::cout << "  Backtrack..." << std::endl;
+      EnterExit ee("EnumerateRecursive", depth);
+
+      std::cout << ee.indentation() << numHydrogens << " hydrogens left [1]..." << std::endl;
+      PrintAtomTypes(atomTypes, depth+1);
+      PrintBondTypes(mol, bondTypes, depth+1);
 #endif
-        Backtrack(atomTypes, bondTypes, levels, numHydrogens);
+
+      if (m_canonical && m_foundLeafNode) {
+#ifdef DEBUG
+        std::cout << ee.indentation() << "--> Canonical and leaf node found, backtracking..." << std::endl;
+#endif
         return;
       }
- 
 
-      if (levels.size()) {
-        AssignmentPropagation(mol, atomTypes, bondTypes, canonAtoms, numHydrogens, levels, functor);
-        if (m_canonical && m_foundLeafNode)
+      // Select next lowest canonical unassigned atom
+      OBAtom *nextAtom = SelectNextAtom(atomTypes);
+      if (!nextAtom) {
+#ifdef DEBUG
+        std::cout << ee.indentation() << "--> No unassigned atoms left, backtracking..." << std::endl;
+#endif
+        return;
+      }
+
+      // Assign it a hydrogen if there are hydrogens left
+      if (numHydrogens) {
+        AssignDonorRAII donor(atomTypes, numHydrogens, nextAtom);
+#ifdef DEBUG
+        std::cout << ee.indentation() << "-> Assign atom " << nextAtom->GetIndex() << " Donor" << std::endl;
+#endif
+
+        // Propagate...
+        AssignmentPropagation(mol, atomTypes, bondTypes, numHydrogens, functor, depth + 1);
+
+#ifdef DEBUG
+        std::cout << ee.indentation() << numHydrogens << " hydrogens left [1b]..." << std::endl;
+        PrintAtomTypes(atomTypes, depth+1);
+        PrintBondTypes(mol, bondTypes, depth+1);
+#endif
+
+        if (m_canonical && m_foundLeafNode) {
+          donor.release();
           return; // early termination
+        }
+      }
 
 #ifdef DEBUG
-        std::cout << "Change?" << std::endl;
-        print_assigned(levels, atomTypes);
+      std::cout << ee.indentation() << numHydrogens << " hydrogens left [2]..." << std::endl;
+      PrintAtomTypes(atomTypes, depth+1);
+      PrintBondTypes(mol, bondTypes, depth+1);
 #endif
-        
-        OBAtom *lastAtom = levels.back().assigned;
-        if (atomTypes[lastAtom->GetIndex()] == Donor) {
-          // Change atom to acceptor and continue the search
-          atomTypes[lastAtom->GetIndex()] = Acceptor;
-          DecrementImplicitHCount(lastAtom);
-          numHydrogens++;
+
+      // Assign it acceptor after backtracking
+      AssignAcceptorRAII acceptor(atomTypes, nextAtom);
 #ifdef DEBUG
-          std::cout << "  Change " << lastAtom->GetIndex() << " to Acceptor" << std::endl;
+      std::cout << ee.indentation() << "-> Assign atom " << nextAtom->GetIndex() << " Acceptor" << std::endl;
 #endif
 
-          std::vector<OBAtom*> &propagatedAtoms = levels.back().propagatedAtoms;
-          for (std::size_t i = 0; i < propagatedAtoms.size(); ++i) {
-            if (atomTypes[propagatedAtoms[i]->GetIndex()] == Donor) {
-              DecrementImplicitHCount(propagatedAtoms[i]);
-              numHydrogens++;
-            }
-            atomTypes[propagatedAtoms[i]->GetIndex()] = Unassigned;
-          }
-
-          std::vector<OBBond*> &propagatedBonds = levels.back().propagatedBonds;
-          for (std::size_t i = 0; i < propagatedBonds.size(); ++i)
-            bondTypes[propagatedBonds[i]->GetIdx()] = Unassigned;
-
-
-          AssignmentPropagation(mol, atomTypes, bondTypes, canonAtoms, numHydrogens, levels, functor);
-          if (m_canonical && m_foundLeafNode)
-            return; // early termination
-        } 
-
-      // Backtrack
+      // Check to ensure there are at least enough unassigned atoms left to assign hydrogens to
+      if (!HasTooManyHydrogensLeft(atomTypes, numHydrogens)) {
+        // Propagate...
+        AssignmentPropagation(mol, atomTypes, bondTypes, numHydrogens, functor, depth + 1);
+      } else {
 #ifdef DEBUG
-        print_assigned(levels, atomTypes);
+        std::cout << ee.indentation() << "--> Too many hydrogens left, backtracking..." << std::endl;
 #endif
-        Backtrack(atomTypes, bondTypes, levels, numHydrogens);
       }
     }
 
+#ifdef DEBUG
+    static void SanityCheckHydrogens(OBAtom *atom, int indent)
+    {
+      OBMol* mol = atom->GetParent();
+      unsigned int totH = 0;
+      FOR_ATOMS_OF_MOL(atm, mol) {
+        totH += atm->GetImplicitHCount();
+      }
+      printf("%sTotal no. of hydrogens in molecule: %d\n", indentation(indent).c_str(), totH);
+    }
+#endif
+
+    static void DecrementImplicitHCount(OBAtom* atom, int indent)
+    {
+      atom->SetImplicitHCount(atom->GetImplicitHCount() - 1);
+#ifdef DEBUG
+      printf("%sDecremented %d (%d) to %d\n", indentation(indent).c_str(), atom->GetIndex(), atom->GetAtomicNum(), atom->GetImplicitHCount());
+      SanityCheckHydrogens(atom, indent);
+#endif
+    }
 
     void Enumerate(OBMol *mol, TautomerFunctor &functor, bool canonical)
     {
@@ -575,24 +756,32 @@ namespace OpenBabel {
       mol->DeleteHydrogens();
 
       // Assign atom types
-      std::vector<Type> atomTypes;
-      AssignAtomTypes(mol, atomTypes);
+      std::vector<Type> atomTypes = InitializeAtomTypes(mol);
+      // Assign bond types
+      std::vector<Type> bondTypes = InitializeBondTypes(mol, atomTypes);
+
+      // If all bonds are assigned around an atom, mark it as Other (e.g. sulfon oxygen)
+      // This avoids premature backtracking (see IsPropagationValid)
+      FOR_ATOMS_OF_MOL (atom, mol) {
+        int numUnassignedBonds = 0;
+        FOR_BONDS_OF_ATOM (bond, &*atom)
+          if (bondTypes[bond->GetIdx()] == Unassigned)
+            ++numUnassignedBonds;
+        if (!numUnassignedBonds)
+          atomTypes[atom->GetIndex()] = Other;
+      }
+
 #ifdef DEBUG
-      print_atom_types(atomTypes);
+      PrintAtomTypes(atomTypes);
+      PrintBondTypes(mol, bondTypes);
 #endif
 
-      // Assign bond types
-      std::vector<Type> bondTypes;
-      AssignBondTypes(mol, atomTypes, bondTypes);
-#ifdef DEBUG
-      print_bond_types(bondTypes);
-#endif
       // Store original h counts
       std::vector<unsigned int> hcounts;
       FOR_ATOMS_OF_MOL(atom, mol)
         hcounts.push_back(atom->GetImplicitHCount());
 #ifdef DEBUG
-      SanityCheckHydrogens(mol->GetAtom(1));
+      SanityCheckHydrogens(mol->GetAtom(1), 0);
 #endif
 
       // Count the number of hydrogens
@@ -602,13 +791,13 @@ namespace OpenBabel {
         if (atomTypes[i] == Donor) {
           numHydrogens++;
           OBAtom* atm = mol->GetAtom(i + 1); // off-by-one
-          DecrementImplicitHCount(atm);
+          DecrementImplicitHCount(atm, 0);
         }
         if (atomTypes[i] == Donor || atomTypes[i] == Acceptor)
           atomTypes[i] = Unassigned;
       }
 #ifdef DEBUG
-      print_atom_types(atomTypes);
+      PrintAtomTypes(atomTypes);
 #endif
 
       // Store original bond orders
@@ -616,7 +805,7 @@ namespace OpenBabel {
       FOR_BONDS_OF_MOL (bond, mol)
         bondOrders.push_back(bond->GetBondOrder());
 
-      // FIXME
+      // FIXME: move canLabels inside...
       std::vector<unsigned int> canonLabels;
       if (canonical) {
         // Set all unassigned bonds to single
@@ -624,36 +813,59 @@ namespace OpenBabel {
           if (bondTypes[bond->GetIdx()] == Unassigned)
             bond->SetBondOrder(1);
         mol->SetAromaticPerceived(false);
-        
+
+        // Compute canonical labels
         std::vector<unsigned int> symmetryClasses;
         OBGraphSym gs(mol);
         gs.GetSymmetry(symmetryClasses);
         CanonicalLabels(mol, symmetryClasses, canonLabels);
-      } else {
+
+        m_canonAtoms.resize(mol->NumAtoms());
         for (std::size_t i = 0; i < mol->NumAtoms(); ++i)
-          canonLabels.push_back(i+1);
+          m_canonAtoms[canonLabels[i]-1] = mol->GetAtom(i+1);
+      } else {
+        FOR_ATOMS_OF_MOL (atom, mol)
+          m_canonAtoms.push_back(&*atom);
       }
 
-      std::vector<OBAtom*> canonAtoms(mol->NumAtoms());
-      for (std::size_t i = 0; i < mol->NumAtoms(); ++i)
-        canonAtoms[canonLabels[i]-1] = mol->GetAtom(i+1);
-      
-      std::vector<Level> levels;
-      EnumerateRecursive(mol, atomTypes, bondTypes, canonAtoms, numHydrogens, levels, functor);
+      EnumerateRecursive(mol, atomTypes, bondTypes, numHydrogens, functor, 0);
 
-      if (!canonical) {
-        // Restore original bond orders
-        FOR_BONDS_OF_MOL (bond, mol)
+      if (!canonical || !m_foundLeafNode) {
+        // Restore original bond orders & aromaticity
+        FOR_BONDS_OF_MOL (bond, mol) {
           bond->SetBondOrder(bondOrders[bond->GetIdx()]);
-        // Restore original implicit H counts
-        FOR_ATOMS_OF_MOL(atom, mol)
+          bond->SetAromatic(false);
+        }
+        // Restore original implicit H counts & aromaticity
+        FOR_ATOMS_OF_MOL(atom, mol) {
           atom->SetImplicitHCount(hcounts[atom->GetIndex()]);
+          atom->SetAromatic(false);
+        }
       }
 
+      mol->SetAromaticPerceived(false);
+
+      // If no leaf was found, call functor with input molecule
+      if (!canonical && !m_foundLeafNode)
+        functor(mol);
     }
 
-  
+
   }; // TuatomerImpl
+
+  void UniqueTautomerFunctor::operator()(OBMol *mol)
+  {
+    OpenBabel::OBConversion conv;
+    conv.SetOutFormat("can");
+    std::string smiles = conv.WriteString(mol, true);
+
+    // Make sure the found tautomer is unique
+    if (std::find(m_smiles.begin(), m_smiles.end(), smiles) != m_smiles.end())
+      return;
+
+    m_smiles.push_back(smiles);
+    this->operator()(mol, smiles);
+  }
 
   void EnumerateTautomers(OBMol *mol, TautomerFunctor &functor)
   {
@@ -670,8 +882,6 @@ namespace OpenBabel {
     TautomerImpl impl;
     impl.Enumerate(mol, functor, true);
   }
-
-
 
 }
 

--- a/src/tautomer.cpp
+++ b/src/tautomer.cpp
@@ -49,7 +49,7 @@ namespace OpenBabel {
     class EnterExit
     {
       public:
-        EnterExit(const std::string &function, int indent = 0) : m_function(function), m_indent(indent)
+        explicit EnterExit(const std::string &function, int indent = 0) : m_function(function), m_indent(indent)
         {
           std::cout << ::OpenBabel::TautomerImpl::indentation(m_indent) << "Enter " << m_function << "()..." << std::endl;
         }
@@ -735,7 +735,7 @@ namespace OpenBabel {
       FOR_ATOMS_OF_MOL(atm, mol) {
         totH += atm->GetImplicitHCount();
       }
-      printf("%sTotal no. of hydrogens in molecule: %d\n", indentation(indent).c_str(), totH);
+      std::cout << indentation(indent) << "Total no. of hydrogens in molecule: " << totH << std::endl;
     }
 #endif
 
@@ -743,7 +743,7 @@ namespace OpenBabel {
     {
       atom->SetImplicitHCount(atom->GetImplicitHCount() - 1);
 #ifdef DEBUG
-      printf("%sDecremented %d (%d) to %d\n", indentation(indent).c_str(), atom->GetIndex(), atom->GetAtomicNum(), atom->GetImplicitHCount());
+      std::cout << indentation(indent) << "Decremented " << atom->GetIndex() << " (" << atom->GetAtomicNum() << ") to " << atom->GetImplicitHCount() << std::endl;
       SanityCheckHydrogens(atom, indent);
 #endif
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ set (cpptests
     )
 set (alias_parts 1)
 set (automorphism_parts 1 2 3 4 5 6 7 8 9 10)
-set (builder_parts 1 2 3 4 5)
+set (builder_parts 1 2 3 4 5 6)
 set (canonconsistent_parts  1 2 3)
 set (canonfragment_parts 1)
 set (canonstable_parts 1)
@@ -226,7 +226,7 @@ if(NOT MINGW AND NOT CYGWIN)
   include(UsePythonTest)
   if(PYTHON_EXECUTABLE)
     set(pytests
-        babel sym smartssym fastsearch distgeom unique kekule pdbformat roundtrip RInChI)
+        babel sym smartssym fastsearch distgeom unique kekule pdbformat RInChI)
     foreach(pytest ${pytests})
     SET_SOURCE_FILES_PROPERTIES(test${pytest}.py PROPERTIES
       PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}"
@@ -249,7 +249,7 @@ endif(NOT MINGW AND NOT CYGWIN)
 if (PYTHON_BINDINGS)
   include(UsePythonTest)
   set(pybindtests
-      bindings _pybel example cdjsonformat pcjsonformat)
+      bindings _pybel example roundtrip cdjsonformat pcjsonformat)
   foreach(pybindtest ${pybindtests})
     SET_SOURCE_FILES_PROPERTIES(test${pybindtest}.py PROPERTIES
         PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ set (cpptests
     )
 set (alias_parts 1)
 set (automorphism_parts 1 2 3 4 5 6 7 8 9 10)
-set (builder_parts 1 2 3 4 5 6)
+set (builder_parts 1 2 3 4 5)
 set (canonconsistent_parts  1 2 3)
 set (canonfragment_parts 1)
 set (canonstable_parts 1)
@@ -47,7 +47,7 @@ set (spectrophore_parts 1 2 3 4 5)
 set (squareplanar_parts 1 2 3 4 5)
 set (stereo_parts 1 2 3 4 5 6)
 set (stereoperception_parts 1 2 3 4)
-set (tautomer_parts 1 2)
+set (tautomer_parts 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28)
 set (tetrahedral_parts 1 2 3 4 5)
 set (tetranonplanar_parts 1)
 set (tetraplanar_parts 1)
@@ -226,7 +226,7 @@ if(NOT MINGW AND NOT CYGWIN)
   include(UsePythonTest)
   if(PYTHON_EXECUTABLE)
     set(pytests
-        babel sym smartssym fastsearch distgeom unique kekule pdbformat RInChI)
+        babel sym smartssym fastsearch distgeom unique kekule pdbformat roundtrip RInChI)
     foreach(pytest ${pytests})
     SET_SOURCE_FILES_PROPERTIES(test${pytest}.py PROPERTIES
       PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}"
@@ -249,7 +249,7 @@ endif(NOT MINGW AND NOT CYGWIN)
 if (PYTHON_BINDINGS)
   include(UsePythonTest)
   set(pybindtests
-      bindings _pybel example roundtrip cdjsonformat pcjsonformat)
+      bindings _pybel example cdjsonformat pcjsonformat)
   foreach(pybindtest ${pybindtests})
     SET_SOURCE_FILES_PROPERTIES(test${pybindtest}.py PROPERTIES
         PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}"

--- a/test/tautomertest.cpp
+++ b/test/tautomertest.cpp
@@ -6,16 +6,18 @@
 
 using namespace OpenBabel;
 
-
+/**
+ * Check the number of enumerated tautomers.
+ */
 void testEnumerateTautomers(const std::string &smiles, int numTautomers)
 {
-  class Functor : public TautomerFunctor
+  class Functor : public UniqueTautomerFunctor
   {
     public:
       int numTautomers;
 
       Functor() : numTautomers(0) {}
-      void operator()(OBMol*)
+      void operator()(OBMol*, const std::string&)
       {
         numTautomers++;
       }
@@ -32,6 +34,9 @@ void testEnumerateTautomers(const std::string &smiles, int numTautomers)
   OB_COMPARE( functor.numTautomers, numTautomers );
 }
 
+/**
+ * Check that each enumerated tautomer has the same canonical tautomer.
+ */
 void testCanonicalTautomers(const std::string &smiles)
 {
   class Functor : public TautomerFunctor
@@ -43,7 +48,7 @@ void testCanonicalTautomers(const std::string &smiles)
       {
         OBConversion conv;
         conv.SetOutFormat("can");
-        tautomers.push_back(conv.WriteString(mol));
+        tautomers.push_back(conv.WriteString(mol, true));
       }
   };
 
@@ -67,12 +72,32 @@ void testCanonicalTautomers(const std::string &smiles)
     OBMol mol2;
     conv.ReadString(&mol2, tautomers[i]);
     CanonicalTautomer(&mol2);
-    canonicalTautomers.push_back(conv.WriteString(&mol2));
+    canonicalTautomers.push_back(conv.WriteString(&mol2, true));
   }
 
   canonicalTautomers.erase(std::unique(canonicalTautomers.begin(), canonicalTautomers.end()), canonicalTautomers.end());
 
   OB_COMPARE(canonicalTautomers.size(), unsigned(1));
+}
+
+/**
+ * Verify that the canonical tautomer is the same as the one provided.
+ */
+void testVerifyCanonicalTautomer(const std::string &smiles, const std::string &expected)
+{
+  // Read the SMILES string
+  OBMol mol;
+  OBConversion conv;
+  conv.SetInFormat("smi");
+  conv.SetOutFormat("can");
+  conv.ReadString(&mol, smiles);
+
+  // Get the canonical tautomer
+  CanonicalTautomer(&mol);
+
+  std::string experimental = conv.WriteString(&mol, true);
+
+  OB_COMPARE(expected, experimental);
 }
 
 
@@ -96,13 +121,201 @@ int tautomertest(int argc, char* argv[]) {
       }
     }
 
+
     // guanine
     switch (choice) {
     case 1:
+      // guanine
       testEnumerateTautomers("Nc1nc2ncnc2c([nH]1)O", 15);
       break;
     case 2:
+      // each output for guanine, should also have 15 tautomers
+      testEnumerateTautomers("Nc1nc(=O)c2=c([nH]1)[nH]cn2", 15);
+      testEnumerateTautomers("Nc1nc(=O)c2=c([nH]1)nc[nH]2", 15);
+      testEnumerateTautomers("Oc1nc(N)[nH]c2-c1ncn2", 15);
+      testEnumerateTautomers("Nc1[nH]c(=O)c2=c(n1)[nH]cn2", 15);
+      testEnumerateTautomers("Nc1nc(O)c2-c(n1)[nH]cn2", 15);
+      testEnumerateTautomers("Nc1nc2=c(c(=O)[nH]1)[nH]cn2", 15);
+      testEnumerateTautomers("Nc1nc(O)c2-c(n1)nc[nH]2", 15);
+      testEnumerateTautomers("Nc1nc2-c(c([nH]1)O)ncn2", 15);
+      testEnumerateTautomers("N=c1[nH]c(=O)c2=c([nH]1)[nH]cn2", 15);
+      testEnumerateTautomers("N=c1nc(O)c2=c([nH]1)[nH]cn2", 15);
+      testEnumerateTautomers("N=c1[nH]c(=O)c2=c([nH]1)nc[nH]2", 15);
+      testEnumerateTautomers("N=c1nc(O)c2=c([nH]1)nc[nH]2", 15);
+      testEnumerateTautomers("N=c1[nH]c(O)c2-c([nH]1)ncn2", 15);
+      testEnumerateTautomers("N=c1[nH]c(O)c2-c(n1)[nH]cn2", 15);
+      testEnumerateTautomers("N=c1nc2-c(c([nH]1)O)[nH]cn2", 15);
+      break;
+    case 3:
+      // each output for guanine should have the same canonical tautomer
       testCanonicalTautomers("Nc1nc2ncnc2c([nH]1)O");
+      testCanonicalTautomers("Nc1nc(=O)c2=c([nH]1)[nH]cn2");
+      testCanonicalTautomers("Nc1nc(=O)c2=c([nH]1)nc[nH]2");
+      testCanonicalTautomers("Oc1nc(N)[nH]c2-c1ncn2");
+      testCanonicalTautomers("Nc1[nH]c(=O)c2=c(n1)[nH]cn2");
+      testCanonicalTautomers("Nc1nc(O)c2-c(n1)[nH]cn2");
+      testCanonicalTautomers("Nc1nc2=c(c(=O)[nH]1)[nH]cn2");
+      testCanonicalTautomers("Nc1nc(O)c2-c(n1)nc[nH]2");
+      testCanonicalTautomers("Nc1nc2-c(c([nH]1)O)ncn2");
+      testCanonicalTautomers("N=c1[nH]c(=O)c2=c([nH]1)[nH]cn2");
+      testCanonicalTautomers("N=c1nc(O)c2=c([nH]1)[nH]cn2");
+      testCanonicalTautomers("N=c1[nH]c(=O)c2=c([nH]1)nc[nH]2");
+      testCanonicalTautomers("N=c1nc(O)c2=c([nH]1)nc[nH]2");
+      testCanonicalTautomers("N=c1[nH]c(O)c2-c([nH]1)ncn2");
+      testCanonicalTautomers("N=c1[nH]c(O)c2-c(n1)[nH]cn2");
+      testCanonicalTautomers("N=c1nc2-c(c([nH]1)O)[nH]cn2");
+      break;
+    case 4:
+      // benzene
+      testEnumerateTautomers("c1ccccc1", 1);
+      testEnumerateTautomers("C1=CC=CC=C1", 1);
+      testEnumerateTautomers("C=1C=CC=CC1", 1);
+      testVerifyCanonicalTautomer("c1ccccc1", "c1ccccc1");
+      testVerifyCanonicalTautomer("C1=CC=CC=C1", "c1ccccc1");
+      testVerifyCanonicalTautomer("C=1C=CC=CC1", "c1ccccc1");
+      break;
+    case 5:
+      // vinyl ether
+      testEnumerateTautomers("C=COC=C", 1);
+      testVerifyCanonicalTautomer("C=COC=C", "C=COC=C");
+      break;
+    case 6:
+      // 6-mercaptopurine
+      testEnumerateTautomers("C1=NC2=C(N1)C(=S)N=CN2", 8);
+      testCanonicalTautomers("C1=NC2=C(N1)C(=S)N=CN2");
+      testVerifyCanonicalTautomer("C1=NC2=C(N1)C(=S)N=CN2", "Sc1[nH]cnc2-c1ncn2");
+      break;
+    case 7:
+      // allopurinol
+      testEnumerateTautomers("C1=C2C(=NC=NC2=O)NN1", 9);
+      testCanonicalTautomers("C1=C2C(=NC=NC2=O)NN1");
+      testVerifyCanonicalTautomer("C1=C2C(=NC=NC2=O)NN1", "Oc1[nH]cnc2-c1cnn2");
+      break;
+    case 8:
+      // chlorzoxazone
+      testEnumerateTautomers("C1=CC2=C(C=C1Cl)NC(=O)O2", 2);
+      testCanonicalTautomers("C1=CC2=C(C=C1Cl)NC(=O)O2");
+      testVerifyCanonicalTautomer("C1=CC2=C(C=C1Cl)NC(=O)O2", "Clc1ccc2c(c1)[nH]c(=O)o2");
+      break;
+    case 9:
+      // 2-mercaptobenzothiazole
+      testEnumerateTautomers("C1=CC=C2C(=C1)NC(=S)S2", 2);
+      testCanonicalTautomers("C1=CC=C2C(=C1)NC(=S)S2");
+      testVerifyCanonicalTautomer("C1=CC=C2C(=C1)NC(=S)S2", "Sc1nc2c(s1)cccc2");
+      break;
+    case 10:
+      // pemoline
+      testEnumerateTautomers("C1=CC=C(C=C1)C2C(=O)N=C(O2)N", 3);
+      testCanonicalTautomers("C1=CC=C(C=C1)C2C(=O)N=C(O2)N");
+      testVerifyCanonicalTautomer("C1=CC=C(C=C1)C2C(=O)N=C(O2)N", "O=C1N=C(OC1c1ccccc1)N");
+      break;
+    case 11:
+      // amitrole
+      testEnumerateTautomers("C1=NNC(=N1)N", 5);
+      testCanonicalTautomers("C1=NNC(=N1)N");
+      testVerifyCanonicalTautomer("C1=NNC(=N1)N", "Nc1ncn[nH]1");
+      break;
+    case 12:
+      // purpald
+      testEnumerateTautomers("C1(=S)NN=C(N1N)NN", 4);
+      testCanonicalTautomers("C1(=S)NN=C(N1N)NN");
+      testVerifyCanonicalTautomer("C1(=S)NN=C(N1N)NN", "Nn1c(NN)nnc1S");
+      break;
+    case 13:
+      // thiotetronic acid
+      testEnumerateTautomers("O=C1CSC(=O)C1", 1);
+      testCanonicalTautomers("O=C1CSC(=O)C1");
+      testVerifyCanonicalTautomer("O=C1CSC(=O)C1", "O=C1SCC(=O)C1");
+      break;
+    case 14:
+      // pyrithione
+      testEnumerateTautomers("C1=CC(=S)N(C=C1)O", 1);
+      testCanonicalTautomers("C1=CC(=S)N(C=C1)O");
+      testVerifyCanonicalTautomer("C1=CC(=S)N(C=C1)O", "S=c1ccccn1O");
+      break;
+    case 15:
+      // iodothiouracil
+      testEnumerateTautomers("C1=C(C(=O)NC(=S)N1)I", 6);
+      testCanonicalTautomers("C1=C(C(=O)NC(=S)N1)I");
+      testVerifyCanonicalTautomer("C1=C(C(=O)NC(=S)N1)I", "O=c1nc(S)[nH]cc1I");
+      break;
+    case 16:
+      // divicine
+      testEnumerateTautomers("n1c(N)nc(O)c(O)c1(N)", 9);
+      testCanonicalTautomers("n1c(N)nc(O)c(O)c1(N)");
+      testVerifyCanonicalTautomer("n1c(N)nc(O)c(O)c1(N)", "O=c1nc(N)[nH]c(c1O)N");
+      break;
+    case 17:
+      // 2-thiouracil
+      testEnumerateTautomers("C1=CNC(=S)NC1=O", 6);
+      testCanonicalTautomers("C1=CNC(=S)NC1=O");
+      testVerifyCanonicalTautomer("C1=CNC(=S)NC1=O", "Oc1ccnc(=S)[nH]1");
+      break;
+    case 18:
+      // flucytosine
+      testEnumerateTautomers("C1=NC(=O)NC(=C1F)N", 6);
+      testCanonicalTautomers("C1=NC(=O)NC(=C1F)N");
+      testVerifyCanonicalTautomer("C1=NC(=O)NC(=C1F)N", "N=c1nc(O)[nH]cc1F");
+      break;
+    case 19:
+      // citrazinic acid
+      testEnumerateTautomers("C1=C(C=C(NC1=O)O)C(=O)O", 2);
+      testCanonicalTautomers("C1=C(C=C(NC1=O)O)C(=O)O");
+      testVerifyCanonicalTautomer("C1=C(C=C(NC1=O)O)C(=O)O", "OC(=O)c1cc(O)[nH]c(=O)c1");
+      break;
+    case 20:
+      // guanoxabenz
+      testEnumerateTautomers("C1=CC(=C(C(=C1)Cl)C=NN=C(N)NO)Cl", 3);
+      testCanonicalTautomers("C1=CC(=C(C(=C1)Cl)C=NN=C(N)NO)Cl");
+      testVerifyCanonicalTautomer("C1=CC(=C(C(=C1)Cl)C=NN=C(N)NO)Cl", "ONC(=N)NN=Cc1c(Cl)cccc1Cl");
+      break;
+    case 21:
+      // tenoxicam
+      testEnumerateTautomers("CN1/C(=C(\\NC2=CC=CC=N2)/O)/C(=O)C3=C(S1(=O)=O)C=CS3", 5);
+      testCanonicalTautomers("CN1/C(=C(\\NC2=CC=CC=N2)/O)/C(=O)C3=C(S1(=O)=O)C=CS3");
+      testVerifyCanonicalTautomer("CN1/C(=C(\\NC2=CC=CC=N2)/O)/C(=O)C3=C(S1(=O)=O)C=CS3", "OC(=C1C(=O)c2sccc2S(=O)(=O)N1C)Nc1ccccn1");
+      break;
+    case 22:
+      // mitoguazone
+      testEnumerateTautomers("CC(=NN=C(N)N)C=NN=C(N)N", 8);
+      testCanonicalTautomers("CC(=NN=C(N)N)C=NN=C(N)N");
+      testVerifyCanonicalTautomer("CC(=NN=C(N)N)C=NN=C(N)N", "CC(=CN=NC(=N)N)NNC(=N)N");
+      break;
+    case 23:
+      // leucopterin
+      testEnumerateTautomers("C12=C(NC(=O)C(=O)N1)N=C(NC2=O)N", 33);
+      testCanonicalTautomers("C12=C(NC(=O)C(=O)N1)N=C(NC2=O)N");
+      testVerifyCanonicalTautomer("C12=C(NC(=O)C(=O)N1)N=C(NC2=O)N", "Nc1nc(=O)c2c([nH]1)[nH]c(=O)c(=O)[nH]2");
+      break;
+    case 24:
+      // methimazole
+      testEnumerateTautomers("CN1C=CNC1=S", 2);
+      testCanonicalTautomers("CN1C=CNC1=S");
+      testVerifyCanonicalTautomer("CN1C=CNC1=S", "Cn1ccnc1S");
+      break;
+    case 25:
+      // ciclopirox
+      testEnumerateTautomers("CC1=CC(=O)N(C(=C1)C2CCCCC2)O", 1);
+      testCanonicalTautomers("CC1=CC(=O)N(C(=C1)C2CCCCC2)O");
+      testVerifyCanonicalTautomer("CC1=CC(=O)N(C(=C1)C2CCCCC2)O", "Cc1cc(C2CCCCC2)n(c(=O)c1)O");
+      break;
+    case 26:
+      // violuric acid
+      testEnumerateTautomers("C1(=C(NC(=O)NC1=O)O)N=O", 10);
+      testCanonicalTautomers("C1(=C(NC(=O)NC1=O)O)N=O");
+      testVerifyCanonicalTautomer("C1(=C(NC(=O)NC1=O)O)N=O", "ON=C1C(=NC(=O)N=C1O)O");
+      break;
+    case 27:
+      // methisazone
+      testEnumerateTautomers("CN1C2=CC=CC=C2C(=NNC(=S)N)C1=O", 5);
+      testCanonicalTautomers("CN1C2=CC=CC=C2C(=NNC(=S)N)C1=O");
+      testVerifyCanonicalTautomer("CN1C2=CC=CC=C2C(=NNC(=S)N)C1=O", "NC(=S)NN=C1c2ccccc2N(C1=O)C");
+      break;
+    case 28:
+      // antralin
+      testEnumerateTautomers("Oc1cccc2c1C(=O)c1c(C2)cccc1O", 2);
+      testCanonicalTautomers("Oc1cccc2c1C(=O)c1c(C2)cccc1O");
+      testVerifyCanonicalTautomer("Oc1cccc2c1C(=O)c1c(C2)cccc1O", "O=C1C=CC=C2C1=C(O)c1c(C2)cccc1O");
       break;
     default:
       std::cout << "Test number " << choice << " does not exist!\n";

--- a/tools/obtautomer.cpp
+++ b/tools/obtautomer.cpp
@@ -2,14 +2,14 @@
 obtautomer - Enumerate tautomer smiles and canonical tautomer smiles
 
 Copyright (C) 2011 Tim Vandermeersch
- 
+
 This file is part of the Open Babel project.
 For more information, see <http://openbabel.org/>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation version 2 of the License.
- 
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -31,21 +31,12 @@ using namespace std;
 /**
  * TautomerFunctor to print out smiles for each found tautomer.
  */
-class Functor : public OpenBabel::TautomerFunctor
+class Functor : public OpenBabel::UniqueTautomerFunctor
 {
   public:
-    bool foundTautomers;
-
-    Functor() : foundTautomers(false) 
+    void operator()(OpenBabel::OBMol *mol, const std::string &smiles)
     {
-    }
-  
-    void operator()(OpenBabel::OBMol *mol)
-    {
-      foundTautomers = true;
-      OpenBabel::OBConversion conv;
-      conv.SetOutFormat("can");
-      std::cout << conv.WriteString(mol);
+      std::cout << smiles << std::endl;
     }
 };
 
@@ -70,12 +61,12 @@ int main(int argc,char **argv)
   // Find Input filetype
   OpenBabel::OBConversion conv;
   OpenBabel::OBFormat *format = conv.FormatFromExt(FileIn);
-    
+
   if (!format || !conv.SetInFormat(format)) {
     cerr << program_name << ": cannot read input format!" << endl;
     exit (-1);
   }
-    
+
   if (!conv.SetOutFormat("can")) {
     cerr << program_name << ": cannot find output format!" << endl;
     exit (-1);
@@ -89,7 +80,7 @@ int main(int argc,char **argv)
     cerr << program_name << ": cannot read input file!" << endl;
     exit (-1);
   }
-  
+
   OpenBabel::OBMol mol;
 
 
@@ -105,13 +96,10 @@ int main(int argc,char **argv)
       } else {
         Functor f;
         EnumerateTautomers(&mol, f);
-
-        if (!f.foundTautomers)
-          std::cout << conv.WriteString(&mol);
       }
-      
+
   } // end for loop
-  
+
   return(0);
 }
 


### PR DESCRIPTION
Various improvements and fixes for the tautomer code.

- Fix issue #227 
- Fix various backtracking issues (rewritten using RAII)
- Perceive aromaticity for each tautomer (fixes failing antralin test)
- Mark atoms that have initially have all bonds assigned as Other (fixes failing tenoxicam test which contains sulfon group)
- Add support for enumerating unique tautomers only (duplicates may be present due to symmetry)
- Add test cases from slides, all are working now (see https://www.daylight.com/meetings/emug99/Delany/taut_html/sld030.htm)

TODO:
- More testing with special functional groups (e.g., N-oxide, conjugated carbanion/carbocation, conjugated nitrogen)
- Add support for keto/enol tautomerism?