### PR TITLE
Do not release OpenBabel::OBConformerSearch::m_score

### DIFF
--- a/include/openbabel/conformersearch.h
+++ b/include/openbabel/conformersearch.h
@@ -332,7 +332,6 @@ namespace OpenBabel {
        */
       void SetScore(OBConformerScore *score)
       {
-        delete m_score;
         m_score = score;
       }
 

--- a/src/conformersearch.cpp
+++ b/src/conformersearch.cpp
@@ -324,7 +324,6 @@ namespace OpenBabel {
   OBConformerSearch::~OBConformerSearch()
   {
     delete m_filter;
-    delete m_score;
     delete (OBRandom*)d;
   }
 

--- a/src/ops/conformer.cpp
+++ b/src/ops/conformer.cpp
@@ -27,6 +27,7 @@ Compile with tools/obabel.cpp rather than tools/babel.cpp
 
 #include <openbabel/babelconfig.h>
 #include <iostream>
+#include <memory>
 #include <vector>
 #include <stdio.h>
 #include <openbabel/op.h>
@@ -216,12 +217,15 @@ namespace OpenBabel
         score = iter->second;
 
       OBConformerSearch cs;
+      std::unique_ptr<OBConformerScore> s;
       if (score == "energy")
-        cs.SetScore(new OBEnergyConformerScore);
+        s.reset(new OBEnergyConformerScore{});
       else if (score == "mine" || score == "minenergy")
-        cs.SetScore(new OBMinimizingEnergyConformerScore);
+        s.reset(new OBMinimizingEnergyConformerScore{});
       else if (score == "minr" || score == "minrmsd")
-        cs.SetScore(new OBMinimizingRMSDConformerScore);
+        s.reset(new OBMinimizingRMSDConformerScore{});
+      if (s)
+        cs.SetScore(s.get());
 
       iter = pmap->find("csfilter");
       if(iter!=pmap->end())


### PR DESCRIPTION
Instead callers must release objects.
Fix #2066, fix #2221.