### PR TITLE
Make openbabel objects thread-safe

### DIFF
--- a/include/openbabel/data.h
+++ b/include/openbabel/data.h
@@ -28,13 +28,13 @@ GNU General Public License for more details.
 #include <vector>
 #include <string>
 #include <cstring>
+#include <openbabel/data_utilities.h>
 
 namespace OpenBabel
 {
 
   class OBAtom;
   class OBMol;
-  class OBTranslator;
 
   /** \class OBGlobalDataBase data.h <openbabel/data.h>
       \brief Base data table class, handles reading data files
@@ -55,6 +55,7 @@ namespace OpenBabel
       std::string  _dir;		//!< Data directory for file if _envvar fails
       std::string  _subdir;	//!< Subdirectory (if using environment variable)
       std::string  _envvar;	//!< Environment variable to check first
+      mutable OBGlobalDBMutex  _db_mutex;	//!< Mutex for concurrency
 
     public:
       //! Constructor
@@ -214,7 +215,6 @@ namespace OpenBabel
   **/
   class OBAPI OBResidueData : public OBGlobalDataBase
     {
-      int                                               _resnum;
       std::vector<std::string>                          _resname;
       std::vector<std::vector<std::string> >            _resatoms;
       std::vector<std::vector<std::pair<std::string,int> > > _resbonds;
@@ -222,6 +222,9 @@ namespace OpenBabel
       //variables used only temporarily for parsing resdata.txt
       std::vector<std::string>                          _vatmtmp;
       std::vector<std::pair<std::string,int> >          _vtmp;
+
+      friend class OBResidueObserver;
+
     public:
 
       OBResidueData();
@@ -230,22 +233,6 @@ namespace OpenBabel
       //! \return the number of residues in the table
       size_t GetSize() { return _resname.size(); }
 
-      //! Sets the table to access the residue information for a specified
-      //!  residue name
-      //! \return whether this residue name is in the table
-      bool SetResName(const std::string &);
-      //! \return the bond order for the bond specified in the current residue
-      //! \deprecated Easier to use the two-argument form
-      int  LookupBO(const std::string &);
-      //! \return the bond order for the bond specified between the two specified
-      //! atom labels
-      int  LookupBO(const std::string &, const std::string&);
-      //! Look up the atom type and hybridization for the atom label specified
-      //! in the first argument for the current residue
-      //! \return whether the atom label specified is found in the current residue
-      bool LookupType(const std::string &,std::string&,int&);
-      //! Assign bond orders, atom types and residues for the supplied OBMol
-      //! based on the residue information assigned to atoms
       bool AssignBonds(OBMol &);
     };
 

--- a/include/openbabel/data.h
+++ b/include/openbabel/data.h
@@ -34,6 +34,7 @@ namespace OpenBabel
 
   class OBAtom;
   class OBMol;
+  class OBTranslator;
 
   /** \class OBGlobalDataBase data.h <openbabel/data.h>
       \brief Base data table class, handles reading data files
@@ -187,12 +188,12 @@ namespace OpenBabel
     {
       int             _linecount;
       unsigned int    _ncols,_nrows;
-      int             _from,_to;
       std::vector<std::string> _colnames;
       std::vector<std::vector<std::string> > _table;
 
-    public:
+      friend class OBTranslator;
 
+    public:
       OBTypeTable(void);
       ~OBTypeTable() {}
 
@@ -200,24 +201,6 @@ namespace OpenBabel
 
       //! \return the number of atom types in the translation table
       size_t GetSize() { return _table.size(); }
-
-      //! Set the initial atom type to be translated
-      bool SetFromType(const char*);
-      //! Set the destination atom type for translation
-      bool SetToType(const char*);
-      //! Translate atom types
-      bool Translate(char *to, const char *from); // to, from
-      //! Translate atom types
-      //! \return whether the translation was successful
-      bool Translate(std::string &to, const std::string &from); // to, from
-      //! Translate atom types
-      //! \return the translated atom type, or an empty string if not possible
-      std::string Translate(const std::string &from);
-
-      //! \return the initial atom type to be translated
-      std::string GetFromType();
-      //! \return the destination atom type for translation
-      std::string GetToType();
     };
 
   //! Global OBTypeTable for translating between different atom types

--- a/include/openbabel/data_utilities.h
+++ b/include/openbabel/data_utilities.h
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <openbabel/babelconfig.h>
 
 #include <vector>
+#include <mutex>
 
 namespace OpenBabel {
  class OBMol;
@@ -130,7 +131,7 @@ public:
 
 	~OBGlobalDBMutex() = default;
 
-	OBGlobalDBMutex& operator=(const OBGlobalDBMutex &) {} // Copy assignment operator
+	OBGlobalDBMutex& operator=(const OBGlobalDBMutex &) { return *this; } // Copy assignment operator
 };
 }
 

--- a/include/openbabel/data_utilities.h
+++ b/include/openbabel/data_utilities.h
@@ -97,6 +97,41 @@ public:
 	//! \return the destination atom type for translation
 	std::string GetToType() const;
 };
+
+class OBAPI OBResidueObserver
+{
+	int _resnum;
+
+public:
+	//! Sets the table to access the residue information for a specified
+	//!  residue name
+	//! \return whether this residue name is in the table
+	bool SetResName(const std::string &);
+	//! \return the bond order for the bond specified in the current residue
+	//! \deprecated Easier to use the two-argument form
+	int  LookupBO(const std::string &);
+	//! \return the bond order for the bond specified between the two specified
+	//! atom labels
+	int  LookupBO(const std::string &, const std::string&);
+	//! Look up the atom type and hybridization for the atom label specified
+	//! in the first argument for the current residue
+	//! \return whether the atom label specified is found in the current residue
+	bool LookupType(const std::string &,std::string&,int&);
+	//! Assign bond orders, atom types and residues for the supplied OBMol
+	//! based on the residue information assigned to atoms
+};
+
+class OBGlobalDBMutex: public std::mutex
+{
+public:
+
+	constexpr OBGlobalDBMutex() noexcept = default;
+	OBGlobalDBMutex(const OBGlobalDBMutex &) { OBGlobalDBMutex(); } // Copy constructor
+
+	~OBGlobalDBMutex() = default;
+
+	OBGlobalDBMutex& operator=(const OBGlobalDBMutex &) {} // Copy assignment operator
+};
 }
 
 #endif //DATA_UTILITIES_H

--- a/include/openbabel/data_utilities.h
+++ b/include/openbabel/data_utilities.h
@@ -68,6 +68,35 @@ namespace OpenBabel {
 				    std::vector<double> &Scomponents,
 				    double            *ZPVE);
 
+class OBAPI OBTranslator
+{
+	int _from, _to;
+
+public:
+	//! Constructor
+	OBTranslator();
+	OBTranslator(const char*, const char*);
+	//! Destructor
+	~OBTranslator() {};
+
+	//! Set the initial atom type to be translated
+	bool SetFromType(const char*);
+	//! Set the destination atom type for translation
+	bool SetToType(const char*);
+	//! Translate atom types
+	bool Translate(char *to, const char *from) const; // to, from
+												//! Translate atom types
+												//! \return whether the translation was successful
+	bool Translate(std::string &to, const std::string &from) const; // to, from
+															  //! Translate atom types
+															  //! \return the translated atom type, or an empty string if not possible
+	std::string Translate(const std::string &from) const;
+
+	//! \return the initial atom type to be translated
+	std::string GetFromType() const;
+	//! \return the destination atom type for translation
+	std::string GetToType() const;
+};
 }
 
 #endif //DATA_UTILITIES_H

--- a/include/openbabel/groupcontrib.h
+++ b/include/openbabel/groupcontrib.h
@@ -52,7 +52,12 @@ public:
 
   //! constructor. Each instance provides an ID and a datafile.
   OBGroupContrib(const char* ID, const char* filename, const char* descr)
-    : OBDescriptor(ID, false), _filename(filename), _descr(descr), _debug(false){}
+    : OBDescriptor(ID, false), _filename(filename), _descr(descr), _debug(false) {
+      _alldescr = _descr;
+      _alldescr += "\n Datafile: ";
+      _alldescr += _filename;
+      _alldescr += "\nOBGroupContrib is definable";
+	}
 
   virtual const char* Description();
 
@@ -69,6 +74,7 @@ public:
 
   const char* _filename;
   const char* _descr;
+  std::string _alldescr;
   std::vector<std::pair<OBSmartsPattern*, double> > _contribsHeavy; //! heavy atom contributions
   std::vector<std::pair<OBSmartsPattern*, double> > _contribsHydrogen; //!  hydrogen contributions
   bool _debug;

--- a/include/openbabel/locale.h
+++ b/include/openbabel/locale.h
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #define OB_LOCALE_H
 
 #include <locale>
+#include <mutex>
 #include <openbabel/babelconfig.h>
 
 #ifndef OBERROR
@@ -43,6 +44,7 @@ namespace OpenBabel
 
   protected:
     OBLocalePrivate* d;
+    static std::mutex LocaleMutex;
   };
 
   //global definitions

--- a/include/openbabel/optransform.h
+++ b/include/openbabel/optransform.h
@@ -33,7 +33,12 @@ class OpTransform : public OBOp
 public:
   //! constructor. Each instance provides an ID, a datafile and a description.
   OpTransform(const char* ID, const char* filename, const char* descr)
-    : OBOp(ID, false), _filename(filename), _descr(descr), _dataLoaded(false){}
+    : OBOp(ID, false), _filename(filename), _descr(descr), _dataLoaded(false) {
+      _alldescr = _descr;
+      _alldescr += "\n Datafile: ";
+      _alldescr += _filename;
+      _alldescr += "\nOpTransform is definable";
+	}
 
   ~OpTransform(){}
 
@@ -61,6 +66,7 @@ private:
   const char* _filename;
   const char* _descr;
   std::vector<std::string> _textlines;
+  std::string _alldescr;
 
   bool _dataLoaded;
   std::vector<OBChemTsfm> _transforms;

--- a/include/openbabel/plugin.h
+++ b/include/openbabel/plugin.h
@@ -27,6 +27,7 @@ General Public License for more details.
 #include <map>
 #include <sstream>
 #include <cstring>
+#include <mutex>
 
 #ifndef OBERROR
  #define OBERROR
@@ -145,6 +146,8 @@ protected:
   ///\brief Returns the type with the specified ID, or NULL if not found.
   ///Needs to be cast to the appropriate class in the calling routine.
   static OBPlugin* BaseFindType(PluginMapType& Map, const char* ID);
+
+  static std::mutex PluginMutex;
 
 protected:
   const char* _id;

--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -33,6 +33,7 @@ GNU General Public License for more details.
 #include <openbabel/obutil.h>
 #include <openbabel/residue.h>
 #include <openbabel/chains.h>
+#include <openbabel/data_utilities.h>
 
 #include <openbabel/math/matrix3x3.h>
 
@@ -107,7 +108,6 @@ namespace OpenBabel
   extern THREAD_LOCAL OBAromaticTyper  aromtyper;
   extern THREAD_LOCAL OBAtomTyper      atomtyper;
   extern THREAD_LOCAL OBPhModel        phmodel;
-  OB_EXTERN OBTypeTable      ttab;
 
   //
   // OBAtom member functions
@@ -475,16 +475,9 @@ namespace OpenBabel
     if (strlen(_type) == 0) // Somehow we still don't have a type!
       {
         char num[6];
-        string fromType = ttab.GetFromType(); // save previous types
-        string toType = ttab.GetToType();
-
-        ttab.SetFromType("ATN");
-        ttab.SetToType("INT");
+        OBTranslator trans("ATN", "INT");
         snprintf(num, 6, "%d", GetAtomicNum());
-        ttab.Translate(_type, num);
-
-        ttab.SetFromType(fromType.c_str());
-        ttab.SetToType(toType.c_str());
+        trans.Translate(_type, num);
       }
     if (_ele == 1 && _isotope == 2)
       snprintf(_type, 6, "%s", "D");

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -1408,7 +1408,6 @@ namespace OpenBabel
         posp_new = coords[counter];
         break;
       }
-    counter = 0;
     for (match_it=match.begin(), counter=0; match_it!=match.end(); ++match_it, ++counter)
       workMol.GetAtom(*match_it)->SetVector( coords[counter] - posp_new );
 

--- a/src/charges/eem.cpp
+++ b/src/charges/eem.cpp
@@ -79,13 +79,13 @@ namespace OpenBabel
   {
     _parameters_file = parameters;
     _type = type;
+    _description = "Assign Electronegativity Equilization Method (EEM) atomic partial charges. ";
+    _description.append(_type);
   }
 
 
   const char *EEMCharges::Description(void)
   {
-    _description = "Assign Electronegativity Equilization Method (EEM) atomic partial charges. ";
-    _description.append(_type);
     return _description.c_str();
   }
 
@@ -156,6 +156,11 @@ namespace OpenBabel
       }
 
       if(!found) {
+        // Cleanup
+        for(unsigned int i = 0; i < dim; i++)
+          delete [] ETA[i];
+        delete [] ETA;
+
         std::stringstream ss;
         ss << "No parameters found for: " << OBElements::GetSymbol(n) << " " << b
            << ". EEM charges were not calculated for the molecule." << std::endl;

--- a/src/charges/fromfile.cpp
+++ b/src/charges/fromfile.cpp
@@ -111,11 +111,12 @@ namespace OpenBabel
 			// First try atom type name
 			if ((res = a->GetResidue()) != nullptr)
 			{
-				char *f = name  = (char*)res->GetAtomID( a ).c_str();
+				string ff = res->GetAtomID(a);
+				char* f = name = (char*)ff.c_str();
 				for( int j = strlen(f)-1; j>=0; j-- ) { if( f[j]==' ' ){ f[j]='\0'; } } // trim trailing whitespace
-				std::string ff = string(f);
+				ff = string(f);
 				if( q_by_name.count( ff ) ) {
-					q = q_by_name[ string(ff) ];
+					q = q_by_name[ ff ];
 					found = true;
 				}
 			}

--- a/src/conformersearch.cpp
+++ b/src/conformersearch.cpp
@@ -247,7 +247,6 @@ namespace OpenBabel {
         return 10e10;
     }
     ff->ConjugateGradients(50);
-    double score = ff->Energy(false); // no gradients
 
     // copy original coordinates back
     for (unsigned int i = 0; i < mol.NumAtoms() * 3; ++i)

--- a/src/data_utilities.cpp
+++ b/src/data_utilities.cpp
@@ -33,6 +33,7 @@ GNU General Public License for more details.
 #include <openbabel/locale.h>
 
 using std::string;
+using std::vector;
 
 namespace OpenBabel {
 
@@ -207,6 +208,7 @@ bool extract_thermochemistry(OpenBabel::OBMol  &mol,
     return (found == 9);
 }
 
+// class OBTranslator
 OBTranslator::OBTranslator() {
 	if (!ttab._init)
 		ttab.Init();
@@ -332,7 +334,76 @@ std::string OBTranslator::GetToType() const
 	else
 		return( ttab._colnames[0] );
 }
+// End class OBTranslator
 
+// class OBResidueObserver
+bool OBResidueObserver::SetResName(const string &s)
+{
+	if (!resdat._init)
+		resdat.Init();
+
+	unsigned int i;
+
+	for (i = 0;i < resdat._resname.size();++i)
+		if (resdat._resname[i] == s)
+		{
+			_resnum = i;
+			return(true);
+		}
+
+	_resnum = -1;
+	return(false);
+}
+
+int OBResidueObserver::LookupBO(const string &s)
+{
+	if (_resnum == -1)
+		return(0);
+
+	unsigned int i;
+	for (i = 0;i < resdat._resbonds[_resnum].size();++i)
+		if (resdat._resbonds[_resnum][i].first == s)
+			return(resdat._resbonds[_resnum][i].second);
+
+	return(0);
+}
+
+int OBResidueObserver::LookupBO(const string &s1, const string &s2)
+{
+	if (_resnum == -1)
+		return(0);
+	string s;
+
+	s = (s1 < s2) ? s1 + " " + s2 : s2 + " " + s1;
+
+	unsigned int i;
+	for (i = 0;i < resdat._resbonds[_resnum].size();++i)
+		if (resdat._resbonds[_resnum][i].first == s)
+			return(resdat._resbonds[_resnum][i].second);
+
+	return(0);
+}
+
+bool OBResidueObserver::LookupType(const string &atmid,string &type,int &hyb)
+{
+	if (_resnum == -1)
+		return(false);
+
+	string s;
+	vector<string>::iterator i;
+
+	for (i = resdat._resatoms[_resnum].begin();i != resdat._resatoms[_resnum].end();i+=3)
+		if (atmid == *i)
+		{
+			++i;
+			type = *i;
+			++i;
+			hyb = atoi((*i).c_str());
+			return(true);
+		}
+
+	return(false);
+} // End class OBResidueObserver
 }
 
 //! \file data_utilities.cpp

--- a/src/depict/depict.cpp
+++ b/src/depict/depict.cpp
@@ -281,7 +281,6 @@ namespace OpenBabel
       vector<unsigned int> copy_sym = symmetry_classes;
       sort(copy_sym.begin(), copy_sym.end());
       vector<unsigned int>::iterator end_pos = unique(copy_sym.begin(), copy_sym.end()); // Requires sorted elements
-      int nclasses = end_pos - copy_sym.begin();
 
       cout << "sym_class[" << atom->GetIndex() << "] = " << symmetry_classes.at(atom->GetIndex()) << endl;
       return symmetry_classes.at(atom->GetIndex());

--- a/src/descriptors/cmpdfilter.cpp
+++ b/src/descriptors/cmpdfilter.cpp
@@ -52,16 +52,14 @@ class CompoundFilter : public OBDescriptor
 public:
 ///Constructor defining ID, the filter string that the descriptor is short for, and a description.
   CompoundFilter(const char* ID, const char* macrotext, const char* descr)
-    : OBDescriptor(ID), _descr(descr), _macroText(macrotext){}
+    : OBDescriptor(ID), _descr(descr), _macroText(macrotext) {
+      _alldescr = _descr;
+      _alldescr += '\n' + _macroText + "\nCompoundFilter is definable"; //Entries in plugindefines.txt can start "CompoundFilter";
+    }
 
   virtual const char* Description()
   {
-    static string txt;
-    txt = _descr;
-    txt += '\n';
-    txt += _macroText;
-    txt += "\nCompoundFilter is definable";//Entries in plugindefines.txt can start "CompoundFilter"
-    return txt.c_str();
+    return _alldescr.c_str();
   }
 
 ///
@@ -81,6 +79,7 @@ public:
 private:
   const char* _descr;
   const string _macroText;
+  string _alldescr;
 };
 
 //*********************************************************************

--- a/src/descriptors/groupcontrib.cpp
+++ b/src/descriptors/groupcontrib.cpp
@@ -42,12 +42,7 @@ namespace OpenBabel
   const char* OBGroupContrib::Description()
   {
    //Adds name of datafile containing SMARTS strings to the description
-    static string txt;
-    txt =  _descr;
-    txt += "\n Datafile: ";
-    txt += _filename;
-    txt += "\nOBGroupContrib is definable";
-    return txt.c_str();
+    return _alldescr.c_str();
   }
 
   bool OBGroupContrib::ParseFile()

--- a/src/descriptors/smartsdescriptors.cpp
+++ b/src/descriptors/smartsdescriptors.cpp
@@ -32,17 +32,17 @@ namespace OpenBabel
   public:
     //! constructor. Each instance provides an ID, a SMARTS pattern and a description.
     SmartsDescriptor(const char* ID, const char* smarts, const char* descr)
-      : OBDescriptor(ID, false), _smarts(smarts), _descr(descr){}
+      : OBDescriptor(ID, false), _smarts(smarts), _descr(descr) {
+        //Adds the SMARTS string to the description
+        _alldescr = _descr;
+        _alldescr += "\n\t SMARTS: ";
+        _alldescr += _smarts;
+        _alldescr += "\nSmartsDescriptor is definable";
+      }
 
     virtual const char* Description()
     {
-      //Adds the SMARTS string to the description
-      static string txt;
-      txt =  _descr;
-      txt += "\n\t SMARTS: ";
-      txt += _smarts;
-      txt += "\nSmartsDescriptor is definable";
-      return txt.c_str();
+      return _alldescr.c_str();
     }
 
     double Predict(OBBase* pOb, string* param=nullptr)
@@ -66,6 +66,7 @@ namespace OpenBabel
   private:
     const char* _smarts;
     const char* _descr;
+    string _alldescr;
   };
 
   //Make global instances

--- a/src/distgeom.cpp
+++ b/src/distgeom.cpp
@@ -432,8 +432,6 @@ namespace OpenBabel {
         continue;
 
       // Aromatic rings must be planar, so atoms in the ring = regular polygon
-      double angle = 180.0 - (360.0 / size);
-      angle *= DEG_TO_RAD;
       float bondDist, radius;
 
       // We should have 1-2 and 1-3 distances set exactly.
@@ -1084,13 +1082,13 @@ namespace OpenBabel {
       }
     }
 
-    for(size_t i=0; i<N; i++) {
-      for (size_t j=0; j<N; j++) {
-        double lb = _d->GetLowerBounds(i, j);
-        double ub = _d->GetUpperBounds(i, j);
-        //cout << "(" << i << ", " << j << ")" << lb << " < " << distMat2(i, j) << " (" << distMat(i, j) << ")" << " < " << ub << endl;
-      }
-    }
+//    for(size_t i=0; i<N; i++) {
+//      for (size_t j=0; j<N; j++) {
+//        double lb = _d->GetLowerBounds(i, j);
+//        double ub = _d->GetUpperBounds(i, j);
+//        cout << "(" << i << ", " << j << ")" << lb << " < " << distMat2(i, j) << " (" << distMat(i, j) << ")" << " < " << ub << endl;
+//      }
+//    }
     return true;
   }
 
@@ -1111,10 +1109,10 @@ namespace OpenBabel {
     LBFGSpp::LBFGSSolver<double> solver(param);
     DistGeomFunc fun(this);
 
-    double fx;
-    int niter = solver.minimize(fun, _coord, fx);
-    //std::cout << niter << " iterations" << std::endl;
-    //std::cout << "f(x) = " << fx << std::endl;
+//    double fx;
+//    int niter = solver.minimize(fun, _coord, fx);
+//    std::cout << niter << " iterations" << std::endl;
+//    std::cout << "f(x) = " << fx << std::endl;
 
     for(size_t i=0; i<N; ++i) {
       vector3 v(_coord(i*dim), _coord(i*dim+1), _coord(i*dim+2));
@@ -1131,13 +1129,13 @@ namespace OpenBabel {
       }
     }
 
-    for(size_t i=0; i<N; i++) {
-      for (size_t j=0; j<N; j++) {
-        double lb = _d->GetLowerBounds(i, j);
-        double ub = _d->GetUpperBounds(i, j);
-        //cout << "(" << i << ", " << j << ")" << lb << " < " << distMat2(i, j) << " < " << ub << endl;
-      }
-    }
+//    for(size_t i=0; i<N; i++) {
+//      for (size_t j=0; j<N; j++) {
+//        double lb = _d->GetLowerBounds(i, j);
+//        double ub = _d->GetUpperBounds(i, j);
+//        cout << "(" << i << ", " << j << ")" << lb << " < " << distMat2(i, j) << " < " << ub << endl;
+//      }
+//    }
     return true;
   }
 
@@ -1156,10 +1154,10 @@ namespace OpenBabel {
     LBFGSpp::LBFGSSolver<double> solver(param);
     DistGeomFunc4D fun(this);
 
-    double fx;
-    int niter = solver.minimize(fun, _coord, fx);
-    //std::cout << niter << " iterations" << std::endl;
-    //std::cout << "f(x) = " << fx << std::endl;
+//    double fx;
+//    int niter = solver.minimize(fun, _coord, fx);
+//    std::cout << niter << " iterations" << std::endl;
+//    std::cout << "f(x) = " << fx << std::endl;
 
     for(size_t i=0; i<N; ++i) {
       vector3 v(_coord(i*dim), _coord(i*dim+1), _coord(i*dim+2));

--- a/src/dlhandler_unix.cpp
+++ b/src/dlhandler_unix.cpp
@@ -50,10 +50,10 @@ namespace OpenBabel {
 
 int matchFiles (SCANDIR_CONST struct dirent *entry_p)
 {
-	string filename(entry_p->d_name);
-	string::size_type extPos = filename.rfind(DLHandler::getFormatFilePattern());
+	string filename(entry_p->d_name), pattern = DLHandler::getFormatFilePattern();
+	string::size_type extPos = filename.rfind(pattern);
 
-	if(extPos!=string::npos && filename.substr(extPos) == DLHandler::getFormatFilePattern())
+	if(extPos!=string::npos && filename.substr(extPos) == pattern)
 		return true;
 
 	return false;

--- a/src/fingerprints/finger3.cpp
+++ b/src/fingerprints/finger3.cpp
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <fstream>
 #include <map>
 #include <string>
+#include <mutex>
 
 #include <openbabel/fingerprint.h>
 
@@ -45,6 +46,8 @@ private:
   vector<pattern> _pats;
   int _bitcount;
   string _version;
+  string _alldescr;
+  mutex _fpmutex;
 
 protected:
   string _patternsfile;
@@ -57,26 +60,14 @@ public:
       _patternsfile="patterns.txt";
     else
       _patternsfile = filename;
+
+    _alldescr = "SMARTS patterns specified in the file " + _patternsfile + "\nPatternFP is definable";
   }
 
 /////////////////////////////////////////////////////////////////////////////
   virtual const char* Description()
   {
-    static string desc;
-    //Read patterns file if it has not been done already,
-    //because we need _bitcount and _version updated
-
-    // _bitcount and _version are available only after the datafile has been parsed.
-    // This is a burden on normal operation (Description() gets called on startup from OBDefine),
-    // so the secondline is present only after the fingerprint has been used.
-    // the
-    string secondline;
-    if(!_pats.empty())
-      secondline = "\n" + toString(_bitcount) + " bits. Datafile version = " +  _version;
-    desc = "SMARTS patterns specified in the file " + _patternsfile
-      + secondline
-      + "\nPatternFP is definable";
-    return (desc.c_str());
+    return _alldescr.c_str();
   }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -158,9 +149,13 @@ public:
   /////////////////////////////////////////////////////////////////////
   bool ReadPatternFile(string& ver)
   {
+    lock_guard<mutex> lock(_fpmutex);
+    if (!_pats.empty())
+      return true;
+
     //Reads three types of file. See below
     ifstream ifs;
-	  stringstream errorMsg;
+    stringstream errorMsg;
 
     if (OpenDatafile(ifs, _patternsfile).length() == 0)
     {

--- a/src/fingerprints/finger3.cpp
+++ b/src/fingerprints/finger3.cpp
@@ -47,7 +47,7 @@ private:
   int _bitcount;
   string _version;
   string _alldescr;
-  mutex _fpmutex;
+  mutable mutex _fpmutex;
 
 protected:
   string _patternsfile;

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -1288,8 +1288,6 @@ namespace OpenBabel
     if (_mol.NumRotors() == 0)
       return 0;
 
-    int origLogLevel = _loglvl;
-
     // Remove all conformers (e.g. from previous conformer generators) except for current conformer
     double *initialCoord = new double [_mol.NumAtoms() * 3]; // initial state
     double *store_initial = new double [_mol.NumAtoms() * 3]; // store the initial state
@@ -1676,8 +1674,7 @@ namespace OpenBabel
     IF_OBFF_LOGLVL_LOW
       OBFFLog("  INITIAL WEIGHTING OF ROTAMERS...\n\n");
 
-    rotor = rl.BeginRotor(ri);
-    for (unsigned int i = 1; i < rl.Size() + 1; ++i, rotor = rl.NextRotor(ri)) {
+    for (unsigned int i = 1; i < rl.Size() + 1; ++i) {
       rotorKey[i] = -1; // no rotation (new in 2.2)
     }
 
@@ -2476,7 +2473,6 @@ namespace OpenBabel
 
       if (e_n1 < opt_e) {
         opt_step = step;
-        opt_e = e_n1;
       }
 
     }
@@ -2959,7 +2955,6 @@ namespace OpenBabel
     if (!_validSetup)
       return 0;
 
-    double e_n2;
     double g2g2, g1g1, beta;
     vector3 grad2, dir2;
     vector3 grad1, dir1; // temporaries to perform dot product, etc.
@@ -2967,8 +2962,6 @@ namespace OpenBabel
 
     if (_ncoords != _mol.NumAtoms() * 3)
       return false;
-
-    e_n2 = 0.0;
 
     for (int i = 1; i <= n; i++) {
       _cstep++;
@@ -3036,7 +3029,7 @@ namespace OpenBabel
       // save the direction
       memcpy(_gradientPtr, _grad1, sizeof(double)*_ncoords);
 
-      e_n2 = Energy() + _constraints.GetConstraintEnergy();
+      double e_n2 = Energy() + _constraints.GetConstraintEnergy();
 
       if ((_cstep % _pairfreq == 0) && _cutoff)
         UpdatePairsSimple(); // Update the non-bonded pairs (Cut-off)

--- a/src/formats/alchemyformat.cpp
+++ b/src/formats/alchemyformat.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <openbabel/bond.h>
 #include <openbabel/elements.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 #include <cstdlib>
 
 
@@ -96,12 +97,14 @@ namespace OpenBabel
 
     mol.ReserveAtoms(natoms);
     mol.BeginModify();
-    ttab.SetFromType("ALC");
 
     string str;
     double x,y,z;
     OBAtom *atom;
+    OBTranslator trans;
     vector<string> vs;
+
+    trans.SetFromType("ALC");
 
     for (i = 1; i <= natoms; i ++)
       {
@@ -117,12 +120,12 @@ namespace OpenBabel
         atom->SetVector(x,y,z); //set coordinates
 
         //set atomic number
-        ttab.SetToType("ATN");
-        ttab.Translate(str,vs[1]);
+        trans.SetToType("ATN");
+        trans.Translate(str,vs[1]);
         atom->SetAtomicNum(atoi(str.c_str()));
         //set type
-        ttab.SetToType("INT");
-        ttab.Translate(str,vs[1]);
+        trans.SetToType("INT");
+        trans.Translate(str,vs[1]);
         atom->SetType(str);
       }
 
@@ -185,13 +188,13 @@ namespace OpenBabel
 
     OBAtom *atom;
     string str,str1;
+    OBTranslator trans("INT", "ALC");
+
     for(i = 1;i <= mol.NumAtoms(); i++)
       {
         atom = mol.GetAtom(i);
         str = atom->GetType();
-        ttab.SetFromType("INT");
-        ttab.SetToType("ALC");
-        ttab.Translate(str1,str);
+        trans.Translate(str1,str);
         snprintf(buffer, BUFF_SIZE, "%5d %-6s%8.4f %8.4f %8.4f     0.0000",
                  i,
                  (char*)str1.c_str(),

--- a/src/formats/bgfformat.cpp
+++ b/src/formats/bgfformat.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <openbabel/bond.h>
 #include <openbabel/elements.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 #include <openbabel/generic.h>
 #include <cstdlib>
 
@@ -105,9 +106,8 @@ namespace OpenBabel
         break;
     }
 
-    ttab.SetFromType("DRE");
-    ttab.SetToType("INT");
     OBAtom *atom;
+    OBTranslator trans("DRE", "INT");
     double x,y,z,chrg;
     for (;;)
       {
@@ -122,7 +122,7 @@ namespace OpenBabel
                &chrg);
         atom = mol.NewAtom();
 
-        ttab.Translate(tmp,tmptyp);
+        trans.Translate(tmp,tmptyp);
         atom->SetType(tmp);
 
         CleanAtomType(tmptyp);
@@ -205,6 +205,7 @@ namespace OpenBabel
     vector<OBAtom*>::iterator i;
     int max_val;
     OBAtom *atom;
+    OBTranslator trans;
     char buffer[BUFF_SIZE];
     char elmnt_typ[8], dreid_typ[8], atm_sym[16], max_val_str[8];
 
@@ -228,7 +229,7 @@ namespace OpenBabel
 
     ofs << "FORMAT ATOM   (a6,1x,i5,1x,a5,1x,a3,1x,a1,1x,a5,3f10.5,1x,a5,i3,i2,1x,f8.5)\n";
 
-    ttab.SetFromType("INT");
+    trans.SetFromType("INT");
 
     for (atom = mol.BeginAtom(i);atom;atom = mol.NextAtom(i))
       {
@@ -236,10 +237,10 @@ namespace OpenBabel
         elmnt_typ[sizeof(elmnt_typ) - 1] = '0';
         ToUpper(elmnt_typ);
 
-        ttab.SetToType("DRE");
-        ttab.Translate(dreid_typ,atom->GetType());
-        ttab.SetToType("HAD");
-        ttab.Translate(max_val_str,atom->GetType());
+        trans.SetToType("DRE");
+        trans.Translate(dreid_typ,atom->GetType());
+        trans.SetToType("HAD");
+        trans.Translate(max_val_str,atom->GetType());
         max_val = atoi(max_val_str);
         if (max_val == 0)
           max_val = 1;

--- a/src/formats/chem3dformat.cpp
+++ b/src/formats/chem3dformat.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <openbabel/atom.h>
 #include <openbabel/elements.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 #include <cstdlib>
 
 
@@ -222,10 +223,8 @@ namespace OpenBabel
     divisor = pow(10.0,exponent);
     mol.ReserveAtoms(natoms);
 
-    ttab.SetToType("INT");
-    ttab.SetFromType(type_key);
-
     OBAtom *atom;
+    OBTranslator trans(type_key, "INT");
     double x,y,z;
     vector3 v;
 
@@ -250,7 +249,7 @@ namespace OpenBabel
           return(false);
 
         atom = mol.NewAtom();
-        ttab.Translate(tmp1,tmp);
+        trans.Translate(tmp1,tmp);
         atom->SetType(tmp1);
         atom->SetVector(v);
         atom->SetAtomicNum(OBElements::GetAtomicNum(atomic_type));
@@ -279,18 +278,19 @@ namespace OpenBabel
     int atnum;
     int type_num;
     char buffer[BUFF_SIZE],type_name[16],ele_type[16];
+    OBTranslator trans;
 
     ofs << mol.NumAtoms();
     if (EQ(mol_typ,"MMADS"))
       {
         ofs << " " << mol.GetTitle();
-        ttab.SetToType("MM2");
+        trans.SetToType("MM2");
       }
     else
-      ttab.SetToType(mol_typ);
+      trans.SetToType(mol_typ);
     ofs << endl;
 
-    ttab.SetFromType("INT");
+    trans.SetFromType("INT");
 
     OBAtom *atom,*nbr;
     vector<OBAtom*>::iterator i;
@@ -298,7 +298,7 @@ namespace OpenBabel
 
     for (atom = mol.BeginAtom(i);atom;atom = mol.NextAtom(i))
       {
-        if (!ttab.Translate(type_name,atom->GetType()))
+        if (!trans.Translate(type_name,atom->GetType()))
           {
             snprintf(buffer, BUFF_SIZE,
                      "Unable to assign %s type to atom %d type = %s\n",

--- a/src/formats/chemdrawcdx.cpp
+++ b/src/formats/chemdrawcdx.cpp
@@ -474,7 +474,7 @@ bool ChemDrawBinaryXFormat::DoFragmentImpl(CDXReader& cdxr, OBMol* pmol,
     if(tag==kCDXObj_Node)
     {
       unsigned nodeID = cdxr.CurrentID();
-      bool isAlias=false, hasElement=false;
+      bool isAlias=false;
       bool hasNumHs = false;
       UINT16 atnum=-1, spin=0, numHs=0;
       int x, y, charge=0, iso=0;
@@ -493,7 +493,6 @@ bool ChemDrawBinaryXFormat::DoFragmentImpl(CDXReader& cdxr, OBMol* pmol,
           break;
         case kCDXProp_Node_Element:
           READ_INT16(cdxr.data(), atnum);
-          hasElement = true;
           break;
         case kCDXProp_2DPosition:
           {

--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -518,7 +518,6 @@ namespace OpenBabel
       //
       // Bond Block
       //
-      stereo = 0;
       bool needs_kekulization = false; // Have we have found an aromatic bond?
       unsigned int begin, end, order, flag;
       for (i = 0;i < nbonds; ++i) {

--- a/src/formats/mmodformat.cpp
+++ b/src/formats/mmodformat.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include <openbabel/bond.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 #include <openbabel/generic.h>
 #include <cstdlib>
 
@@ -123,8 +124,9 @@ namespace OpenBabel
     int i,j;
     double charge;
     OBAtom atom;
+    OBTranslator trans;
 
-    ttab.SetFromType("MMD");
+    trans.SetFromType("MMD");
     for (i = 1; i <= natoms; i++)
       {
         if (!ifs.getline(buffer,BUFF_SIZE))
@@ -154,11 +156,11 @@ namespace OpenBabel
         atom.SetVector(v);
 
         string str = temp_type,str1;
-        ttab.SetToType("ATN");
-        ttab.Translate(str1,str);
+        trans.SetToType("ATN");
+        trans.Translate(str1,str);
         atom.SetAtomicNum(atoi(str1.c_str()));
-        ttab.SetToType("INT");
-        ttab.Translate(str1,str);
+        trans.SetToType("INT");
+        trans.Translate(str1,str);
         atom.SetType(str1);
 
         // stuff for optional fields
@@ -215,6 +217,7 @@ namespace OpenBabel
     //Define some references so we can use the old parameter names
     ostream &ofs = *pConv->GetOutStream();
     OBMol &mol = *pmol;
+    OBTranslator trans;
 
     char buffer[BUFF_SIZE];
     snprintf(buffer, BUFF_SIZE, " %5d %6s      E = %7.3f KJ/mol",
@@ -226,8 +229,8 @@ namespace OpenBabel
     string from,to;
     vector<OBAtom*>::iterator i;
     vector<OBBond*>::iterator j;
-    ttab.SetFromType("INT");
-    ttab.SetToType("MMD");
+    trans.SetFromType("INT");
+    trans.SetToType("MMD");
 
     for (atom = mol.BeginAtom(i);atom;atom = mol.NextAtom(i)) {
         if (atom->GetAtomicNum() == OBElements::Hydrogen) {
@@ -242,7 +245,7 @@ namespace OpenBabel
           }
         } else {
             from = atom->GetType();
-            ttab.Translate(to,from);
+            trans.Translate(to,from);
             type = atoi((char*)to.c_str());
         }
         snprintf(buffer, BUFF_SIZE, "%4d",type);

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -24,6 +24,7 @@ GNU General Public License for more details.
 #include <openbabel/kekulize.h>
 #include <openbabel/obfunctions.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 #include <cstdlib>
 
 using namespace std;
@@ -264,6 +265,7 @@ namespace OpenBabel
     int i;
     vector3 v;
     OBAtom atom;
+    OBTranslator trans;
     double x,y,z,pcharge;
     char temp_type[BUFF_SIZE], resname[BUFF_SIZE], atmid[BUFF_SIZE];
     int elemno, resnum = -1;
@@ -271,7 +273,7 @@ namespace OpenBabel
     bool has_explicit_hydrogen = false;
     bool has_residue_information = false;
 
-    ttab.SetFromType("SYB");
+    trans.SetFromType("SYB");
     for (i = 0;i < natoms;i++)
       {
         if (!ifs.getline(buffer,BUFF_SIZE))
@@ -309,10 +311,10 @@ namespace OpenBabel
           atom.SetFormalCharge(1);
         }
 
-        ttab.SetToType("ATN");
-        ttab.Translate(str1,str);
+        trans.SetToType("ATN");
+        trans.Translate(str1,str);
         elemno = atoi(str1.c_str());
-        ttab.SetToType("IDX");
+        trans.SetToType("IDX");
 
         // We might have missed some SI or FE type things above, so here's
         // another check
@@ -320,10 +322,10 @@ namespace OpenBabel
           {
             temp_type[1] = (char)tolower(temp_type[1]);
             str = temp_type;
-            ttab.SetToType("ATN");
-            ttab.Translate(str1,str);
+            trans.SetToType("ATN");
+            trans.Translate(str1,str);
             elemno = atoi(str1.c_str());
-            ttab.SetToType("IDX");
+            trans.SetToType("IDX");
           }
         // One last check if there isn't a period in the type,
         // it's a malformed atom type, but it may be the element symbol
@@ -358,8 +360,8 @@ namespace OpenBabel
           atom.SetIsotope(isotope);
         else if (elemno == 1)
           has_explicit_hydrogen = true;
-        ttab.SetToType("INT");
-        ttab.Translate(str1,str);
+        trans.SetToType("INT");
+        trans.Translate(str1,str);
         atom.SetType(str1);
         atom.SetPartialCharge(pcharge);
         // MMFF94 has different atom types for Cu(I) and Cu(II)
@@ -679,12 +681,10 @@ namespace OpenBabel
 
     OBAtom *atom;
     OBResidue *res;
+    OBTranslator trans("INT", "SYB");
 
     vector<OBAtom*>::iterator i;
     std::map<int, int> labelcount;
-
-    ttab.SetFromType("INT");
-    ttab.SetToType("SYB");
 
     bool hasFormalCharges = false;
     for (atom = mol.BeginAtom(i);atom;atom = mol.NextAtom(i))
@@ -701,7 +701,7 @@ namespace OpenBabel
         strcpy(rnum,"1");
 
         str = atom->GetType();
-        ttab.Translate(str1,str);
+        trans.Translate(str1,str);
 
         if (atom->GetFormalCharge() != 0) hasFormalCharges = true;
         //

--- a/src/formats/mpdformat.cpp
+++ b/src/formats/mpdformat.cpp
@@ -24,6 +24,7 @@ GNU General Public License for more details.
 #include <openbabel/atom.h>
 #include <openbabel/elements.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 #include <cstdlib>
 
 
@@ -204,12 +205,11 @@ namespace OpenBabel
     OBMol &mol = *pmol;
 
     OBAtom *atom,*nbr,*nbr2; // define atom and neghbour atom pointers
+    OBTranslator trans("INT", "SBN");
     string str,src,name;     // str used for output, src for handling
     unsigned int orig,otyp;  // orig holds first index for removal from layer 2, otype for output
     //    char buffer[BUFF_SIZE];
     bool xml_true=false, pre_true=false, idx_true=false;
-    ttab.SetFromType("INT");
-    ttab.SetToType("SBN");
     int layer[LAYER_DEPTH][LAYER_SIZE]; // layer stores the frequencies of each atom type
     ClearLayer(layer);
 
@@ -227,7 +227,7 @@ namespace OpenBabel
 		if(pConv->IsOption("i")) // using IDX not SBN
       {
         idx_true=true;
-        ttab.SetToType("IDX");
+        trans.SetToType("IDX");
       }
 
     str = mol.GetTitle();
@@ -256,7 +256,7 @@ namespace OpenBabel
     for (atom = mol.BeginAtom(i);atom;atom = mol.NextAtom(i))
       {
         src = atom->GetType();
-        ttab.Translate(str,src);
+        trans.Translate(str,src);
         // if (idx_true==true){
         otyp = atoi(str.c_str());
         //}
@@ -269,7 +269,7 @@ namespace OpenBabel
         for (nbr = atom->BeginNbrAtom(j);nbr;nbr = atom->NextNbrAtom(j))
           {
             src = nbr->GetType();
-            ttab.Translate(str,src);
+            trans.Translate(str,src);
             // if (idx_true==true){
             otyp = atoi(str.c_str());
             //}
@@ -281,7 +281,7 @@ namespace OpenBabel
               {
                 if (nbr2->GetIdx()==orig) continue;
                 src = nbr2->GetType();
-                ttab.Translate(str,src);
+                trans.Translate(str,src);
                 // if (idx_true==true){
                 otyp = atoi(str.c_str());
                 //}

--- a/src/formats/orcaformat.cpp
+++ b/src/formats/orcaformat.cpp
@@ -135,7 +135,6 @@ namespace OpenBabel
     std::vector<double> CDWavelength, CDVelosity, CDStrengthsLength;
     // frequencies and normal modes
     std::vector<double> FrequenciesAll;
-    int nModeAll = 0;
 
     //MO data
     bool m_openShell = false;
@@ -325,7 +324,6 @@ namespace OpenBabel
                 ifs.getline(buffer,BUFF_SIZE);
                 tokenize(vs,buffer);
             }
-            nModeAll = FrequenciesAll.size();
 
         } // if "VIBRATIONAL FREQUENCIES"
 

--- a/src/formats/pcmodelformat.cpp
+++ b/src/formats/pcmodelformat.cpp
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 #include <openbabel/atom.h>
 #include <openbabel/elements.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 #include <openbabel/obiter.h>
 #include <openbabel/bond.h>
 #include <cstdlib>
@@ -80,6 +81,7 @@ namespace OpenBabel
     string temp, temp2;
 
     OBAtom *atom;
+    OBTranslator trans;
     vector<string> vs;
     double x, y, z;
     unsigned int token;
@@ -87,7 +89,7 @@ namespace OpenBabel
     bool parsingBonds, readingMol = false;
     bool hasPartialCharges = false;
 
-    ttab.SetFromType("PCM");
+    trans.SetFromType("PCM");
 
     mol.BeginModify();
 
@@ -102,7 +104,6 @@ namespace OpenBabel
           }
         else if (readingMol && strncmp(buffer,"}", 1) == 0)
           {
-            readingMol = false;
             break;
           }
         else if (readingMol && strncmp(buffer,"AT ",3) == 0)
@@ -113,12 +114,12 @@ namespace OpenBabel
 
             atom = mol.NewAtom();
             temp = vs[2].c_str();
-            ttab.SetToType("INT");
-            ttab.Translate(temp2, temp);
+            trans.SetToType("INT");
+            trans.Translate(temp2, temp);
             atom->SetType(temp2);
 
-            ttab.SetToType("ATN");
-            ttab.Translate(temp2, temp);
+            trans.SetToType("ATN");
+            trans.Translate(temp2, temp);
             atom->SetAtomicNum(atoi(temp2.c_str()));
             x = atof(vs[3].c_str());
             y = atof(vs[4].c_str());
@@ -191,6 +192,7 @@ namespace OpenBabel
     ostream &ofs = *pConv->GetOutStream();
     OBMol &mol = *pmol;
     OBAtom *nbr;
+    OBTranslator trans;
     vector<OBBond*>::iterator j;
     string type, temp;
     int nbrIdx, atomIdx;
@@ -200,13 +202,13 @@ namespace OpenBabel
     ofs << "NA " << mol.NumAtoms() << endl;
     ofs << "ATOMTYPES 1" << endl; // MMX atom types
 
-    ttab.SetFromType("INT");
-    ttab.SetToType("PCM");
+    trans.SetFromType("INT");
+    trans.SetToType("PCM");
 
     string str,str1;
     FOR_ATOMS_OF_MOL(atom, mol)
       {
-        ttab.Translate(type,atom->GetType());
+        trans.Translate(type,atom->GetType());
         atomIdx = atom->GetIdx();
 
         ofs << "AT " << atom->GetIdx() << "," << type << ":";

--- a/src/formats/pdbqtformat.cpp
+++ b/src/formats/pdbqtformat.cpp
@@ -578,7 +578,6 @@ namespace OpenBabel
           OutputGroup(mol, ofs, (*tree.find(*it)).second.atoms, new_order, !preserve_original_index);
         }
       }
-      unsigned int child=i;
       for (vector <unsigned int>::iterator it=(*tree.find(i)).second.parents.end(); it != (*tree.find(i)).second.parents.begin(); )
       {
         --it;

--- a/src/formats/povrayformat.cpp
+++ b/src/formats/povrayformat.cpp
@@ -804,7 +804,6 @@ namespace OpenBabel
     //Define some references so we can use the old parameter names
     ostream &ofs = *pConv->GetOutStream();
     OBMol &mol = *pmol;
-    const char* title = pmol->GetTitle();
 
     static long num = 0;
     double min_x, max_x, min_y, max_y, min_z, max_z; /* Edges of bounding box */

--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -652,10 +652,10 @@ namespace OpenBabel {
     // Add the data stored inside the _squarePlanarMap to the atoms now after end
     // modify so they don't get lost.
     if(!_squarePlanarMap.empty()) {
-      OBAtom* atom;
+//      OBAtom* atom;
       map<OBAtom*, OBSquarePlanarStereo::Config*>::iterator ChiralSearch;
       for(ChiralSearch = _squarePlanarMap.begin(); ChiralSearch != _squarePlanarMap.end(); ++ChiralSearch) {
-        atom = ChiralSearch->first;
+//        atom = ChiralSearch->first;
         OBSquarePlanarStereo::Config *sp = ChiralSearch->second;
         if (!sp)
           continue;

--- a/src/formats/tinkerformat.cpp
+++ b/src/formats/tinkerformat.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include <openbabel/bond.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 #include <openbabel/generic.h>
 
 #include <openbabel/forcefield.h>
@@ -170,6 +171,7 @@ namespace OpenBabel
     unsigned int i;
     char buffer[BUFF_SIZE];
     OBBond *bond;
+    OBTranslator trans;
     vector<OBBond*>::iterator j;
 
     // Before we try output of MMFF94 atom types, check if it works
@@ -191,7 +193,7 @@ namespace OpenBabel
       snprintf(buffer, BUFF_SIZE, "%6d %-20s   MMFF94 parameters\n",mol.NumAtoms(),mol.GetTitle());
     ofs << buffer;
 
-    ttab.SetFromType("INT");
+    trans.SetFromType("INT");
 
     OBAtom *atom;
     string str,str1;
@@ -203,8 +205,8 @@ namespace OpenBabel
         atomType = 0; // Something is very wrong if this doesn't get set below
 
         if (mm2Types) {
-          ttab.SetToType("MM2");
-          ttab.Translate(str1,str);
+          trans.SetToType("MM2");
+          trans.Translate(str1,str);
           atomType = atoi((char*)str1.c_str());
         }
         if (mmffTypes) {

--- a/src/formats/vaspformat.cpp
+++ b/src/formats/vaspformat.cpp
@@ -448,7 +448,6 @@ namespace OpenBabel {
           while (!strstr(buffer, "Eigenvectors")) {
             vector<vector3> vib;
             tokenize(vs, buffer);
-            int freqnum = atoi(vs[0].c_str());
             if (vs[1].size() == 1 and vs[1].compare("f") == 0) {
               // Real frequency
               Frequencies.push_back(atof(vs[7].c_str()));

--- a/src/formats/xedformat.cpp
+++ b/src/formats/xedformat.cpp
@@ -20,6 +20,7 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include <openbabel/bond.h>
 #include <openbabel/data.h>
+#include <openbabel/data_utilities.h>
 
 #include <cstdlib>
 
@@ -79,10 +80,9 @@ bool XEDFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
     int type_name, mass;
     OBAtom *atom;
     OBBond *bond;
+    OBTranslator trans("INT", "XED");
     string str,str1;
 
-    ttab.SetFromType("INT");
-    ttab.SetToType("XED");
     snprintf(buffer, BUFF_SIZE, "%10.3f%10i%10i",
             mol.GetEnergy(),mol.NumAtoms(),mol.NumBonds());
     ofs << buffer << endl;
@@ -105,7 +105,7 @@ bool XEDFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
     {
         atom = mol.GetAtom(i);
         str = atom->GetType();
-        ttab.Translate(str1,str);
+        trans.Translate(str1,str);
 
         type_name = atoi((char*) str1.c_str());
         switch (type_name)

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -421,7 +421,6 @@ namespace OpenBabel
     int k,l,m;
     double x,y,z,dx_2,dy_2;
     double *c = mol.GetCoordinates();
-    size = mol.NumAtoms()*3;
 
     OBAtom *atom;
     vector<OBAtom*>::iterator i;
@@ -457,7 +456,6 @@ namespace OpenBabel
     int k,l,m;
     double x,y,z,dx_2,dy_2;
     double *c = mol.GetCoordinates();
-    size = mol.NumAtoms()*3;
 
     OBAtom *atom;
     vector<OBAtom*>::iterator i;

--- a/src/kekulize.cpp
+++ b/src/kekulize.cpp
@@ -91,7 +91,6 @@ namespace OpenBabel
     // Does it already have an explicit double bond?
     FOR_BONDS_OF_ATOM(bond, atom) {
       if (bond->IsAromatic()) continue;
-      OBAtom *nbr = bond->GetNbrAtom(atom);
       switch (bond->GetBondOrder()) {
       case 0: case 1:
         continue;

--- a/src/locale.cpp
+++ b/src/locale.cpp
@@ -76,6 +76,8 @@ namespace OpenBabel
    * to SetLocale() and the last call to RestoreLocale() will do any work.
    **/
 
+  std::mutex OBLocale::LocaleMutex;
+
   OBLocale::OBLocale()
   {
     d = new OBLocalePrivate;
@@ -91,6 +93,8 @@ namespace OpenBabel
 
   void OBLocale::SetLocale()
   {
+    std::lock_guard<std::mutex> lock(LocaleMutex);
+
     if (d->counter == 0) {
       // Set the locale for number parsing to avoid locale issues: PR#1785463
 #if HAVE_USELOCALE
@@ -114,6 +118,8 @@ namespace OpenBabel
 
   void OBLocale::RestoreLocale()
   {
+    std::lock_guard<std::mutex> lock(LocaleMutex);
+
     --d->counter;
     if(d->counter == 0) {
       // return the locale to the original one

--- a/src/math/matrix3x3.cpp
+++ b/src/math/matrix3x3.cpp
@@ -645,7 +645,6 @@ namespace OpenBabel
 
     // Now sort the eigenvalues (and the eigenvectors) so that the
     // smallest eigenvalues come first.
-    nrot = l;
 
     for (j = 0; j < static_cast<int>(n)-1; j++)
       {

--- a/src/mcdlutil.cpp
+++ b/src/mcdlutil.cpp
@@ -1836,7 +1836,6 @@ namespace OpenBabel {
       return result;
     };
     test=false;
-    i=0;
     j=getAtom(atomDetected[n])->na;
     for (i=0; i<NAROMMAX; i++) if (j == possibleAromatic[i]) {
         test=true;
@@ -2196,7 +2195,7 @@ namespace OpenBabel {
     int atomSecond;
 
     double r,cf,fi,ux,uy,ux1,uy1,ux2,uy2,uvX,uvY,c,s;
-    double xCenterOld,yCenterOld,xCenterNew,yCenterNew,bondLengthOld,bondLengthNew;
+    double xCenterOld,yCenterOld,xCenterNew,yCenterNew,bondLengthOld;
     neighbourlist *bk;
     int n,n1,n2;
     double r1;
@@ -2216,7 +2215,6 @@ namespace OpenBabel {
     defineAtomConn();
     allAboutCycles();
 
-    test=true;
     bk = (neighbourlist *)malloc(nAtoms() * sizeof(adjustedlist));
     defineBondConn(bk);
     //{Start clean for LISTATOMCLEAN and LISTBONDCLEAN atoms and bonds}
@@ -2418,7 +2416,6 @@ namespace OpenBabel {
               if ((ux==0) && (uy==0)) ux=1;
               fi=(k-nb-1)*PI/(double)k;
               //Addition for fluorine chain fragments...
-              isChainFour=false;
               n=0; mm1=-1; mm2=-1; mAny=-1;
               if ((k == 4) && (getAtom(k1)->na == 6))  for (j=0; j<getAtom(k1)->nb; j++) {
                   n1=getAtom(k1)->ac[j];
@@ -2449,7 +2446,6 @@ namespace OpenBabel {
                 isCycle=(n == 2);
               };
               if (isChainFour) {
-                n=0;
                 fi=PI/3;
                 ux1= ux*cos(fi)+uy*sin(fi);
                 uy1=-ux*sin(fi)+uy*cos(fi);
@@ -2625,18 +2621,14 @@ namespace OpenBabel {
         }
         i++;
       }
-    bondLengthNew=0;
 
     //Rescaling and shift of structure
-    for (i=0; i<bondClean; i++)  bondLengthNew=bondLengthNew+bondLength(listBondClean[i]);
-    bondLengthNew=bondLengthNew/(double)bondClean;
     xCenterNew=0; yCenterNew=0;
     for (i=0; i<atomClean; i++) {
       xCenterNew=xCenterNew+getAtom(listAtomClean[i])->rx;
       yCenterNew=yCenterNew+getAtom(listAtomClean[i])->ry;
     };
     xCenterNew=xCenterNew/(double)atomClean; yCenterNew=yCenterNew/(double)atomClean;
-    bondLengthNew=0.15*bondLengthOld;
     //IOPT[7]-controlles, whether or not the atom's shifts should be created, if coordinates of pair of atoms are identical
     if (spn==3) {                     //Rescaling and shift coordinates for group (CODE=3)
       xCenterNew=getAtom(sCHA1)->rx;
@@ -2962,14 +2954,12 @@ namespace OpenBabel {
     //part flip is executed. Case CHB-ring bond-no effects}
 
     int cHA1, cHA2, n;
-    bool test;
     std::vector<int>list1(listarSize());
     double r, xc, yc, xo, yo, xn, yn;
     int i;
 
     if (cHB < 0) return;
 
-    test=makeFragment(list1,getBond(cHB)->at[1],getBond(cHB)->at[0]);
     if (list1.size() > 1) {
       //One of the atoms haven't neighbours-flip unavalable
       cHA1=getBond(cHB)->at[0];
@@ -3170,7 +3160,6 @@ namespace OpenBabel {
     aDist[att]=0;
     k=0;
     atomoBond[att]=a[att];
-    testOK=false;
     test=true;
 
     while (test) {
@@ -3186,7 +3175,6 @@ namespace OpenBabel {
               if ((aDist[i2] >= k) && (aDist[i2] <= 65700)) {
                 //if the neighbour has not been added yet to list}
                 aDist[i2]=k;          //Mark neighbour's sphere number
-                jj=0;
                 test=true;
                 for (jj=1; jj<=3; jj++) {
                   if (((*aPrev[jj-1])[i2] == -1) || (jj == 3)) {
@@ -3351,7 +3339,6 @@ namespace OpenBabel {
 
     r=averageBondLength()/blDenominator;
     k=hasOverlapped(r,false);
-    result=k;
     smCopy->moleculeCopy(*this);
     test=true;
     while (test) {
@@ -4366,7 +4353,6 @@ namespace OpenBabel {
       xu2=-xu2; yu2=-yu2;
       r1=xu1*xu2+yu1*yu2;
       r2=yu1*xu2-xu1*yu2;
-      nBondsOld=this->nBonds();
       nAtomsOld=this->nAtoms();
       if (isAddition) mouseButton=1; else mouseButton=2;
 
@@ -4376,15 +4362,13 @@ namespace OpenBabel {
 
       if (isAddition) {
         this->addBond(1,nAtomsOld,thisAN);
-      } else nAtomsOld=nAtomsOld-1;
+      }
     } else if ((smBN >= 0) && (thisBN >= 0)) {       //connection through bonds
       this->bondUnitVector(thisBN,xu1,yu1);
       fragmentMol.bondUnitVector(smBN,xu2,yu2);
       xu2=-xu2; yu2=-yu2;
       r1=xu1*xu2+yu1*yu2;
       r2=yu1*xu2-xu1*yu2;
-      nBondsOld=this->nBonds();
-      nAtomsOld=this->nAtoms();
       addFragment(fragmentMol,list.size(),thisAN,thisBN,smBN,list,
                   xOld,yOld,xNew,yNew,scale,r1,r2,1,false);
     }
@@ -7149,7 +7133,6 @@ namespace OpenBabel {
     };
     std::vector<int> allAtomList(sm.nAtoms(), 0);
     std::vector<int>    atomList(sm.nAtoms(), 0);
-    n=0;
     if (sm.getBond(bondN)->at[0] == atomN) {
       at=sm.getBond(bondN)->at[0];
       atEx=sm.getBond(bondN)->at[1];

--- a/src/mcdlutil.cpp
+++ b/src/mcdlutil.cpp
@@ -4593,7 +4593,6 @@ namespace OpenBabel {
       //Store NO OTHER atom attribute
       for (i=0; i<nAtoms(); i++) getAtom(queryAQTested[i])->special=aSTested[i];
       defineBondConn(queryBK);
-      j=0;
       //Search for last non-special atom in query}
       queryStereoQ=stereoBondChange(); //Stereo bond conversion
     };
@@ -4856,8 +4855,6 @@ namespace OpenBabel {
       for (int j=0; j<nBonds(); ++j)
         bEQ[i][j] = false;
     }
-
-    cycleNumber=0;
 
     molecule1->fIOPT11=fIOPT11;
     molecule1->fIOPT12=fIOPT13;

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -2533,6 +2533,7 @@ namespace OpenBabel
         end = GetAtom(second);
         if (!bgn || !end)
           {
+            delete bond;
             obErrorLog.ThrowError(__FUNCTION__, "Unable to add bond - invalid atom index", obDebug);
             return(false);
           }

--- a/src/obmolecformat.cpp
+++ b/src/obmolecformat.cpp
@@ -167,7 +167,6 @@ namespace OpenBabel
                                   auditMsg,
                                   obInfo);
           }
-        ret=true;
 
         ret = DoOutputOptions(pOb, pConv);
 

--- a/src/ops/largest.cpp
+++ b/src/ops/largest.cpp
@@ -32,25 +32,26 @@ namespace OpenBabel
 class OpLargest : public OBOp
 {
 public:
-  OpLargest(const char* ID) : OBOp(ID, false){};
+  OpLargest(const char* ID) : OBOp(ID, false) {
+    description = (strcmp(ID,"largest")!=0) ?
+    "# <descr> Output # mols with smallest values of descriptor(not displayed in GUI)\n"
+    "    obabel infile.xxx -Ooutfile.yyy --smallest 5 MW\n"
+    "will convert only the molecules with the 5 smallest molecular weights.\n" :
+    "# <descr> Output # mols with largest values\n"
+    "of a descriptor <descr>. For example:\n"
+    "    obabel infile.xxx -Ooutfile.yyy --largest 5 MW\n"
+    "will convert only the molecules with the 5 largest molecular weights.\n";
+    description +=
+    "A property (OBPairData) can be used instead of a descriptor, but\n"
+    "must be present in the first molecule. If the number is omitted,\n"
+    "1 is assumed.\n"
+    "The parameters can be in either order.\n"
+    "Preceding the descriptor by ~ inverts the comparison. (Use this form in the GUI.)\n"
+    "If a + follows the descriptor, e.g. MW+ , the value will be added to the title.\n";
+  };
   const char* Description()
   {
     //Need to use a member variable so that const char* is valid when it is returned
-    description = (strcmp(GetID(),"largest")!=0) ?
-     "# <descr> Output # mols with smallest values of descriptor(not displayed in GUI)\n"
-     "    obabel infile.xxx -Ooutfile.yyy --smallest 5 MW\n"
-     "will convert only the molecules with the 5 smallest molecular weights.\n" :
-     "# <descr> Output # mols with largest values\n"
-     "of a descriptor <descr>. For example:\n"
-     "    obabel infile.xxx -Ooutfile.yyy --largest 5 MW\n"
-     "will convert only the molecules with the 5 largest molecular weights.\n";
-    description +=
-     "A property (OBPairData) can be used instead of a descriptor, but\n"
-     "must be present in the first molecule. If the number is omitted,\n"
-     "1 is assumed.\n"
-     "The parameters can be in either order.\n"
-     "Preceding the descriptor by ~ inverts the comparison. (Use this form in the GUI.)\n"
-     "If a + follows the descriptor, e.g. MW+ , the value will be added to the title.\n";
     return description.c_str();
   }
 

--- a/src/ops/optransform.cpp
+++ b/src/ops/optransform.cpp
@@ -28,12 +28,7 @@ namespace OpenBabel
   const char* OpTransform::Description()
   {
     //Adds name of datafile containing SMARTS strings to the description
-    static std::string txt;
-    txt =  _descr;
-    txt += "\n Datafile: ";
-    txt += _filename;
-    txt += "\nOpTransform is definable";
-    return txt.c_str();
+    return _alldescr.c_str();
   }
 
 bool OpTransform::Initialize()

--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -443,7 +443,7 @@ namespace OpenBabel
 
   static int CreateAtom( Pattern *pat, AtomExpr *expr, int part,int vb)
   {
-    int index,size;
+    int index;
 
     if (!pat)
       return -1; // should never happen
@@ -451,7 +451,6 @@ namespace OpenBabel
     if( pat->acount == pat->aalloc )
       {
         pat->aalloc += ATOMPOOL;
-        size = (int)(pat->aalloc*sizeof(AtomSpec));
         if( pat->atom )
           {
             AtomSpec *tmp = new AtomSpec[pat->aalloc];
@@ -475,7 +474,7 @@ namespace OpenBabel
 
   static int CreateBond( Pattern *pat, BondExpr *expr, int src, int dst )
   {
-    int index,size;
+    int index;
 
     if (!pat)
       return -1; // should never happen
@@ -483,7 +482,6 @@ namespace OpenBabel
     if( pat->bcount == pat->balloc )
       {
         pat->balloc += BONDPOOL;
-        size = (int)(pat->balloc*sizeof(BondSpec));
         if( pat->bond )
           {
             BondSpec *tmp = new BondSpec[pat->balloc];

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -43,8 +43,12 @@ OBPlugin::PluginMapType& OBPlugin::GetTypeMap(const char* PluginID)
 
 int OBPlugin::AllPluginsLoaded = 0;
 
+mutex OBPlugin::PluginMutex;
+
 void OBPlugin::LoadAllPlugins()
 {
+  lock_guard<mutex> lock(PluginMutex);
+
   int count = 0;
 #if  defined(USING_DYNAMIC_LIBS)
   // Depending on availability, look successively in

--- a/src/reactionfacade.cpp
+++ b/src/reactionfacade.cpp
@@ -119,7 +119,6 @@ namespace OpenBabel
     std::set<unsigned int> unassigned_components;
 
     FOR_ATOMS_OF_MOL(atom, _mol) {
-      OBAtom* atm = &*atom;
       unsigned int component = GetComponentId(&*atom);
       switch (GetRole(&*atom)) {
       case REACTANT:


### PR DESCRIPTION
Currently, this pull request make only some of the openbabel objects thread-safe: `OpenBabel::OBConversion` and `OpenBabel::OBGlobalDataBase`. I will keep working on this topic for the rest of the objects and update this PR.

Important note: this commit will change the API interface of openbabel.