### PR TITLE
Remove std::binary_function, which is removed in C++17

### DIFF
--- a/include/openbabel/inchiformat.h
+++ b/include/openbabel/inchiformat.h
@@ -131,7 +131,6 @@ public:
   // and "CH4" is less than "C2H6"
   // and "CH4" is less than "ClH" (hydrogen chloride)
   struct InchiLess
-    : public std::binary_function<const std::string&, const std::string&, bool>
   {
     bool operator()(const std::string& s1, const std::string& s2) const
     {

--- a/include/openbabel/plugin.h
+++ b/include/openbabel/plugin.h
@@ -38,7 +38,7 @@ namespace OpenBabel
 ///@{
 
 /// @brief Case insensitive string comparison for PluginMapType key.
-struct OBERROR CharPtrLess : public std::binary_function<const char*,const char*, bool>
+struct OBERROR CharPtrLess
 {
   bool operator()(const char* p1,const char* p2) const
   { return strcasecmp(p1,p2)<0; }

--- a/scripts/openbabel-R.i
+++ b/scripts/openbabel-R.i
@@ -293,13 +293,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %include <openbabel/chains.h>
 %include <openbabel/typer.h>
-
-// To avoid warning in plugin.h about "Nothing known about std::binary_function"
-namespace std { 
-        template <T1, T2, T3>
-        class binary_function {}; 
-}
-%template(dummy) std::binary_function <const char *, const char *, bool>;
 %include <openbabel/plugin.h>
 
 // To avoid warning in oberror.h about "Nothing known about std::stringbuf"

--- a/scripts/openbabel-csharp.i
+++ b/scripts/openbabel-csharp.i
@@ -831,13 +831,6 @@ CAST_GENERICDATA_TO(VirtualBond);
 
 %include <openbabel/chains.h>
 %include <openbabel/typer.h>
-
-// To avoid warning in plugin.h about "Nothing known about std::binary_function"
-namespace std { 
-        template <T1, T2, T3>
-        class binary_function {}; 
-}
-%template(dummy) std::binary_function <const char *, const char *, bool>;
 %include <openbabel/plugin.h>
 
 // To avoid warning in oberror.h about "Nothing known about std::stringbuf"

--- a/scripts/openbabel-java.i
+++ b/scripts/openbabel-java.i
@@ -249,13 +249,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %include <openbabel/chains.h>
 %include <openbabel/typer.h>
-
-// To avoid warning in plugin.h about "Nothing known about std::binary_function"
-namespace std { 
-        template <T1, T2, T3>
-        class binary_function {}; 
-}
-%template(dummy) std::binary_function <const char *, const char *, bool>;
 %include <openbabel/plugin.h>
 
 // To avoid warning in oberror.h about "Nothing known about std::stringbuf"

--- a/scripts/openbabel-perl.i
+++ b/scripts/openbabel-perl.i
@@ -194,13 +194,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %import <openbabel/chains.h>
 %import <openbabel/typer.h>
-
-// To avoid warning in oberror.h about "Nothing known about std::binary_function"
-namespace std { 
-        template <T1, T2, T3>
-        class binary_function {}; 
-}
-%template(Dummy) std::binary_function <const char *, const char *, bool>;
 %include <openbabel/plugin.h>
 
 // To avoid warning in oberror.h about "Nothing known about std::stringbuf"

--- a/scripts/openbabel-php.i
+++ b/scripts/openbabel-php.i
@@ -226,13 +226,6 @@ CAST_GENERICDATA_TO(VirtualBond)
 
 %include <openbabel/chains.h>
 %include <openbabel/typer.h>
-
-// To avoid warning in plugin.h about "Nothing known about std::binary_function"
-namespace std { 
-        template <T1, T2, T3>
-        class binary_function {}; 
-}
-%template(dummy) std::binary_function <const char *, const char *, bool>;
 %include <openbabel/plugin.h>
 
 // To avoid warning in oberror.h about "Nothing known about std::stringbuf"

--- a/scripts/openbabel-python.i
+++ b/scripts/openbabel-python.i
@@ -267,13 +267,6 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 %include <openbabel/kekulize.h>
 %include <openbabel/chains.h>
 %include <openbabel/typer.h>
-
-// To avoid warning in plugin.h about "Nothing known about std::binary_function"
-namespace std {
-        template <T1, T2, T3>
-        class binary_function {};
-}
-%template(dummy) std::binary_function <const char *, const char *, bool>;
 %include <openbabel/plugin.h>
 
 // To avoid warning in oberror.h about "Nothing known about std::stringbuf"

--- a/scripts/openbabel-ruby.i
+++ b/scripts/openbabel-ruby.i
@@ -215,13 +215,6 @@ CAST_GENERICDATA_TO(SquarePlanarStereo)
 
 %import <openbabel/chains.h>
 %import <openbabel/typer.h>
-
-// To avoid warning in oberror.h about "Nothing known about std::binary_function"
-namespace std { 
-        template <T1, T2, T3>
-        class binary_function {}; 
-}
-%template(Dummy) std::binary_function <const char *, const char *, bool>;
 %include <openbabel/plugin.h>
 
 // To avoid warning in oberror.h about "Nothing known about std::stringbuf"

--- a/src/ops/sort.cpp
+++ b/src/ops/sort.cpp
@@ -29,7 +29,7 @@ namespace OpenBabel
 {
 
 template<class T>
-struct Order : public std::binary_function<std::pair<OBBase*,T>, std::pair<OBBase*,T>, bool>
+struct Order
 {
   Order(OBDescriptor* pDesc, bool rev) : _pDesc(pDesc), _rev(rev){}
   bool operator()(std::pair<OBBase*,T> p1, std::pair<OBBase*,T> p2) const


### PR DESCRIPTION
fix #2461