### PR TITLE
use pip to install python interface without pre-installing c++ interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,10 +418,15 @@ if(UNIX AND BUILD_SHARED)
   if(APPLE)
     set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR})
   else()
+    if(BUILD_BY_PIP)
+      set(CMAKE_INSTALL_RPATH "\$ORIGIN/../${LIB_INSTALL_DIR}:\$ORIGIN/${LIB_INSTALL_DIR}:\$ORIGIN/../../")
+      set(DCMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    else()
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}")
     set(CMAKE_SKIP_BUILD_RPATH FALSE)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+    endif()
   endif()
 endif()
 
@@ -708,6 +713,9 @@ option(PHP_BINDINGS "Build PHP bindings" OFF)
 
 # Should Python bindings be built?
 option(PYTHON_BINDINGS "Build Python bindings" OFF)
+
+# Build by pip
+option(BUILD_BY_PIP "Build by pip" OFF)
 
 # Should Ruby bindings be built?
 option(RUBY_BINDINGS "Build Ruby bindings" OFF)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cmake_build_extension", "cmake", "ninja"]

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -122,18 +122,23 @@ if (DO_PYTHON_BINDINGS)
         if(NOT BINDINGS_ONLY)
             add_dependencies(bindings_python openbabel)
         endif()
+		if(BUILD_BY_PIP)
+		  set(PYOBABEL_INSTDIR ".")
+		else()
+          set(PYOBABEL_INSTDIR ${PYTHON_INSTDIR}/openbabel)
+		endif()
 
         install(TARGETS bindings_python
-                LIBRARY DESTINATION ${PYTHON_INSTDIR}/openbabel
+                LIBRARY DESTINATION ${PYOBABEL_INSTDIR}
                 COMPONENT bindings_python)
         install(FILES ${openbabel_SOURCE_DIR}/scripts/python/openbabel/__init__.py
-                DESTINATION ${PYTHON_INSTDIR}/openbabel
+                DESTINATION ${PYOBABEL_INSTDIR}
                 COMPONENT bindings_python)
         install(FILES ${openbabel_SOURCE_DIR}/scripts/python/openbabel/openbabel.py
-                DESTINATION ${PYTHON_INSTDIR}/openbabel
+                DESTINATION ${PYOBABEL_INSTDIR}
                 COMPONENT bindings_python)
         install(FILES ${openbabel_SOURCE_DIR}/scripts/python/openbabel/pybel.py
-                DESTINATION ${PYTHON_INSTDIR}/openbabel
+                DESTINATION ${PYOBABEL_INSTDIR}
                 COMPONENT bindings_python)
     else(NOT WIN32)
         set_target_properties(bindings_python PROPERTIES
@@ -149,18 +154,23 @@ if (DO_PYTHON_BINDINGS)
         if(NOT BINDINGS_ONLY)
             add_dependencies(bindings_python openbabel)
         endif()
+		if(BUILD_BY_PIP)
+		  set(PYOBABEL_INSTDIR ".")
+		else()
+          set(PYOBABEL_INSTDIR ${PYTHON_INSTDIR}/openbabel)
+		endif()
 
         install(TARGETS bindings_python
-                LIBRARY DESTINATION ${PYTHON_INSTDIR}/openbabel
+                LIBRARY DESTINATION ${PYOBABEL_INSTDIR}
                 COMPONENT bindings_python)
         install(FILES ${openbabel_SOURCE_DIR}/scripts/python/openbabel/__init__.py
-                DESTINATION ${PYTHON_INSTDIR}/openbabel
+                DESTINATION ${PYOBABEL_INSTDIR}
                 COMPONENT bindings_python)
         install(FILES ${openbabel_SOURCE_DIR}/scripts/python/openbabel/openbabel.py
-                DESTINATION ${PYTHON_INSTDIR}/openbabel
+                DESTINATION ${PYOBABEL_INSTDIR}
                 COMPONENT bindings_python)
         install(FILES ${openbabel_SOURCE_DIR}/scripts/python/openbabel/pybel.py
-                DESTINATION ${PYTHON_INSTDIR}/openbabel
+                DESTINATION ${PYOBABEL_INSTDIR}
                 COMPONENT bindings_python)
         add_custom_command(TARGET bindings_python POST_BUILD
           COMMAND ${CMAKE_COMMAND} -E copy ${openbabel_SOURCE_DIR}/scripts/python/openbabel/openbabel.py ${openbabel_BINARY_DIR}/bin/${CMAKE_CFG_INTDIR}

--- a/scripts/python/openbabel/__init__.py.in
+++ b/scripts/python/openbabel/__init__.py.in
@@ -4,6 +4,12 @@ from . import openbabel
 
 __version__ = "${BABEL_VERSION}"
 
+if "${BUILD_BY_PIP}" == "ON":
+    import os
+    base_dir = os.path.abspath(os.path.dirname(__file__))
+    os.environ["BABEL_LIBDIR"] = os.path.join(base_dir, "lib")
+    os.environ["BABEL_DATADIR"] = os.path.join(base_dir, "share", "openbabel", __version__)
+
 _thismodule = sys.modules[__name__]
 
 class OBProxy(object):

--- a/scripts/python/openbabel/__init__.py.in
+++ b/scripts/python/openbabel/__init__.py.in
@@ -7,7 +7,7 @@ __version__ = "${BABEL_VERSION}"
 if "${BUILD_BY_PIP}" == "ON":
     import os
     base_dir = os.path.abspath(os.path.dirname(__file__))
-    os.environ["BABEL_LIBDIR"] = os.path.join(base_dir, "lib")
+    os.environ["BABEL_LIBDIR"] = os.path.join(base_dir, "lib", "openbabel", __version__)
     os.environ["BABEL_DATADIR"] = os.path.join(base_dir, "share", "openbabel", __version__)
 
 _thismodule = sys.modules[__name__]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+import os
+import sys
+from cmake_build_extension import BuildExtension, CMakeExtension
+from setuptools import setup
+
+# Path to scripts/python
+base_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "scripts", "python")
+
+
+setup(
+    name="openbabel",
+    version="3.1.1",
+    author='Noel O\'Boyle',
+    author_email='openbabel-discuss@lists.sourceforge.net',
+    license='GPL-2.0',
+    url='http://openbabel.org/',
+    description='Python interface to the Open Babel chemistry library',
+    long_description=open(os.path.join(base_dir, 'README.rst')).read(),
+    ext_modules=[
+        CMakeExtension(name="OpenBabel",
+                       install_prefix="openbabel",
+                       cmake_configure_options=[
+                            "-DPYTHON_EXECUTABLE=" + sys.executable,
+                            "-DCMAKE_BUILD_TYPE=Release",
+                            "-DWITH_INCHI=ON",
+                            "-DPYTHON_BINDINGS=ON",
+                            "-DRUN_SWIG=ON",
+                            "-DBUILD_BY_PIP=ON",
+                       ]),
+    ],
+    cmdclass=dict(build_ext=BuildExtension),
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Console',
+        'Environment :: Other Environment',
+        'Intended Audience :: Education',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: GNU General Public License (GPL)',
+        'Natural Language :: English',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: OS Independent',
+        'Operating System :: POSIX',
+        'Operating System :: POSIX :: Linux',
+        'Operating System :: Unix',
+        'Programming Language :: C++',
+        'Programming Language :: Python',
+        'Topic :: Scientific/Engineering :: Bio-Informatics',
+        'Topic :: Scientific/Engineering :: Chemistry',
+        'Topic :: Software Development :: Libraries'
+    ]
+)


### PR DESCRIPTION
Use pip to Install from the source code:
Firstly install Eigen3 and swig, then
```sh
git clone https://github.com/openbabel/openbabel
cd openbabel
pip install -v .
```
OpenBabel Python interface will be installed.

So, it is also possible to build wheels. <s>I created a GitHub Action to build automatically.</s> (CI still has some problems but building manually is OK)
If you can upload wheels to the pypi, then users can use `pip install openbabel` to install
OpenBabel directly without pre-installing anything.
