### PR TITLE
Replacing deprecated set-env and set-path commands

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -56,7 +56,7 @@ jobs:
       if: runner.os == 'Windows'
       run: |
         choco install ninja
-        echo "::set-env name=DEPS::msvc-dependencies-master"
+        echo "DEPS=msvc-dependencies-master" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Install Dependencies (macOS)
       if: runner.os == 'macOS'

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -52,6 +52,7 @@ jobs:
     - name: Install Dependencies (Linux)
       if: runner.os == 'Linux'
       run: sudo apt-get -qq install ninja-build swig libeigen3-dev libboost-all-dev
+
     - name: Install Dependencies (Windows)
       if: runner.os == 'Windows'
       run: |

--- a/.github/workflows/misspell-fixer.yml
+++ b/.github/workflows/misspell-fixer.yml
@@ -11,6 +11,6 @@ jobs:
       uses: sobolevn/misspell-fixer-action@master
       with:
         options: '-rsvn include/openbabel src tools'
-    - uses: peter-evans/create-pull-request@v2.4.4
+    - uses: peter-evans/create-pull-request@v3.8.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For the GitHub workflows, the `set-env` and `set-path` commands have been deprecated and removed.

- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/

This PR replaces one `set_env` command in the `build_cmake.yml` according to the GitHub Environment Files documentation.

- https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#environment-files

Also, the `peter-evans/create-pull-request` has also been updated to 3.8.0 as well for this issue.