### PR TITLE
WLN Reader Additions

### DIFF
--- a/src/formats/wln-nextmove.cpp
+++ b/src/formats/wln-nextmove.cpp
@@ -23,6 +23,7 @@ GNU General Public License for more details.
 #include <vector>
 #include <numeric>
 #include <openbabel/obiter.h>
+#include <algorithm>
 
 #include <cstdlib>
 


### PR DESCRIPTION
Added functionality for peri/poly fused rings. Small changes to allow more fused notation ring combinations. Small QOL changes for atom assignment and "locant" path definitions. Added support for major periodic table elements, Spiro & ring bridge support. Combinations of cyclic unit merging now available on read. 

Tests on the Pubchem data yielded read results of 97%

* Created function for polyfused ring systems - 

```c++

polyfused_ring(std::vector<OpenBabel::OBAtom*> &ring,std::vector<char> char_vector, std::vector<int> atom_vector, int ring_positions)
```
* Created function for perfused ring systems- 
```c++
int perifused_ring(std::vector<OpenBabel::OBAtom*> &ring,std::vector<char> char_vector, std::vector<int> atom_vector,std::vector<char> peri_vector, int ring_positions) {
```
this has limited functionality for larger combinations, but covers the basic peri fused examples for rings up to 2 peri atoms. 

* Several Additions to ``bool parse_ring()`` to facilitate the above functions

* Full addition of periodic elements to all switch statements in parse_ring, parse_inorganic