### PR TITLE
Replace deprecated C headers with C++ alternatives

### DIFF
--- a/src/base.cpp
+++ b/src/base.cpp
@@ -17,7 +17,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 ***********************************************************************/
 
-#include <string.h>
+#include <cstring>
 
 #include <openbabel/babelconfig.h>
 #include <openbabel/base.h>

--- a/src/chains.cpp
+++ b/src/chains.cpp
@@ -24,10 +24,10 @@ GNU General Public License for more details.
 //////////////////////////////////////////////////////////////////////////////
 #include <openbabel/babelconfig.h>
 
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
-#include <ctype.h>
+#include <cstdlib>
+#include <cstring>
+#include <cstdio>
+#include <cctype>
 #include <map>
 
 #include <openbabel/mol.h>

--- a/src/confsearch.cpp
+++ b/src/confsearch.cpp
@@ -30,9 +30,9 @@ GNU General Public License for more details.
 #include <openbabel/math/vector3.h>
 #include <openbabel/elements.h>
 
-#include <float.h> // For DBL_MAX
+#include <cfloat> // For DBL_MAX
 #include <algorithm> // For min
-#include <limits.h> // For UINTS_MAX with certain old GCC4
+#include <climits> // For UINTS_MAX with certain old GCC4
 
 #include <iomanip> // For setprecision
 

--- a/src/depict/svgpainter.cpp
+++ b/src/depict/svgpainter.cpp
@@ -20,7 +20,7 @@ GNU General Public License for more details.
 #include <iostream>
 #include <iomanip>
 #include <sstream>
-#include <math.h>
+#include <cmath>
 using namespace std;
 
 #if defined(_MSC_VER) && _MSC_VER >= 1200 && _MSC_VER < 1800 // Between VC++ 6.0 and VC++ 11.0

--- a/src/formats/PQSformat.cpp
+++ b/src/formats/PQSformat.cpp
@@ -19,7 +19,7 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include <cstdlib>
 
-#include <ctype.h>
+#include <cctype>
 
 #if HAVE_STRINGS_H
 #include <strings.h>

--- a/src/formats/acrformat.cpp
+++ b/src/formats/acrformat.cpp
@@ -24,7 +24,7 @@ GNU General Public License for more details.
 #include <openbabel/atom.h>
 #include <openbabel/elements.h>
 #include <openbabel/obmolecformat.h>
-#include <stdio.h>
+#include <cstdio>
 #include <cstdlib>
 
 using namespace std;

--- a/src/formats/chemtoolformat.cpp
+++ b/src/formats/chemtoolformat.cpp
@@ -22,7 +22,7 @@ GNU General Public License for more details.
 #include <openbabel/bond.h>
 #include <openbabel/elements.h>
 
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace std;
 namespace OpenBabel

--- a/src/formats/jaguarformat.cpp
+++ b/src/formats/jaguarformat.cpp
@@ -22,7 +22,7 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include <openbabel/generic.h>
 
-#include <ctype.h>
+#include <cctype>
 #include <cstdlib>
 
 using namespace std;

--- a/src/formats/mdffformat.cpp
+++ b/src/formats/mdffformat.cpp
@@ -22,7 +22,7 @@ GNU General Public License for more details.
 #include <openbabel/obiter.h>
 
 
-#include <limits.h>
+#include <climits>
 #include <locale> // For isalpha(int)
 #include <map>
 #include <stdexcept>

--- a/src/formats/mmcifformat.cpp
+++ b/src/formats/mmcifformat.cpp
@@ -26,7 +26,7 @@ GNU General Public License for more details.
 
 #include <iostream>
 #include <algorithm>
-#include <ctype.h>
+#include <cctype>
 
 using namespace std;
 namespace OpenBabel

--- a/src/formats/pointcloudformat.cpp
+++ b/src/formats/pointcloudformat.cpp
@@ -37,8 +37,8 @@
 
 #include <iostream>
 
-#include <stdlib.h>
-#include <math.h>
+#include <cstdlib>
+#include <cmath>
 #include <cstdlib>
 
 #ifndef M_PI

--- a/src/formats/povrayformat.cpp
+++ b/src/formats/povrayformat.cpp
@@ -15,9 +15,9 @@ GNU General Public License for more details.
 #include <openbabel/babelconfig.h>
 
 /* ---- C includes ---- */
-#include <math.h>
-#include <time.h>
-#include <stdlib.h>
+#include <cmath>
+#include <ctime>
+#include <cstdlib>
 
 /* ---- OpenBabel include ---- */
 #include <openbabel/obmolecformat.h>

--- a/src/formats/stlformat.cpp
+++ b/src/formats/stlformat.cpp
@@ -37,8 +37,8 @@
 
 #include <iostream>
 
-#include <stdlib.h>
-#include <math.h>
+#include <cstdlib>
+#include <cmath>
 
 // uint8_t and uint16_t are not defined for earlier versions of msvc
 #if defined(_MSC_VER) && _MSC_VER <= 1600

--- a/src/formats/xml/cmlformat.cpp
+++ b/src/formats/xml/cmlformat.cpp
@@ -27,7 +27,7 @@ GNU General Public License for more details.
 #include <openbabel/stereo/cistrans.h>
 #include <openbabel/obfunctions.h>
 #include <openbabel/xml.h>
-#include <float.h>
+#include <cfloat>
 #ifdef HAVE_SHARED_POINTER
   #include <openbabel/reaction.h>
 #endif

--- a/src/locale.cpp
+++ b/src/locale.cpp
@@ -16,8 +16,8 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 ***********************************************************************/
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <openbabel/locale.h>
 
 #if HAVE_XLOCALE_H

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -21,7 +21,7 @@ GNU General Public License for more details.
 #include <openbabel/babelconfig.h>
 
 #include <iostream>
-#include <float.h>
+#include <cfloat>
 
 #include <openbabel/math/vector3.h>
 #include "../rand.h"

--- a/src/obconversion.cpp
+++ b/src/obconversion.cpp
@@ -43,7 +43,7 @@ GNU General Public License for more details.
 #include <typeinfo>
 #include <iterator>
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <openbabel/obconversion.h>
 //#include <openbabel/mol.h>

--- a/src/ops/conformer.cpp
+++ b/src/ops/conformer.cpp
@@ -29,7 +29,7 @@ Compile with tools/obabel.cpp rather than tools/babel.cpp
 #include <iostream>
 #include <memory>
 #include <vector>
-#include <stdio.h>
+#include <cstdio>
 #include <openbabel/op.h>
 #include <openbabel/mol.h>
 #include <openbabel/bond.h>

--- a/src/ops/partialcharges.cpp
+++ b/src/ops/partialcharges.cpp
@@ -24,7 +24,7 @@ GNU General Public License for more details.
 #include<openbabel/chargemodel.h>
 #include <openbabel/obconversion.h>
 
-#include <string.h>
+#include <cstring>
 namespace OpenBabel
 {
 

--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -18,7 +18,7 @@ GNU General Public License for more details.
 ***********************************************************************/
 #include <openbabel/babelconfig.h>
 
-#include <ctype.h>
+#include <cctype>
 #include <iomanip>
 #include <cstring>
 

--- a/src/pointgroup.cpp
+++ b/src/pointgroup.cpp
@@ -27,7 +27,7 @@ GNU General Public License for more details.
 #include <iostream>
 
 #include <string>
-#include <math.h>
+#include <cmath>
 #include <cstring>
 #include <algorithm>
 

--- a/src/rand.cpp
+++ b/src/rand.cpp
@@ -24,9 +24,9 @@ GNU General Public License for more details.
  */
 #include <openbabel/babelconfig.h>
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cmath>
 
 #include "rand.h"
 

--- a/src/rotor.cpp
+++ b/src/rotor.cpp
@@ -29,7 +29,7 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 
 #include <set>
-#include <assert.h>
+#include <cassert>
 
 // private data headers with default parameters
 #include "torlib.h"

--- a/test/addhtest.cpp
+++ b/test/addhtest.cpp
@@ -30,7 +30,7 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include <openbabel/generic.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 

--- a/test/aromatest.cpp
+++ b/test/aromatest.cpp
@@ -32,7 +32,7 @@ GNU General Public License for more details.
 extern "C" int strncasecmp(const char *s1, const char *s2, size_t n);
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 

--- a/test/atom.cpp
+++ b/test/atom.cpp
@@ -26,7 +26,7 @@ GNU General Public License for more details.
 #include <openbabel/atom.h>
 #include <openbabel/obconversion.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace std;

--- a/test/bond.cpp
+++ b/test/bond.cpp
@@ -27,7 +27,7 @@ GNU General Public License for more details.
 #include <openbabel/bond.h>
 #include <openbabel/obconversion.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace std;

--- a/test/cmlreadfile.cpp
+++ b/test/cmlreadfile.cpp
@@ -25,7 +25,7 @@ GNU General Public License for more details.
 #include <openbabel/mol.h>
 #include <openbabel/obconversion.h>
 #include <cstdlib>
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace std;

--- a/test/conversion.cpp
+++ b/test/conversion.cpp
@@ -25,7 +25,7 @@ GNU General Public License for more details.
 #include <openbabel/mol.h>
 #include <openbabel/obconversion.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <cstdlib>
 

--- a/test/datatest.cpp
+++ b/test/datatest.cpp
@@ -23,8 +23,8 @@ GNU General Public License for more details.
 
 #include <openbabel/babelconfig.h>
 
-#include <math.h>
-#include <stdio.h>
+#include <cmath>
+#include <cstdio>
 #include <iostream>
 
 #include <openbabel/mol.h>

--- a/test/format.cpp
+++ b/test/format.cpp
@@ -26,7 +26,7 @@ GNU General Public License for more details.
 #include <cstdlib>
 #include <openbabel/obconversion.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace std;

--- a/test/gziptest.cpp
+++ b/test/gziptest.cpp
@@ -25,7 +25,7 @@ GNU General Public License for more details.
 #include <openbabel/mol.h>
 #include <openbabel/obconversion.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 

--- a/test/internalcoord.cpp
+++ b/test/internalcoord.cpp
@@ -26,7 +26,7 @@ GNU General Public License for more details.
 #include <openbabel/obconversion.h>
 #include <openbabel/internalcoord.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace std;

--- a/test/logp_psa.cpp
+++ b/test/logp_psa.cpp
@@ -28,7 +28,7 @@ GNU General Public License for more details.
 #include <openbabel/obutil.h>
 #include <cstdlib>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace std;

--- a/test/math.cpp
+++ b/test/math.cpp
@@ -30,8 +30,8 @@ GNU General Public License for more details.
 #include "../src/rand.cpp"
 
 #include <iostream>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include <cstdio>
 
 #define REPEAT 1000

--- a/test/mol.cpp
+++ b/test/mol.cpp
@@ -28,7 +28,7 @@ GNU General Public License for more details.
 #include <openbabel/bond.h>
 #include <cstdlib>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace std;

--- a/test/multicmltest.cpp
+++ b/test/multicmltest.cpp
@@ -25,7 +25,7 @@ GNU General Public License for more details.
 #include <openbabel/mol.h>
 #include <openbabel/obconversion.h>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 

--- a/test/pdbreadfile.cpp
+++ b/test/pdbreadfile.cpp
@@ -27,7 +27,7 @@ GNU General Public License for more details.
 #include <openbabel/atom.h>
 #include <cstdlib>
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <openbabel/elements.h>
 

--- a/test/residue.cpp
+++ b/test/residue.cpp
@@ -29,7 +29,7 @@ GNU General Public License for more details.
 #include <openbabel/chains.h>
 #include <openbabel/residue.h>
 #include <cstdlib>
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 
 using namespace std;

--- a/test/roundtrip.cpp
+++ b/test/roundtrip.cpp
@@ -32,7 +32,7 @@ GNU General Public License for more details.
 extern "C" int strncasecmp(const char *s1, const char *s2, size_t n);
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 

--- a/tools/obfragment.cpp
+++ b/tools/obfragment.cpp
@@ -37,7 +37,7 @@
 extern "C" int strncasecmp(const char *s1, const char *s2, size_t n);
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/tools/obrotamer.cpp
+++ b/tools/obrotamer.cpp
@@ -31,7 +31,7 @@ GNU General Public License for more details.
 #include "../src/rand.h"
 #include "../src/rand.cpp"
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 

--- a/tools/obseq.cpp
+++ b/tools/obseq.cpp
@@ -29,7 +29,7 @@ GNU General Public License for more details.
 extern "C" int strncasecmp(const char *s1, const char *s2, size_t n);
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 

--- a/tools/obsort-fragment.cpp
+++ b/tools/obsort-fragment.cpp
@@ -29,7 +29,7 @@ GNU General Public License for more details.
 extern "C" int strncasecmp(const char *s1, const char *s2, size_t n);
 #endif
 
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <fstream>
 #include <algorithm>


### PR DESCRIPTION
[C++ Standard § D.11.1 &#91;depr.c.headers.general&#93;](https://github.com/cplusplus/draft/blob/b8e95495a29142edcb9098225fe764154806c14a/source/future.tex#L227-L260)