### PR TITLE
Fix search of coordinate system

### DIFF
--- a/src/formats/gaussformat.cpp
+++ b/src/formats/gaussformat.cpp
@@ -509,7 +509,7 @@ namespace OpenBabel
             // The "nosym" keyword has been requested
             no_symmetry = true;
           }
-        if (strstr(buffer, "orientation:") != nullptr)
+        if (strstr(buffer, "orientation:") != nullptr && (strstr(buffer, "Dipole") == nullptr))
           {
             i++;
             tokenize (vs, buffer);


### PR DESCRIPTION
**When merged this pull request will:**
- Prevent parser from matching ` Dipole orientation:` if no input orientation was printed.
- `obabel H2O_freq.log -O H2O.cml` work with [H2O_freq.log](https://github.com/openbabel/openbabel/files/8307662/H2O_freq.log)
