### PR TITLE
Fix missing atom pybel properties.

### DIFF
--- a/scripts/python/openbabel/pybel.py
+++ b/scripts/python/openbabel/pybel.py
@@ -717,7 +717,7 @@ class Atom(object):
     Attributes:
        atomicmass, atomicnum, cidx, coords, coordidx, degree, exactmass,
        formalcharge, heavydegree, heterodegree, hyb, idx,
-       implicitvalence, isotope, partialcharge, residue, spin, type,
+       explicitvalence, totalvalence, isotope, partialcharge, residue, spin, type,
        vector.
 
     (refer to the Open Babel library documentation for more info).
@@ -743,7 +743,7 @@ class Atom(object):
 
     @property
     def cidx(self):
-        return self.OBAtom.GetCIdx()
+        raise AttributeError("This property is no longer available.")
 
     @property
     def coordidx(self):
@@ -786,8 +786,16 @@ class Atom(object):
         return self.OBAtom.GetIdx()
 
     @property
-    def implicitvalence(self):
-        return self.OBAtom.GetImplicitValence()
+    def index(self):
+        return self.OBAtom.GetIndex()
+    
+    @property
+    def explicitvalence(self):
+        return self.OBAtom.GetExplicitValence()
+        
+    @property
+    def totalvalence(self):
+        return self.OBAtom.GetTotalValence()
 
     @property
     def isotope(self):

--- a/test/testbindings.py
+++ b/test/testbindings.py
@@ -1071,6 +1071,28 @@ class AtomClass(PythonBindings):
     """Tests to ensure that refactoring the atom class handling retains
     functionality"""
 
+    def testAtomProperties(self):
+        mol = pybel.readstring("smi","C=C")
+        #some of these weren't working after 3.0
+        a =  mol.atoms[0]
+        self.assertEqual(a.atomicmass,12.0107)
+        self.assertEqual(a.atomicnum,6)
+        self.assertEqual(a.coordidx,0)
+        self.assertEqual(a.degree, 1)
+        self.assertEqual(a.exactmass, 12.0)
+        self.assertEqual(a.formalcharge, 0)
+        self.assertEqual(a.heavydegree,1)
+        self.assertEqual(a.heterodegree,0)
+        self.assertEqual(a.hyb, 2)
+        self.assertEqual(a.idx, 1)
+        self.assertEqual(a.totalvalence, 4)
+        self.assertEqual(a.explicitvalence, 2)
+        self.assertEqual(a.isotope, 0)
+        self.assertEqual(a.partialcharge, 0.0)
+        self.assertEqual(a.spin, 0)
+        self.assertEqual(a.type, 'C2')
+        self.assertEqual(a.index, 0)
+
     def testSMILES(self):
         mol = pybel.readstring("smi", "C[CH3:6]")
         atom = mol.OBMol.GetAtom(2)


### PR DESCRIPTION
Some properties (e.g. implicitvalence) are no longer available.
Also added index as a property and a test.