### PR TITLE
ci: rearrange tar options properly

### DIFF
--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Packing
       run: |
-        tar cvjf openbabel-latest.tar.bz2 openbabel --exclude-vcs --exclude-backups --exclude='.github*'
+        tar --exclude-vcs --exclude-backups --exclude='.github*' -cvjf openbabel-latest.tar.bz2 openbabel
       working-directory: ${{ runner.workspace }}
 
     - name: Upload


### PR DESCRIPTION
```
tar: The following options were used after any non-optional arguments in archive create or update mode.  These options are positional and affect only arguments that follow them.  Please, rearrange them properly.
tar: --exclude-vcs has no effect
tar: --exclude-backups has no effect
tar: --exclude ‘.github*’ has no effect
tar: Exiting with failure status due to previous errors
```