### PR TITLE
refactor: use `std::unordered_map` for hash map

### DIFF
--- a/include/openbabel/obmolecformat.h
+++ b/include/openbabel/obmolecformat.h
@@ -19,18 +19,8 @@ GNU General Public License for more details.
 #ifndef OB_MOLECULEFORMAT_H
 #define OB_MOLECULEFORMAT_H
 
-#ifdef _MSC_VER
-  #include <unordered_map>
-#endif
-
 #include <ciso646>  // detect std::lib
-#ifdef _LIBCPP_VERSION
-  #include <unordered_map>
-#elif __GNUC__ == 4 && __GNUC_MINOR__ >= 1
-  #include <tr1/unordered_map>
-#elif defined(USE_BOOST)
-  #include <boost/tr1/unordered_map.hpp>
-#endif
+#include <unordered_map>
 
 #include <openbabel/babelconfig.h>
 #include <openbabel/obconversion.h>
@@ -141,15 +131,7 @@ public:
     (OBReaction* pReact, OBConversion* pConv, OBFormat* pFormat);
 #endif
 
-#ifdef _MSC_VER
-  typedef std::tr1::unordered_map<std::string, unsigned> NameIndexType;
-#elif defined(_LIBCPP_VERSION)
   typedef std::unordered_map<std::string, unsigned> NameIndexType;
-#elif (__GNUC__ == 4 && __GNUC_MINOR__ >= 1 && !defined(__APPLE_CC__)) || defined (USE_BOOST)
-  typedef std::tr1::unordered_map<std::string, unsigned> NameIndexType;
-#else
-  typedef std::map<std::string, unsigned> NameIndexType;
-#endif
 
   // documentation in obmolecformat.cpp
   static bool   ReadNameIndex(NameIndexType& index, const std::string& datafilename,

--- a/src/obmolecformat.cpp
+++ b/src/obmolecformat.cpp
@@ -470,8 +470,7 @@ namespace OpenBabel
       if the environment variable is not set
       - in a subdirectory of the BABEL_DATADIR directory with the version of OpenBabel as its name
       An index of type NameIndexType is then constructed. NameIndexType is defined
-      in obmolecformat.h and may be a std::tr1::unordered_map (a hash_map) or std::map.
-      In any case it is searched by
+      in obmolecformat.h as std::unordered_map. It is searched by
       @code
       NameIndexType::iterator itr = index.find(molecule_name);
       if(itr!=index.end())

--- a/src/ops/unique.cpp
+++ b/src/ops/unique.cpp
@@ -21,27 +21,10 @@ GNU General Public License for more details.
 #include <openbabel/obconversion.h>
 #include <openbabel/descriptor.h>
 #include <openbabel/inchiformat.h>
-#if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
-  #include <unordered_map>
-#elif (__GNUC__ == 4 && __GNUC_MINOR__ >= 1 && !defined(__APPLE_CC__))
-  #include <tr1/unordered_map>
-#else
-  #ifdef USE_BOOST
-    #include <boost/tr1/unordered_map.hpp>
-  #else
-    #define NO_UNORDERED_MAP
-    #include <map>
-  #endif
-#endif
+#include <unordered_map>
 
 using namespace std;
-#ifndef NO_UNORDERED_MAP
-  #ifdef _LIBCPP_VERSION
-    using std::unordered_map;
-  #else
-    using std::tr1::unordered_map;
-  #endif
-#endif
+
 namespace OpenBabel
 {
 
@@ -82,11 +65,7 @@ private:
   unsigned _ndups;
   bool _inv;
 
-#ifdef NO_UNORDERED_MAP
-  typedef map<std::string, std::string> UMap;
-#else
   typedef unordered_map<std::string, std::string> UMap;
-#endif
 
   //key is descriptor text(usually inchi) value is molecule title
   UMap _inchimap;


### PR DESCRIPTION
The checks are no longer necessary as C++11 is now used.