### PR TITLE
Rename EXTERN to OB_EXTERN to prevent clashes in other headers

### DIFF
--- a/include/openbabel/atom.h
+++ b/include/openbabel/atom.h
@@ -23,8 +23,8 @@ GNU General Public License for more details.
 
 #include <openbabel/babelconfig.h>
 
-#ifndef EXTERN
-#  define EXTERN extern
+#ifndef OB_EXTERN
+#  define OB_EXTERN extern
 #endif
 
 #include <vector>

--- a/include/openbabel/bond.h
+++ b/include/openbabel/bond.h
@@ -24,8 +24,8 @@ GNU General Public License for more details.
 
 #include <openbabel/babelconfig.h>
 
-#ifndef EXTERN
-#  define EXTERN extern
+#ifndef OB_EXTERN
+#  define OB_EXTERN extern
 #endif
 
 #include <openbabel/base.h>

--- a/include/openbabel/chains.h
+++ b/include/openbabel/chains.h
@@ -283,7 +283,7 @@ namespace OpenBabel
     };
 
     //! Global OBChainsParser for detecting macromolecular chains and residues
-    EXTERN  OBChainsParser   chainsparser;
+    OB_EXTERN  OBChainsParser   chainsparser;
 
 }
 #endif // OB_CHAINS_H

--- a/include/openbabel/data.h
+++ b/include/openbabel/data.h
@@ -90,7 +90,7 @@ namespace OpenBabel
 
   public:
     /** \brief Initialize Heat of Formation for atom
-        
+
      @param element The element string
      @param charge  The formal charge of the particle (if an ion)
      @param method  The method used for determining the value
@@ -159,7 +159,7 @@ namespace OpenBabel
       //! \return the number of elements in the Atomic Heat Of Formation table
       size_t GetSize() { return _atomhof.size(); }
 
-      /** \brief Read one line in the file and parse it 
+      /** \brief Read one line in the file and parse it
           @param Unnamed the line to be parsed
       */
       void	ParseLine(const char*);
@@ -175,7 +175,7 @@ namespace OpenBabel
        is known at temperature T. If 1 the values
        including all corrections are returned in the dhof variable.
       */
-      int	GetHeatOfFormation(std::string elem, 
+      int	GetHeatOfFormation(std::string elem,
                                int charge,
                                std::string method,
                                double T, double *dhof0,
@@ -222,7 +222,7 @@ namespace OpenBabel
 
   //! Global OBTypeTable for translating between different atom types
   //! (e.g., Sybyl <-> MM2)
-  EXTERN  OBTypeTable      ttab;
+  OB_EXTERN  OBTypeTable      ttab;
 
   /** \class OBResidueData data.h <openbabel/data.h>
       \brief Table of common biomolecule residues (for PDB or other files).
@@ -267,11 +267,11 @@ namespace OpenBabel
     };
 
   //! Global OBResidueData biomolecule residue database
-  EXTERN  OBResidueData    resdat;
+  OB_EXTERN  OBResidueData    resdat;
 
 
 } // end namespace OpenBabel
-  
+
 #endif //DATA_H
 
 //! \file data.h

--- a/include/openbabel/graphsym.h
+++ b/include/openbabel/graphsym.h
@@ -25,8 +25,8 @@ GNU General Public License for more details.
 #include <openbabel/stereo/stereo.h>
 #include <vector>
 
-#ifndef EXTERN
-#  define EXTERN extern
+#ifndef OB_EXTERN
+#  define OB_EXTERN extern
 #endif
 
 namespace OpenBabel {
@@ -80,5 +80,3 @@ namespace OpenBabel {
 
 //! \file graphsym.h
 //! \brief Handle and perceive graph symmtery for canonical numbering
-
-

--- a/include/openbabel/internalcoord.h
+++ b/include/openbabel/internalcoord.h
@@ -24,8 +24,8 @@ GNU General Public License for more details.
 #include <openbabel/babelconfig.h>
 #include <stddef.h>
 
-#ifndef EXTERN
-#  define EXTERN extern
+#ifndef OB_EXTERN
+#  define OB_EXTERN extern
 #endif
 
 namespace OpenBabel

--- a/include/openbabel/mol.h
+++ b/include/openbabel/mol.h
@@ -24,13 +24,13 @@ GNU General Public License for more details.
 
 #include <openbabel/babelconfig.h>
 
-#ifndef EXTERN
-#  define EXTERN extern
+#ifndef OB_EXTERN
+#  define OB_EXTERN extern
 #endif
 #ifndef THREAD_LOCAL
 #ifdef SWIG
 # define THREAD_LOCAL
-# elif (__cplusplus >= 201103L) 
+# elif (__cplusplus >= 201103L)
 //this is required for correct multi-threading
 #  define THREAD_LOCAL thread_local
 # else

--- a/include/openbabel/plugin.h
+++ b/include/openbabel/plugin.h
@@ -371,7 +371,7 @@ public:
 
 #define OB_STATIC_PLUGIN(className,instanceName) \
   class className; \
-  OBAPI EXTERN className instanceName;
+  OBAPI OB_EXTERN className instanceName;
 
   // formats
   OB_STATIC_PLUGIN(ABINITFormat, theABINITFormat)

--- a/include/openbabel/residue.h
+++ b/include/openbabel/residue.h
@@ -27,8 +27,8 @@ obtained in part or whole from RasMol2 by Roger Sayle.
 
 #include <openbabel/babelconfig.h>
 
-#ifndef EXTERN
-#  define EXTERN extern
+#ifndef OB_EXTERN
+#  define OB_EXTERN extern
 #endif
 
 #include <vector>

--- a/include/openbabel/typer.h
+++ b/include/openbabel/typer.h
@@ -62,12 +62,12 @@ public:
 #ifndef THREAD_LOCAL
 # define THREAD_LOCAL
 #endif
-#ifndef EXTERN
-#error EXTERN
+#ifndef OB_EXTERN
+#error OB_EXTERN
 #endif
 //! Global OBAtomTyper for marking internal valence, hybridization,
 //!  and atom types (for internal and external use)
-THREAD_LOCAL EXTERN OBAtomTyper      atomtyper;
+THREAD_LOCAL OB_EXTERN OBAtomTyper      atomtyper;
 
 // class introduction in typer.cpp
 class OBAPI OBAromaticTyper
@@ -81,7 +81,7 @@ public:
 };
 
 //! Global OBAromaticTyper for detecting aromatic atoms and bonds
-THREAD_LOCAL EXTERN OBAromaticTyper  aromtyper;
+THREAD_LOCAL OB_EXTERN OBAromaticTyper  aromtyper;
 
 // class introduction in typer.cpp
 class OBAPI OBRingTyper : public OBGlobalDataBase

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -45,7 +45,7 @@ using namespace std;
 
 namespace OpenBabel
 {
-  EXTERN OBChainsParser chainsparser;
+  OB_EXTERN OBChainsParser chainsparser;
   /** \class OBAtom atom.h <openbabel/atom.h>
       \brief Atom class
 
@@ -107,8 +107,8 @@ namespace OpenBabel
   extern THREAD_LOCAL OBAromaticTyper  aromtyper;
   extern THREAD_LOCAL OBAtomTyper      atomtyper;
   extern THREAD_LOCAL OBPhModel        phmodel;
-  EXTERN OBTypeTable      ttab;
-  
+  OB_EXTERN OBTypeTable      ttab;
+
   //
   // OBAtom member functions
   //
@@ -677,7 +677,7 @@ namespace OpenBabel
 
   // Helper function for IsHBondAcceptor
   static bool IsSulfoneOxygen(OBAtom* atm)
-  // Stefano Forli 
+  // Stefano Forli
   //atom is connected to a sulfur that has a total
   //of 2 attached free oxygens, and it's not a sulfonamide
   //e.g. C-SO2-C
@@ -978,7 +978,7 @@ namespace OpenBabel
   unsigned int OBAtom::GetExplicitValence() const
   {
     unsigned int bosum = 0;
-    
+
     OBBondIterator i;
     for (OBBond *bond = ((OBAtom*)this)->BeginBond(i); bond; bond = ((OBAtom*)this)->NextBond(i))
       bosum += bond->GetBondOrder();
@@ -1745,21 +1745,21 @@ namespace OpenBabel
   }
 
   // new function, Stefano Forli
-  // Incorporate ideas and data from Kubyni and others. 
+  // Incorporate ideas and data from Kubyni and others.
   // [1] Kubinyi, H. "Changing paradigms in drug discovery.
   //    "SPECIAL PUBLICATION-ROYAL SOCIETY OF CHEMISTRY 304.1 (2006): 219-232.
   //
-  // [2] Kingsbury, Charles A. "Why are the Nitro and Sulfone 
+  // [2] Kingsbury, Charles A. "Why are the Nitro and Sulfone
   //     Groups Poor Hydrogen Bonders?." (2015).
   //
-  // [3] Per Restorp, Orion B. Berryman, Aaron C. Sather, Dariush Ajami 
+  // [3] Per Restorp, Orion B. Berryman, Aaron C. Sather, Dariush Ajami
   //     and Julius Rebek Jr., Chem. Commun., 2009, 5692 DOI: 10.1039/b914171e
   //
   // [4] Dunitz, Taylor. "Organic fluorine hardly ever accepts
   //     hydrogen bonds." Chemistry-A European Journal 3.1 (1997): 83-92.
   //
   // This function has a finer grain than the original
-  // implementation, checking also the neighbor atoms. 
+  // implementation, checking also the neighbor atoms.
   // Accordingly to these rules, the function will return:
   //
   //    aliph-O-aliph ether   -> true   [1]
@@ -1775,7 +1775,7 @@ namespace OpenBabel
   //    aromatic O            -> false  [1]
   //    O-nitro               -> false  [2]
   //    organic F (R-F)       -> false  [4]
-  //    
+  //
   bool OBAtom::IsHbondAcceptor() {
       if (_ele == 8) {
         // oxygen; this should likely be a separate function
@@ -1794,20 +1794,20 @@ namespace OpenBabel
           return(false);
           }
         FOR_NBORS_OF_ATOM(nbr, this){
-          if (nbr->IsAromatic()){ 
+          if (nbr->IsAromatic()){
             aroCount += 1;
             if (aroCount == 2){ // aromatic ether (aro-O-aro) (NO)
-              return(false); 
+              return(false);
             }
           }
-          else { 
+          else {
             if (nbr->GetAtomicNum() == OBElements::Hydrogen) { // hydroxyl (YES)
-              return(true); 
+              return(true);
             }
             else {
               bond = nbr->GetBond(this);
-              if ( (bond->IsEster()) && (!(IsCarboxylOxygen()))) 
-                 return(false); 
+              if ( (bond->IsEster()) && (!(IsCarboxylOxygen())))
+                 return(false);
             }
           }
         }

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -33,8 +33,8 @@
 
 /* Used to export symbols for DLL / shared library builds */
 #if defined(MAKE_OBDLL) // e.g. in src/main.cpp
- #ifndef EXTERN
-  #define EXTERN   OB_EXPORT extern
+ #ifndef OB_EXTERN
+  #define OB_EXTERN   OB_EXPORT extern
  #endif
  #ifndef OBAPI
   #define OBAPI    OB_EXPORT
@@ -63,8 +63,8 @@
 
 #else   // defined(MAKE_OBDLL)
 
- #ifndef EXTERN
-  #define EXTERN   OB_IMPORT extern
+ #ifndef OB_EXTERN
+  #define OB_EXTERN   OB_IMPORT extern
  #endif
  #ifndef OBAPI
   #define OBAPI    OB_IMPORT
@@ -89,7 +89,7 @@
   #ifndef OBDEPICT
  #define OBDEPICT  OB_IMPORT
  #endif
- 
+
  #endif
 
 #endif
@@ -192,4 +192,3 @@
     #define TIME_WITH_SYS_TIME 0
   #endif
 #endif
-


### PR DESCRIPTION
Discovered with Ruby 2.5 SWIG bindings