### PR TITLE
Used <regex> directly

### DIFF
--- a/src/formats/gamessukformat.cpp
+++ b/src/formats/gamessukformat.cpp
@@ -23,12 +23,12 @@
 
 #include <algorithm>
 #include <cmath>
-
-#ifdef _MSC_VER
+#include <regex>
+/*#ifdef _MSC_VER
 #include <regex>
 #else
 #include <regex.h>
-#endif
+#endif*/
 
 using namespace std;
 
@@ -797,20 +797,20 @@ namespace OpenBabel
     //                     ------label--------   -------charge-------- < seems enough for a match
     string pattern(" *\\* *[a-zA-Z]{1,2}[0-9]* *[0-9]{1,3}\\.[0-9]{1}");
     bool iok;
-#ifdef _MSC_VER
-    std::tr1::regex myregex;
+//#ifdef _MSC_VER
+    regex myregex;
     try {
       myregex.assign(pattern,
-                     std::tr1::regex_constants::extended |
-                     std::tr1::regex_constants::nosubs);
+                     regex_constants::extended |
+                     regex_constants::nosubs);
       iok = true;
-    } catch (std::tr1::regex_error ex) {
+    } catch (regex_error ex) {
       iok = false;
     }
-#else
+/*#else
     regex_t *myregex = new regex_t;
     iok = regcomp(myregex, pattern.c_str(), REG_EXTENDED | REG_NOSUB)==0;
-#endif
+#endif*/
     if (!iok) cerr << "Error compiling regex in GUK OUTPUT!\n";
 
     // Read in the coordinates - we process them directly rather
@@ -820,11 +820,11 @@ namespace OpenBabel
 
       // End of geometry block
       if (strstr(buffer, "*************************") != nullptr) break;
-#ifdef _MSC_VER
-      if (std::tr1::regex_search(buffer, myregex)) {
-#else
+//#ifdef _MSC_VER
+      if (regex_search(buffer, myregex)) {
+/*#else
         if (regexec(myregex, buffer, 0, nullptr, 0) == 0) {
-#endif
+#endif*/
           //cerr << "Got Coord line: " << buffer << endl;
           OBAtom *atom = mol.NewAtom();
           tokenize(tokens,buffer," ");
@@ -841,9 +841,9 @@ namespace OpenBabel
         }
       }
       mol.EndModify();
-#ifndef _MSC_VER
+/*#ifndef _MSC_VER
       regfree(myregex);
-#endif
+#endif*/
       return true;
     } // End ReadInitalCartesian
 

--- a/src/formats/orcaformat.cpp
+++ b/src/formats/orcaformat.cpp
@@ -23,12 +23,12 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include <openbabel/generic.h>
 #include <cstdlib>
-
-#ifdef _MSC_VER
+#include <regex>
+/*#ifdef _MSC_VER
 #include <regex>
 #else
 #include <regex.h>
-#endif
+#endif*/
 
 #include <iomanip>
 
@@ -696,26 +696,26 @@ namespace OpenBabel
 
 // small function to avoid wrong parsing
 // if there is no whitespace between the numbers in the column structure
-#ifdef _MSC_VER
+//#ifdef _MSC_VER
   string OrcaOutputFormat::checkColumns(string checkBuffer)
   {
     string pattern ("[0-9]-");
-    std::tr1::regex myregex;
-    std::tr1::smatch pm;
+    regex myregex;
+    smatch pm;
     try {
       myregex.assign(pattern,
-                     std::tr1::regex_constants::extended);
+                     regex_constants::extended);
       //iok = true;
-    } catch (std::tr1::regex_error ex) {
+    } catch (regex_error ex) {
         return (checkBuffer); // do nothing
       //iok = false;
     }
-    while (std::tr1::regex_search (checkBuffer,pm,myregex)) {
+    while (regex_search (checkBuffer,pm,myregex)) {
         checkBuffer.insert(pm.position(0)+1, " ");
     }
     return (checkBuffer);
   }
-#else
+/*#else
   string OrcaOutputFormat::checkColumns(string checkBuffer)
   {
       string pattern ("[0-9]-");
@@ -729,5 +729,5 @@ namespace OpenBabel
       }
       return (checkBuffer);
   }
-#endif
+#endif*/
 } //namespace OpenBabel


### PR DESCRIPTION
<regex> has been in C++11 std, so it may be used directly,and it can be compiled with msys2 successfully.