### PR TITLE
Fix build on illumos

### DIFF
--- a/test/addhtest.cpp
+++ b/test/addhtest.cpp
@@ -34,6 +34,10 @@ GNU General Public License for more details.
 #include <iostream>
 #include <fstream>
 
+#if defined(__sun)
+#include <alloca.h>
+#endif
+
 using namespace std;
 using namespace OpenBabel;
 


### PR DESCRIPTION
This include is required for `alloca()`.

Reference: <https://illumos.org/man/3c/alloca>