### PR TITLE
Fix examples failing to build with GCC / libstdc++ v8.3

### DIFF
--- a/doc/examples/obconformersearch_default.cpp
+++ b/doc/examples/obconformersearch_default.cpp
@@ -8,10 +8,10 @@
 using namespace OpenBabel;
 
 // Helper function to read molecule from file
-shared_ptr<OBMol> GetMol(const std::string &filename)
+obsharedptr<OBMol> GetMol(const std::string &filename)
 {
   // Create the OBMol object.
-  shared_ptr<OBMol> mol(new OBMol);
+  obsharedptr<OBMol> mol(new OBMol);
 
   // Create the OBConversion object.
   OBConversion conv;
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
   }
 
   // Read the file
-  shared_ptr<OBMol> mol = GetMol(argv[1]);
+  obsharedptr<OBMol> mol = GetMol(argv[1]);
 
   // Create the OBConformerSearch object
   OBConformerSearch cs;


### PR DESCRIPTION
The example program obconformersearch_default does not build
successfully with GCC 8.3.1 and its accompanying C++ standard
library.  The issue revolves around its use of a non-namespaced
shared_ptr template.  Since the source already includes the header
needed to use OB's shared pointer alias, obsharedptr, this
commit resolves the issue by making it use that alias (as opposed to
by using std::shared_ptr explicitly).