### PR TITLE
Support Python 2.7 in setup.py

### DIFF
--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -106,7 +106,7 @@ class CustomBuildExt(build_ext):
                   'For example:',
                   '  python setup.py build_ext -I{} -L{}'.format(self.ob_include_dir, self.ob_library_dir),
                   '  python setup.py install',
-                  sep=r'\n')
+                  sep='\n')
             sys.exit(1)
 
 

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import os
 import re
 import subprocess
@@ -105,7 +106,7 @@ class CustomBuildExt(build_ext):
                   'For example:',
                   '  python setup.py build_ext -I{} -L{}'.format(self.ob_include_dir, self.ob_library_dir),
                   '  python setup.py install',
-                  sep='\n')
+                  sep=r'\n')
             sys.exit(1)
 
 


### PR DESCRIPTION
``setup.py`` is used for pip installs on Linux. python 2.7 is the default Linux on Ubuntu 18.04 (for example), which has long-term support until 2023.