### PR TITLE
Update descriptions of formats

### DIFF
--- a/src/formats/copyformat.cpp
+++ b/src/formats/copyformat.cpp
@@ -42,7 +42,7 @@ public:
 "  Extract only structures that include at least one aromatic carbon\n"
 "  (by matching the SMARTS pattern ``[c]``)::\n\n"
 
-"   babel -s '[c]' database.sdf -ocopy new.sd\n\n"
+"   obabel database.sdf -ocopy -O new.sdf -s '[c]' \n\n"
 
 ".. note::\n\n"
 " XML files may be missing non-object elements\n"

--- a/src/formats/fastsearchformat.cpp
+++ b/src/formats/fastsearchformat.cpp
@@ -430,7 +430,7 @@ virtual const char* Description() //required
                   "Currently, updating is only done on index files that"
                   "have the same name as the datafile.\n"
                   "Do not specify an output file; use the form:\n"
-	                "   babel datafile.xxx -ofs -xu", obError);
+	                "   obabel datafile.xxx -ofs -xu", obError);
                 return false;
               }
           }

--- a/src/formats/fingerprintformat.cpp
+++ b/src/formats/fingerprintformat.cpp
@@ -45,13 +45,13 @@ namespace OpenBabel
 
 "A list of available fingerprint types can be obtained by::\n\n"
 
-"  babel -L fingerprints\n\n"
+"  obabel -L fingerprints\n\n"
 
 "The current default type FP2 is is of the Daylight type, indexing a molecule\n"
 "based on the occurrence of linear fragment up to 7 atoms in length. To use a\n"
 "fingerprint type other than the default, use the ``-xf`` option, for example::\n\n"
 
-"  babel infile.xxx -ofpt -xfFP3\n\n"
+"  obabel infile.xxx -ofpt -xfFP3\n\n"
 
 "For a single molecule the fingerprint is output in hexadecimal form\n"
 "(intended mainly for debugging).\n\n"

--- a/src/formats/getinchi.cpp
+++ b/src/formats/getinchi.cpp
@@ -47,7 +47,7 @@ extraneous characters inserted, for example because of word wrapping,
 provided it follows certain rules.
 
 When this file (getinchi.cpp) is read, 15 InChIs will be extracted, e.g.
- babel -iinchi getinchi.cpp -osmi
+ obabel -iinchi getinchi.cpp -osmi
 
 Inside an InChI string ignore anything between < and >
 This means that an InChI string can be split up by inserting any number of <br /> elements:

--- a/src/formats/pngformat.cpp
+++ b/src/formats/pngformat.cpp
@@ -422,7 +422,7 @@ files in any format. Each can contain multiple molecules. Each molecule is outpu
 in a separate chunk in a format specified by the -xO option. the default with no
 option is InChI. The chunk ID is normally tEXt but can be specified in the -xa option.
 For example
-  babel OrigImg.png Firstmol.smi Secondmol.mol2 OutImg.png -xO "cml" -xa "chEm"
+  obabel OrigImg.png Firstmol.smi Secondmol.mol2 OutImg.png -xO "cml" -xa "chEm"
 
 It should be possible to embed into png filesusing the API.
 The following is simplified and UNTESTED:

--- a/src/formats/svgformat.cpp
+++ b/src/formats/svgformat.cpp
@@ -56,7 +56,7 @@ public:
 
       "Multiple molecules are displayed in a grid of dimensions specified by\n"
       "the ``-xr`` and ``-xc`` options (number of rows and columns respectively\n"
-      "and ``--rows``, ``--cols`` with babel).\n"
+      "and ``--rows``, ``--cols`` with obabel).\n"
       "When displayed in most modern browsers, like Firefox, there is\n"
       "javascript support for zooming (with the mouse wheel)\n"
       "and panning (by dragging with the left mouse button).\n\n"
@@ -196,7 +196,7 @@ bool SVGFormat::WriteChemObject(OBConversion* pConv)
 
     pConv->AddOption("svgbswritechemobject"); // to show WriteMolecule that this function has been called
     const char* pc = pConv->IsOption("c");
-    //alternative for babel because -xc cannot take a parameter, because some other format uses it
+    //alternative for obabel because -xc cannot take a parameter, because some other format uses it
     //similarly for -xr -xp
     if(!pc)
       pc = pConv->IsOption("cols", OBConversion::GENOPTIONS);

--- a/src/formats/textformat.cpp
+++ b/src/formats/textformat.cpp
@@ -30,7 +30,7 @@ public:
   {
     return
      "Read and write raw text\n"
-     "Facilitates the input of boilerplate text with babel commandline" ;
+     "Facilitates the input of boilerplate text with obabel commandline" ;
   }
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Some format descriptions still use the obsolete command `babel` in their example or other parts. This PR updates the descriptions and comments of 7 formats: `copy`, `fs`, `fpt`, `inchi`, `png`, `svg`, and `text`. 