### PR TITLE
Do not release OpenBabel::OBConformerSearch::m_filter

### DIFF
--- a/include/openbabel/conformersearch.h
+++ b/include/openbabel/conformersearch.h
@@ -318,7 +318,6 @@ namespace OpenBabel {
        */
       void SetFilter(OBConformerFilter *filter)
       {
-        delete m_filter;
         m_filter = filter;
       }
       /**

--- a/src/conformersearch.cpp
+++ b/src/conformersearch.cpp
@@ -323,7 +323,6 @@ namespace OpenBabel {
 
   OBConformerSearch::~OBConformerSearch()
   {
-    delete m_filter;
     delete (OBRandom*)d;
   }
 

--- a/src/ops/conformer.cpp
+++ b/src/ops/conformer.cpp
@@ -243,8 +243,11 @@ namespace OpenBabel
       if(iter!=pmap->end())
         check_hydrogens = false;
  
+      std::unique_ptr<OBConformerFilter> f;
       if (filter == "steric")
-        cs.SetFilter(new OBStericConformerFilter(cutoff, vdw_factor, check_hydrogens));
+        f.reset(new OBStericConformerFilter(cutoff, vdw_factor, check_hydrogens));
+      if (f)
+        cs.SetFilter(f.get());
 
       iter = pmap->find("printrot");
       if(iter!=pmap->end())


### PR DESCRIPTION
related to #2229, current implementation causes segmentation fault after call SetFilter from python