### PR TITLE
Fixed crash in obthermo due to pointgroup code.

### DIFF
--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -24,7 +24,6 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include <openbabel/generic.h>
 
-#include <openbabel/pointgroup.h>
 #include <cstdlib>
 
 using namespace std;
@@ -332,18 +331,9 @@ namespace OpenBabel
         S0MT += 1000*eFactor*(Hcorr-Gcorr)/temperature;
     }
 
-    // Check for symmetry
-    OBPointGroup obPG;
-
-    obPG.Setup(mol);
-    const char *pg = obPG.IdentifyPointGroup();
-
     double Rgas = 1.9872041; // cal/mol K http://en.wikipedia.org/wiki/Gas_constant
     double Srot = -Rgas * log(double(RotSymNum));
 
-
-    //printf("DHf(M,0) = %g, DHf(M,T) = %g, S0(M,T) = %g\nPoint group = %s RotSymNum = %d Srot = %g\n",
-    //       dhofM0, dhofMT, S0MT, pg, RotSymNum, Srot);
     if (RotSymNum > 1)
     {
         // We assume Gaussian has done this correctly!

--- a/tools/obthermo.cpp
+++ b/tools/obthermo.cpp
@@ -26,7 +26,6 @@ GNU General Public License for more details.
 #include <openbabel/mol.h>
 #include <openbabel/obconversion.h>
 #include <openbabel/data_utilities.h>
-#include <openbabel/pointgroup.h>
 #include <cstdlib>
 #ifndef _MSC_VER
   #include <unistd.h>
@@ -126,19 +125,15 @@ int main(int argc,char **argv)
   OBMol mol;
   if ((conv.Read(&mol, &ifs)) && ! mol.Empty())
   {
-      OBPointGroup obPG;
       double temperature, DeltaHf0, DeltaHfT, DeltaGfT, DeltaSfT, S0T, CVT, CPT, ZPVE;
       std::vector<double> Scomponents;
       
-      obPG.Setup(&mol);
       printf("obthermo - extract thermochemistry data from quantum chemistry logfiles\n");
       printf("Number of rotatable bonds: %d\n", Nrot);
       if (dBdT == 0)
       {
           printf("Please supply --dbdt option to get reliable heat capacity at constant pressure.\n");
       }
-      printf("Point group according to OpenBabel: %s\n", 
-             obPG.IdentifyPointGroup());
       bool bVerbose = true;
       if (extract_thermochemistry(mol, 
                                   bVerbose,


### PR DESCRIPTION
The pointgroup code has been disabled in obthermo because a
crash  was introduced relating to the link between OBatom and
OBmol.