### PR TITLE
CMake: fix time check typo (fixes build failure w/ GCC 12)

### DIFF
--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -182,8 +182,8 @@
 #define OB_MODULE_PATH "@OB_MODULE_PATH@"
 
 #ifndef TIME_WITH_SYS_TIME
-  #ifdef HAVE_SYS_TIME
-    #ifdef HAVE_TIME
+  #ifdef HAVE_SYS_TIME_H
+    #ifdef HAVE_TIME_H
       #define TIME_WITH_SYS_TIME 1
     #else
       #define TIME_WITH_SYS_TIME 0


### PR DESCRIPTION
Without this fixed check, we get a build failure with GCC 12:
```
/var/tmp/portage/sci-chemistry/openbabel-3.1.1_p20210225/work/openbabel-08e23f39b0cc39b4eebd937a5a2ffc1a7bac3e1b/include/openbabel/obutil.h:65:14: error: ‘clock’ was not declared in this scope; did you mean ‘clock_t’?
   65 |       start= clock();
      |              ^~~~~
      |              clock_t
```

Bug: https://bugs.gentoo.org/851510