### PR TITLE
Fixes miscellaneous undefined behaviors

### DIFF
--- a/src/fingerprints/finger3.cpp
+++ b/src/fingerprints/finger3.cpp
@@ -255,7 +255,8 @@ public:
       int num =  ppat->numbits, div = ppat->numoccurrences+1, ngrp;
       while(num) //for each group of bits
       {
-        ngrp = (num + div -1)/div--; //rounds up
+        ngrp = (num + div - 1) / div; //rounds up
+        div -= 1;
         num -= ngrp;
         if(GetBit(fp, n) == bSet)
         {

--- a/src/formats/yasaraformat.cpp
+++ b/src/formats/yasaraformat.cpp
@@ -224,8 +224,7 @@ int mob_atomsize(struct mobatom *atom)
 /* MOVE POINTER TO NEXT ATOM OF YASARA OBJECT STRUCTURE
    ==================================================== */
 struct mobatom *mob_next(struct mobatom *atom)
-{ mem_inc(atom,mob_atomsize(atom));
-  return(atom); }
+{ return((struct mobatom *) ((char *) atom + mob_atomsize(atom))); }
 
 void mob_setnext(struct mobatom **atomadd)
 { *atomadd=mob_next(*atomadd); }
@@ -437,7 +436,7 @@ bool YOBFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
     *((int32*)atomname)=id.atom;
     atomname[4]=0;
     /* SHIFT ATOM NAME BY ONE CHARACTER TO REMOVE LEADING SPACE */
-    if (atomname[0]==' '&&(!pConv->IsOption("f",OBConversion::INOPTIONS))) memcpy(atomname,atomname+1,4);
+    if (atomname[0]==' '&&(!pConv->IsOption("f",OBConversion::INOPTIONS))) memmove(atomname,atomname+1,4);
     /* RENAME TERMINAL OXYGENS */
     str=atomname;
     if (str=="OT1") str="O";


### PR DESCRIPTION
Fixes three miscellaneous undefined behaviors:

 1. One instance of using memcpy() with overlapping source and
    destination strings.

 2. One instance of reading and modifying an object without an
    intervening sequence point.

 3. One modification of an object via a pointer to a different,
    unrelated type.