### PR TITLE
Add a build for bindings (eventually will generate source tar)

### DIFF
--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -17,7 +17,7 @@ jobs:
             name: "Linux SWIG All Bindings",
             os: ubuntu-latest,
             cc: "gcc", cxx: "g++",
-            cmake_flags: "-DALL_BINDINGS=ON -DRUN_SWIG=ON"
+            cmake_flags: "-DPYTHON_BINDINGS=ON -DRUBY_BINDINGS=ON -DPHP_BINDINGS=ON -DPERL_BINDINGS=ON -DJAVA_BINDINGS=ON -DCSHARP_BINDINGS=ON -DRUN_SWIG=ON"
           }
 
     steps:

--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install Dependencies (Linux)
       if: runner.os == 'Linux'
-      run: sudo apt-get -qq install ninja-build swig libeigen3-dev libboost-all-dev
+      run: sudo apt-get -qq install ninja-build swig libeigen3-dev libboost-all-dev r-base-core r-base-dev mono-devel
 
     - name: Configure
       run: |

--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -1,0 +1,40 @@
+name: CMake Build Matrix
+
+on: [push, pull_request]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Linux SWIG All Bindings",
+            os: ubuntu-latest,
+            cc: "gcc", cxx: "g++",
+            cmake_flags: "-DALL_BINDINGS=ON -DRUN_SWIG=ON"
+          }
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get -qq install ninja-build swig libeigen3-dev libboost-all-dev
+
+    - name: Configure
+      run: |
+        mkdir "${{ runner.workspace }}/build"
+        cd "${{ runner.workspace }}/build"
+        cmake $GITHUB_WORKSPACE -GNinja -DCMAKE_C_COMPILER=${{matrix.config.cc}} -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} ${{matrix.config.cmake_flags}}
+      shell: bash
+
+    - name: Build
+      run: CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake --build .
+      shell: bash
+      working-directory: ${{ runner.workspace }}/build

--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -17,7 +17,7 @@ jobs:
             name: "Linux SWIG All Bindings",
             os: ubuntu-latest,
             cc: "gcc", cxx: "g++",
-            cmake_flags: "-DPYTHON_BINDINGS=ON -DRUBY_BINDINGS=ON -DPHP_BINDINGS=ON -DPERL_BINDINGS=ON -DJAVA_BINDINGS=ON -DCSHARP_BINDINGS=ON -DRUN_SWIG=ON"
+            cmake_flags: "-DPYTHON_BINDINGS=ON -DPHP_BINDINGS=ON -DPERL_BINDINGS=ON -DJAVA_BINDINGS=ON -DCSHARP_BINDINGS=ON -DRUN_SWIG=ON"
           }
 
     steps:

--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -17,7 +17,7 @@ jobs:
             name: "Linux SWIG All Bindings",
             os: ubuntu-latest,
             cc: "gcc", cxx: "g++",
-            cmake_flags: "-DPYTHON_BINDINGS=ON -DPHP_BINDINGS=ON -DPERL_BINDINGS=ON -DJAVA_BINDINGS=ON -DCSHARP_BINDINGS=ON -DRUN_SWIG=ON"
+            cmake_flags: "-DPYTHON_BINDINGS=ON -DPERL_BINDINGS=ON -DJAVA_BINDINGS=ON -DCSHARP_BINDINGS=ON -DRUN_SWIG=ON"
           }
 
     steps:


### PR DESCRIPTION
This will be a separate build script because eventually this
will generate the *source* with all bindings updated, not a binary
(e.g. to automate releases)