### PR TITLE
verbose flag in OBForceField for all stdout writes

### DIFF
--- a/src/confsearch.cpp
+++ b/src/confsearch.cpp
@@ -391,7 +391,8 @@ int OBForceField::DiverseConfGen(double rmsd, unsigned int nconfs, double energy
     if (rotor_sizes.size() > 0 && combinations == 0) { // Overflow!
       combinations = UINT_MAX;
     }
-    std::cout << "..tot conformations = " << combinations << "\n";
+    if (verbose)
+      std::cout << "..tot conformations = " << combinations << "\n";
 
     if (nconfs == 0)
       nconfs = 1 << 20;
@@ -432,7 +433,8 @@ int OBForceField::DiverseConfGen(double rmsd, unsigned int nconfs, double energy
       }
       counter++;
     } while (combination != 1 && counter < nconfs); // The LFSR always terminates with a 1
-    std::cout << "..tot confs tested = " << counter << "\n..below energy threshold = " << N_low_energy << "\n";
+    if (verbose)
+      std::cout << "..tot confs tested = " << counter << "\n..below energy threshold = " << N_low_energy << "\n";
 
     // Reset the coordinates to those of the initial structure
     _mol.SetCoordinates(store_initial);


### PR DESCRIPTION
make stdout writes dependent on verbose flag that allow to turn off logs completely