### PR TITLE
Workaround for SWIG 4.0.1 Java source code problem

### DIFF
--- a/scripts/openbabel-java.i
+++ b/scripts/openbabel-java.i
@@ -93,7 +93,6 @@ namespace std {
 %feature("ignore") vector< vector<T> >::push_back;
 %feature("ignore") vector< vector<T> >::rbegin;
 %feature("ignore") vector< vector<T> >::rend;
-%feature("ignore") vector< vector<T> >::reserve;
 %feature("ignore") vector< vector<T> >::resize;
 %feature("ignore") vector< vector<T> >::swap;
 %template(vectorv ## name) vector< vector<T> >;
@@ -117,7 +116,6 @@ namespace std {
 %feature("ignore") vector<T>::push_back;
 %feature("ignore") vector<T>::rbegin;
 %feature("ignore") vector<T>::rend;
-%feature("ignore") vector<T>::reserve;
 %feature("ignore") vector<T>::resize;
 %feature("ignore") vector<T>::swap;
 %template(vector ## vectorname) vector<T>;
@@ -141,7 +139,6 @@ namespace std {
 %feature("ignore") vector< pair<T1, T2> >::push_back;
 %feature("ignore") vector< pair<T1, T2> >::rbegin;
 %feature("ignore") vector< pair<T1, T2> >::rend;
-%feature("ignore") vector< pair<T1, T2> >::reserve;
 %feature("ignore") vector< pair<T1, T2> >::resize;
 %feature("ignore") vector< pair<T1, T2> >::swap;
 %template(vpair ## vectorname) vector< pair<T1, T2> >;


### PR DESCRIPTION
Workaround a problem in SWIG 4.0.1 (at least) where the generated Java source relies on reserve being present. See https://github.com/swig/swig/issues/1787.