### PR TITLE
More robust pdb reading.

### DIFF
--- a/src/formats/pdbformat.cpp
+++ b/src/formats/pdbformat.cpp
@@ -257,14 +257,10 @@ namespace OpenBabel
       OBAtomAssignTypicalImplicitHydrogens(&*matom);
 
     // clean out remaining blank lines
-    std::streampos ipos;
-    do
+    while(ifs.peek() == '\n' && !ifs.eof())
     {
-      ipos = ifs.tellg();
       ifs.getline(buffer,BUFF_SIZE);
     }
-    while(strlen(buffer) == 0 && !ifs.eof() );
-    ifs.seekg(ipos);
 
     return(true);
   }


### PR DESCRIPTION
Not all istream implementations support tell/seek so use peek when
consuming blank lines.