### PR TITLE
update interface pybel.py

### DIFF
--- a/scripts/python/examples/testpybel.py
+++ b/scripts/python/examples/testpybel.py
@@ -192,7 +192,7 @@ M  END
         self.assertRaises(OSError, self.RFreaderror)
 
     def RFformaterror(self):
-        mol = getattr(self.toolkit.readfile("noel", "head.sdf"), nextmethod)()
+        mol = getattr(self.toolkit.readfile("noel", self.head), nextmethod)()
 
     def testRFformaterror(self):
         """Test that invalid formats raise an error"""

--- a/scripts/python/examples/testpybel.py
+++ b/scripts/python/examples/testpybel.py
@@ -19,9 +19,9 @@ try:
         cinfony = None
     try:
         from openbabel import pybel
-        rdkit = cdk = None
     except ImportError:
         pybel = None
+    rdkit = cdk = None
 except AttributeError:
     from cinfony import cdk
     pybel = rdkit = None
@@ -192,7 +192,7 @@ M  END
         self.assertRaises(OSError, self.RFreaderror)
 
     def RFformaterror(self):
-        mol = getattr(self.toolkit.readfile("noel", self.head), nextmethod)()
+        mol = getattr(self.toolkit.readfile("noel", os.path.join(here,"head.sdf")), nextmethod)()
 
     def testRFformaterror(self):
         """Test that invalid formats raise an error"""

--- a/scripts/python/openbabel/pybel.py
+++ b/scripts/python/openbabel/pybel.py
@@ -156,8 +156,14 @@ def readfile(format=None, filename=None, opt=None):
     >>> print atomtotal
     43
     """
+    # To be compitable with testing work inside `python/examples/testpybel.py`,
+    # "format" has to be checked first, ValueError should be raised, if it does
+    # not work, whether it's defined by user-input or guessed from filename.
+    #
+    # If filename does not exist, OSError should be raised instead.
     if not os.path.isfile(filename):
-        raise ValueError("No such file: '%s'" % filename)
+        # use a very unusual string to clarify errors when format not works
+        filename = '>>/NONE'
     if not format:
         if filename.endswith('.tgz'):
             new = filename[:-4]
@@ -172,7 +178,15 @@ def readfile(format=None, filename=None, opt=None):
     obconversion = ob.OBConversion()
     formatok = obconversion.SetInFormat(format)
     if not formatok:
-        raise ValueError("%s is not a recognised Open Babel format" % format)
+        if filename == '>>/NONE':
+            raise ValueError("Input file does not exist")
+        else:
+            raise ValueError(
+                "File format (%s) guessed from file (%s) "
+                "is not a recognised Open Babel format" % (format,filename)
+            )
+    if not os.path.isfile(filename):
+        raise OSError("Input file does not exist")
     if opt is None:
         opt = {}
     for k, v in opt.items():

--- a/scripts/python/openbabel/pybel.py
+++ b/scripts/python/openbabel/pybel.py
@@ -157,7 +157,7 @@ def readfile(format=None, filename=None, opt=None):
     43
     """
     if not os.path.isfile(filename):
-        raise IOError("No such file: '%s'" % filename)
+        raise ValueError("No such file: '%s'" % filename)
     if not format:
         if filename.endswith('.tgz'):
             new = filename[:-4]

--- a/scripts/python/openbabel/pybel.py
+++ b/scripts/python/openbabel/pybel.py
@@ -178,13 +178,16 @@ def readfile(format=None, filename=None, opt=None):
     obconversion = ob.OBConversion()
     formatok = obconversion.SetInFormat(format)
     if not formatok:
-        if filename == '>>/NONE':
-            raise ValueError("Input file does not exist")
+        if format:
+            raise ValueError("%s is not a recognised Open Babel format" % format)
         else:
-            raise ValueError(
-                "File format (%s) guessed from file (%s) "
-                "is not a recognised Open Babel format" % (format,filename)
-            )
+            if filename == '>>/NONE':
+                raise ValueError("Input file does not exist")
+            else:
+                raise ValueError(
+                    "File format (%s) guessed from file (%s) "
+                    "is not a recognised Open Babel format" % (format,filename)
+                )
     if not os.path.isfile(filename):
         raise OSError("Input file does not exist")
     if opt is None:


### PR DESCRIPTION
There are two minor issues in Python interface `pybel` module `readfile` function:

It has arguments like `readfile(format, filename, opt=None)`, argument `format` is mandatory required, however, it should have the ability to be guessed from the input `filename`, which is also required. Secondly, for `openbabel`, the compressed `gzip` filetype can also be supported in some extents. User may feel confused with which type of “correct” file format should be input if they happen to have a `gzip` file like “**file.sdf.tgz**" or the equivalent things.

To be noted: in order to be maximumly compatible with early version of `pybel`, the sequence of arguments inside are kept consistent.

With the new version of codes, `readfile` can be used to read file like: `readfile(filename=”head.sdf.tgz”)`.