### PR TITLE
Fix memory leak in mol.cpp

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -3164,7 +3164,13 @@ namespace OpenBabel
     EndModify();
     if (unset)
       {
-        _c = nullptr;
+        if (_c != nullptr){
+          delete [] _c;
+
+          // Note that the above delete doesn't set _c value to nullptr
+          _c = nullptr;
+        }
+
         for (atom = BeginAtom(i);atom;atom = NextAtom(i))
           atom->ClearCoordPtr();
 	if (_vconf.size() > 0)


### PR DESCRIPTION
After this fix, valgrind reports no leaks ([valgrind-out.txt](https://github.com/openbabel/openbabel/files/4631753/valgrind-out.txt)) when running mol test (besides the dlopen ([supr.txt](https://github.com/openbabel/openbabel/files/4631752/supr.txt))):
```
valgrind --leak-check=full  --show-leak-kinds=all --track-origins=yes --log-file=valgrind-out.txt --suppressions=../supr.txt ./bin/test_runner mol 1
```

