### PR TITLE
Separate issue templates [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 <!--
  Before submitting please search open and closed issues at
  https://github.com/openbabel/openbabel
@@ -8,11 +17,8 @@
  The GitHub issue tracker is for bug reports and feature requests.
  If you have a question about using Open Babel, please post to openbabel-discuss@lists.sourceforge.net
 
- Feel free to use the following as a template and remove or add fields as you see fit. You can convert `[ ]` into `[x]` to check boxes.
+ Feel free to use the following as a template and remove or add fields as you see fit.
 -->
-
-- [ ] I believe this to be a bug with Open Babel
-- [ ] This is a feature request
 
 ## Environment Information
 Open Babel version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+


### PR DESCRIPTION
Now GitHub can offer multiple issue templates.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository