### PR TITLE
Fix the compiler warning about large object size

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -3167,7 +3167,8 @@ namespace OpenBabel
         _c = NULL;
         for (atom = BeginAtom(i);atom;atom = NextAtom(i))
           atom->ClearCoordPtr();
-        _vconf.resize(_vconf.size()-1);
+	if (_vconf.size() > 0)
+	  _vconf.resize(_vconf.size()-1);
       }
 
     if (_c != NULL)


### PR DESCRIPTION
```
[92/558] Building CXX object src/CMakeFiles/openbabel.dir/mol.cpp.o
In member function ‘void OpenBabel::OBMol::ConnectTheDots()’:
cc1plus: warning: ‘void* __builtin_memset(void*, int, long unsigned int)’: specified size 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
```
The change I've made is to guard against a negative value. I think the compiler is maybe being extra cautious. On the other hand, maybe it's a true logic error in the original code - can you take a quick look @ghutchis.