### PR TITLE
Fix hydrogen suppression when specifying SMILES atom order

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -2847,7 +2847,7 @@ namespace OpenBabel {
 
     // Add extra hydrogens.
     int hcount = numImplicitHs;
-    if (hcount > 0 && (atom == _endatom || atom == _startatom)) // Leave a free valence for attachment
+    if (hcount > 0 && (atom == _endatom || (atom == _startatom && !options.ordering))) // Leave a free valence for attachment
       hcount--;
     if (hcount > 0) {
       if (options.smarts && stereo == nullptr) {


### PR DESCRIPTION
Ensure that specifying the output atom order in SMILES does not cause any hydrogens to be suppressed. This occurred if the atom written first was a bracket atom with a hydrogen count:
```
$ obabel  -:"c1[nH]ccc1" -osmi -xo "2-3-4-5-1"
[n]1cccc1
```
