### PR TITLE
Initialize allocated memory to zero.

### DIFF
--- a/include/openbabel/typer.h
+++ b/include/openbabel/typer.h
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 #define OB_TYPER_H
 
 #include <openbabel/babelconfig.h>
-#include <openbabel/mol.h>
+#include <openbabel/mol.h>  //needed for THREAD_LOCAL definition
 
 #include <vector>
 #include <string>

--- a/src/formats/MCDLformat.cpp
+++ b/src/formats/MCDLformat.cpp
@@ -237,7 +237,7 @@ private:
     int *  nsum[MAXBONDS];
     bool lflag[MAXFRAGS];
     char strg[MAXFRAGS+1];
-	char * strngs[MAXFRAGS+1];
+    char * strngs[MAXFRAGS+1];
     char tstr[MAXFRAGS+1];
     int  numdups, dupfrag, jump;
     bool jflag;
@@ -245,8 +245,8 @@ private:
     int  mx[MAXFRAGS];
 
 	//stack overflow message-move data from stack to heap
-	for (i=0; i<=MAXFRAGS; i++) strngs[i]=(char *)malloc(MAXFRAGS);
-    for (i=0; i<MAXBONDS; i++)  nsum[i]=(int *) malloc(MAXFRAGS);
+	for (i=0; i<=MAXFRAGS; i++) strngs[i]=(char *)calloc(MAXFRAGS,sizeof(char));
+    for (i=0; i<MAXBONDS; i++)  nsum[i]=(int *) calloc(MAXFRAGS,sizeof(int));
 
     // depth = recursion level
     if (depth > 10)

--- a/src/formats/xtcformat.cpp
+++ b/src/formats/xtcformat.cpp
@@ -303,7 +303,7 @@ namespace OpenBabel
      * XDR staructure)
      */
     if (xdrs == NULL) {
-      xdridptr[xdrid] = (XDR *) malloc(sizeof(XDR));
+      xdridptr[xdrid] = (XDR *) calloc(1,sizeof(XDR));
       xdrstdio_create(xdridptr[xdrid], xdrfiles[xdrid], lmode);
     } else {
       xdridptr[xdrid] = xdrs;
@@ -659,13 +659,13 @@ namespace OpenBabel
 
       xdr_float(xdrs, precision);
       if (ip == NULL) {
-        ip = (int *)malloc(size3 * sizeof(*ip));
+        ip = (int *)calloc(size3, sizeof(*ip));
         if (ip == NULL) {
           fprintf(stderr,"malloc failed\n");
           return 0;
         }
         bufsize = static_cast<int> (size3 * 1.2);
-        buf = (int *)malloc(bufsize * sizeof(*buf));
+        buf = (int *)calloc(bufsize, sizeof(*buf));
         if (buf == NULL) {
           fprintf(stderr,"malloc failed\n");
           return 0;
@@ -903,13 +903,13 @@ namespace OpenBabel
       }
       xdr_float(xdrs, precision);
       if (ip == NULL) {
-        ip = (int *)malloc(size3 * sizeof(*ip));
+        ip = (int *)calloc(size3, sizeof(*ip));
         if (ip == NULL) {
           fprintf(stderr,"malloc failed\n");
           return 0;
         }
         bufsize = static_cast<int> (size3 * 1.2);
-        buf = (int *)malloc(bufsize * sizeof(*buf));
+        buf = (int *)calloc(bufsize, sizeof(*buf));
         if (buf == NULL) {
           fprintf(stderr,"malloc failed\n");
           return 0;

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -203,8 +203,7 @@ namespace OpenBabel
     kekule_system = new OBBitVec(*needs_dbl_bond);
 
     // Create lookup of degrees
-    unsigned int *degrees = (unsigned int*)malloc(sizeof(unsigned int)*atomArraySize);
-    memset(degrees, 0, sizeof(unsigned int)*atomArraySize);
+    unsigned int *degrees = (unsigned int*)calloc(atomArraySize,sizeof(unsigned int));
     std::vector<OBAtom*> degreeOneAtoms;
     FOR_ATOMS_OF_MOL(atom, m_mol) {
       unsigned int atom_idx = atom->GetIdx();

--- a/src/mcdlutil.cpp
+++ b/src/mcdlutil.cpp
@@ -956,7 +956,7 @@ namespace OpenBabel {
     double r1,r2,s1,s3;
 
     if (bkExt != NULL) bk=bkExt; else {
-      bk=(neighbourlist *)malloc(nAtoms() * sizeof(adjustedlist));
+      bk=(neighbourlist *)calloc(nAtoms(), sizeof(adjustedlist));
       defineBondConn(bk);
     };
     nBondNo=0;
@@ -1867,7 +1867,7 @@ namespace OpenBabel {
     neighbourlist *bk;
 
     if (nBonds() == 0) return;
-    bk=(neighbourlist *)malloc(nAtoms() * sizeof(adjustedlist));
+    bk=(neighbourlist *)calloc(nAtoms(), sizeof(adjustedlist));
     defineBondConn(bk);
     //initial values for MainList-number of bonds, connected to each atom and their numbers in array BOND
     for (i=0; i<nBonds(); i++) {
@@ -2215,7 +2215,7 @@ namespace OpenBabel {
     allAboutCycles();
 
     test=true;
-    bk = (neighbourlist *)malloc(nAtoms() * sizeof(adjustedlist));
+    bk = (neighbourlist *)calloc(nAtoms(), sizeof(adjustedlist));
     defineBondConn(bk);
     //{Start clean for LISTATOMCLEAN and LISTBONDCLEAN atoms and bonds}
     baseCycle=0;
@@ -3279,7 +3279,7 @@ namespace OpenBabel {
     } else {
       for (i=0; i<em->nBonds(); i++) if ((em->getBond(i)->tb >= 9) && (em->getBond(i)->tb <= 11)) em->getBond(i)->tb=1;
     };
-    bk=(neighbourlist *)malloc(nAtoms() * sizeof(adjustedlist));
+    bk=(neighbourlist *)calloc(nAtoms(), sizeof(adjustedlist));
     em->defineBondConn(bk);
     //
     for (i=0; i<em->nAtoms(); i++) a[i]=em->getAtom(i)->allAtAtom();
@@ -4461,7 +4461,7 @@ namespace OpenBabel {
     };
 
     //Initializinf arrays
-    neighbourlist *queryBK=(neighbourlist *)malloc(listarSize()*sizeof(adjustedlist));
+    neighbourlist *queryBK=(neighbourlist *)calloc(listarSize(),sizeof(adjustedlist));
     queryQHydr.resize(listarSize());
     queryAGer.resize(listarSize());
     queryAQTested.resize(listarSize());
@@ -4857,18 +4857,14 @@ namespace OpenBabel {
     if (this->listarSize()>queryAQTested.size()) queryAQTested.resize(this->listarSize());
 
     // Initialise aEQ, a 2D bool matrix of size [molecule1->nAtoms()][nAtoms()] and set all to false
-    bool **aEQ = (bool **)malloc(molecule1->nAtoms()*sizeof(bool *));
+    bool **aEQ = (bool **)calloc(molecule1->nAtoms(),sizeof(bool *));
     for (int i=0; i<molecule1->nAtoms(); ++i) {
-      aEQ[i] = (bool *)malloc(nAtoms()*sizeof(bool ));
-      for (int j=0; j<nAtoms(); ++j)
-        aEQ[i][j] = false;
+      aEQ[i] = (bool *)calloc(nAtoms(),sizeof(bool ));
     }
     // Initialise bEQ, a 2D bool matrix of size [molecule1->nBonds()][nBonds()] and set all to false
-    bool **bEQ = (bool **)malloc(molecule1->nBonds()*sizeof(bool *));
+    bool **bEQ = (bool **)calloc(molecule1->nBonds(),sizeof(bool *));
     for (int i=0; i<molecule1->nBonds(); ++i) {
-      bEQ[i] = (bool *)malloc(nBonds()*sizeof(bool ));
-      for (int j=0; j<nBonds(); ++j)
-        bEQ[i][j] = false;
+      bEQ[i] = (bool *)calloc(nBonds(),sizeof(bool ));
     }
 
     cycleNumber=0;
@@ -4881,7 +4877,7 @@ namespace OpenBabel {
     //{R/S/Z/E description are removed: they are not used in substructure search}
     if (fIOPT13) molecule1->atomBondChange(); //Semipolar bond conversion
     molecule1->defineAtomConn();
-    neighbourlist *structureBK = (neighbourlist *)malloc(molecule1->nAtoms() * sizeof(adjustedlist));
+    neighbourlist *structureBK = (neighbourlist *)calloc(molecule1->nAtoms(), sizeof(adjustedlist));
     molecule1->defineBondConn(structureBK);
     // GRH: 2011-10-15 unused via clang static analyzer
     // stereoS=molecule1->stereoBondChange(); //Stereo bond conversion}

--- a/tools/obrms.cpp
+++ b/tools/obrms.cpp
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
 	}
 
 	if(!docross && fileTest.size() == 0) {
-    cerr << helpmsg;
+	  cerr << helpmsg;
 	  cerr << "Command line parse error: test file is required but missing\n";
 	  exit(-1);
 	}


### PR DESCRIPTION
It is arguable if this is strictly better (you won't see uninitialized
reads in valgrind when debugging memory errors) but seems like good
defensive programming to me.  I don't know of any bugs that are fixed as
a result of not having uninitialized memory, but this was motivated by
another bug involving uninitializd memory and the changes have been
sitting in my fork for a while.