### PR TITLE
Resolve ImportError with make test

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -106,6 +106,7 @@ if (DO_PYTHON_BINDINGS)
         set_target_properties(bindings_python PROPERTIES
             OUTPUT_NAME _openbabel
             PREFIX ""
+            LIBRARY_OUTPUT_DIRECTORY "${openbabel_SOURCE_DIR}/scripts/python/openbabel/"
             SUFFIX .so )
         execute_process(
           COMMAND


### PR DESCRIPTION
This change will build _openbabel.so in scripts/python/openbabel instead
of the default build/lib.  This is necessary because openbabel.py tries
to import _openbabel like this:

if __package__ or "." in __name__:
    from . import _openbabel
else:
    import _openbabel

This results in a circular import error when running make test (the
first branch of the if is triggered).  This code appears to be generated by
SWIG with no obvious way to change it to catch the ImportError and call
import _openbabel instead.  Note the PYTHONPATH is set to include
build/lib, but it doesn't matter because SWIG is forcing the import to
happen in scripts/python/openbabel.

I'm not sure why this hasn't been a problem in the past, perhaps there's
been a change in SWIG.  This is with SWIG 4.0.1 and cmake 3.18.6.

I think the best solution is to move all the files that are being built
in /scripts to the build directory rather than polluting the src tree
with them, but this would require changing all the bindings and I'm not
up for building and testing every binding.