### PR TITLE
clang-tidy: readability-delete-null-pointer

### DIFF
--- a/src/depict/depict.cpp
+++ b/src/depict/depict.cpp
@@ -381,8 +381,7 @@ namespace OpenBabel
     if (!d->painter)
       return false;
 
-    if (d->mol != nullptr)
-      delete d->mol;
+    delete d->mol;
     d->mol = new OBMol(*mol); // Copy it
 
     double width=0.0, height=0.0;

--- a/src/distgeom.cpp
+++ b/src/distgeom.cpp
@@ -119,8 +119,7 @@ namespace OpenBabel {
 
   OBDistanceGeometry::~OBDistanceGeometry()
   {
-    if (_d != nullptr)
-      delete _d;
+    delete _d;
   }
 
   float OBDistanceGeometry::GetUpperBounds(int i, int j) {
@@ -131,8 +130,7 @@ namespace OpenBabel {
   }
   bool OBDistanceGeometry::Setup(const OBMol &mol, bool useCurrentGeometry)
   {
-    if (_d != nullptr)
-      delete _d;
+    delete _d;
     // TODO: add IsSetupNeeded() like OBForceField to prevent duplication of work
 
     dim = 4;

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -823,12 +823,10 @@ namespace OpenBabel
       _mol = mol;
       _ncoords = _mol.NumAtoms() * 3;
 
-      if (_velocityPtr)
-        delete [] _velocityPtr;
+      delete [] _velocityPtr;
       _velocityPtr = nullptr;
 
-      if (_gradientPtr)
-        delete [] _gradientPtr;
+      delete [] _gradientPtr;
       _gradientPtr = new double[_ncoords];
 
       if (_mol.NumAtoms() && _constraints.Size())
@@ -879,12 +877,10 @@ namespace OpenBabel
       _mol = mol;
       _ncoords = _mol.NumAtoms() * 3;
 
-      if (_velocityPtr)
-        delete [] _velocityPtr;
+      delete [] _velocityPtr;
       _velocityPtr = nullptr;
 
-      if (_gradientPtr)
-        delete [] _gradientPtr;
+      delete [] _gradientPtr;
       _gradientPtr = new double[_ncoords];
 
       _constraints = constraints;
@@ -2892,8 +2888,7 @@ namespace OpenBabel
       OBFFLog("--------------------------------\n");
     }
 
-    if (_grad1 != nullptr)
-      delete [] _grad1;
+    delete [] _grad1;
     _grad1 = new double[_ncoords];
     memset(_grad1, '\0', sizeof(double)*_ncoords);
 

--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -243,8 +243,7 @@ namespace OpenBabel
                 //! @todo allow better multi-line comments
                 // which don't allow ill-formed data to consume memory
                 // Thanks to Andrew Dalke for the pointer
-                if (comment != nullptr)
-                  delete [] comment;
+                delete [] comment;
                 comment = new char [len];
                 memcpy(comment,buffer,len);
               }

--- a/src/formats/mopacformat.cpp
+++ b/src/formats/mopacformat.cpp
@@ -352,8 +352,7 @@ namespace OpenBabel
             ifs.getline(buffer,BUFF_SIZE);	// SUM
             tokenize(vs, buffer);
             if (vs.size() == 5) {
-              if (dipoleMoment)
-                delete dipoleMoment;
+              delete dipoleMoment;
 
               dipoleMoment = new OBVectorData;
               double x, y, z;

--- a/src/mcdlutil.cpp
+++ b/src/mcdlutil.cpp
@@ -1053,7 +1053,7 @@ namespace OpenBabel {
     };
     //end addition from 16 April 2006
     if (bkExt == nullptr) free(bk);
-    if (blStore != nullptr) delete(blStore);
+    delete blStore;
     return result;
   };
 
@@ -3481,9 +3481,9 @@ namespace OpenBabel {
       result=k;
     };
     //freeing resources
-    if (smCopy != nullptr) delete(smCopy);
-    if (bestStore != nullptr) delete(bestStore);
-    if (tmpStore != nullptr) delete(tmpStore);
+    delete smCopy;
+    delete bestStore;
+    delete tmpStore;
 
     return result;
   };

--- a/src/obconversion.cpp
+++ b/src/obconversion.cpp
@@ -311,10 +311,7 @@ namespace OpenBabel {
   OBConversion::~OBConversion()
   {
     if(pAuxConv!=this)
-      if(pAuxConv)
-      {
-        delete pAuxConv;
-      }
+      delete pAuxConv;
     // Free any remaining streams from convenience functions
     SetInStream(nullptr);
     SetOutStream(nullptr);
@@ -1050,7 +1047,7 @@ namespace OpenBabel {
     ofstream *ofs = new ofstream(filePath.c_str(),omode);
     if(!ofs || !ofs->good())
       {
-        if(ofs) delete ofs;
+        delete ofs;
         obErrorLog.ThrowError(__FUNCTION__,"Cannot write to " + filePath, obError);
         return false;
       }
@@ -1095,7 +1092,7 @@ namespace OpenBabel {
     ifstream *ifs = new ifstream(filePath.c_str(),imode);
     if(!ifs || !ifs->good())
     {
-        if(ifs) delete ifs;
+        delete ifs;
         obErrorLog.ThrowError(__FUNCTION__,"Cannot read from " + filePath, obError);
         return false;
     }
@@ -1123,7 +1120,7 @@ namespace OpenBabel {
     ifstream *ifs = new ifstream(infilepath.c_str(),ios_base::in|ios_base::binary);  //always open in binary mode
     if(!ifs || !ifs->good())
     {
-      if(ifs) delete ifs;
+      delete ifs;
       obErrorLog.ThrowError(__FUNCTION__,"Cannot read from " + infilepath, obError);
       return false;
     }
@@ -1141,7 +1138,7 @@ namespace OpenBabel {
     ofstream *ofs = new ofstream(outfilepath.c_str(),ios_base::out|ios_base::binary);//always open in binary mode
     if(!ofs || !ofs->good())
     {
-      if(ofs) delete ofs;
+      delete ofs;
       obErrorLog.ThrowError(__FUNCTION__,"Cannot write to " + outfilepath, obError);
       return false;
     }

--- a/src/oberror.cpp
+++ b/src/oberror.cpp
@@ -156,8 +156,7 @@ namespace OpenBabel
     StopErrorWrap();
 
     // free the internal filter streambuf
-    if (_filterStreamBuf != nullptr)
-      delete _filterStreamBuf;
+    delete _filterStreamBuf;
   }
 
   void OBMessageHandler::ThrowError(OBError err, errorQualifier qualifier)

--- a/src/parsmart.cpp
+++ b/src/parsmart.cpp
@@ -1716,7 +1716,6 @@ namespace OpenBabel
 
   bool OBSmartsPattern::Init(const char *buffer)
   {
-    if (_buffer != nullptr)
       delete[] _buffer;
     _buffer = new char[strlen(buffer) + 1];
     strcpy(_buffer,buffer);
@@ -1731,8 +1730,7 @@ namespace OpenBabel
 
   bool OBSmartsPattern::Init(const std::string &s)
   {
-    if (_buffer != nullptr)
-      delete[] _buffer;
+    delete[] _buffer;
     _buffer = new char[s.length() + 1];
     strcpy(_buffer, s.c_str());
 
@@ -1748,8 +1746,7 @@ namespace OpenBabel
   {
     if (_pat)
       FreePattern(_pat);
-    if(_buffer)
-    	delete [] _buffer;
+    delete [] _buffer;
   }
 
   bool OBSmartsPattern::Match(OBMol &mol,bool single)
@@ -2324,8 +2321,7 @@ namespace OpenBabel
 
   OBSSMatch::~OBSSMatch()
   {
-    if (_uatoms)
-      delete [] _uatoms;
+    delete [] _uatoms;
   }
 
   void OBSSMatch::Match(std::vector<std::vector<int> > &mlist,int bidx)


### PR DESCRIPTION
`delete nullptr;` has no effect and there is no necessity to check if a pointer is not `nullptr`.