### PR TITLE
Fix ring iterations w/no rings

### DIFF
--- a/src/obiter.cpp
+++ b/src/obiter.cpp
@@ -1019,7 +1019,7 @@ namespace OpenBabel
       \endcode
   **/
 
-  OBMolRingIter::OBMolRingIter(OBMol *mol): _parent(mol)
+  OBMolRingIter::OBMolRingIter(OBMol *mol): _parent(mol), _ptr(nullptr)
   {
     if (!_parent->HasSSSRPerceived())
       _parent->FindSSSR();
@@ -1029,7 +1029,7 @@ namespace OpenBabel
       _ptr = _rings->BeginRing(_i);
   }
 
-  OBMolRingIter::OBMolRingIter(OBMol &mol): _parent(&mol)
+  OBMolRingIter::OBMolRingIter(OBMol &mol): _parent(&mol), _ptr(nullptr)
   {
     if (!_parent->HasSSSRPerceived())
       _parent->FindSSSR();

--- a/test/iterators.cpp
+++ b/test/iterators.cpp
@@ -149,7 +149,15 @@ int iterators(int argc, char* argv[])
                << " but found " << counter << '\n';
         else
           cout << "ok " << ++currentTest << '\n';
-      } // if (have rings)
+      } else {// if (have rings)
+          //if no rings, iterator should still work
+          unsigned cnt = 0;
+          FOR_RINGS_OF_MOL(ring, mol) {
+              cnt++;
+          }
+          if(cnt != 0) cout << "not ok " << ++currentTest
+                  << " iterated over ringless molecule ";
+      }
     }
 
   // output the number of tests run


### PR DESCRIPTION
The constructor was not initializing _ptr to null, and this is what was
used to test the validity of the iterator.  This caused iteration over a
ringless molecule (e.g. empty) to sometimes fail (segfault or infinite
loop).  But not always.