### PR TITLE
Allow GUI to compile with wxWidgets built with STL

### DIFF
--- a/src/GUI/OBGUI.cpp
+++ b/src/GUI/OBGUI.cpp
@@ -1128,7 +1128,7 @@ void OBGUIFrame::OnClickPlugin(wxCommandEvent& event)
   if(item)
   {
     //Find the name of the plugin type. It seems difficult to go up a menu hierarchy.
-    wxwxMenuItemListNode *node = listMenu->GetMenuItems().GetFirst();
+    wxMenuItemList::compatibility_iterator node = listMenu->GetMenuItems().GetFirst();
     while (node)
     {
       wxMenuItem* itemm = node->GetData();


### PR DESCRIPTION
`wxMenuItemList` - a `wxList` of `wxMenuItem`s - should be iterated using the `wxMenuItemList::compatibility_iterator` so that it can be compiled with wxWidgets built with STL.

This commit does not make GUI require wxWidgets > 2.8 nor wxWidgets compiled with STL but makes the code compatible with more recent versions of wxWidgets compiled with STL.

See also [the wxWidgets wiki about this topic](https://wiki.wxwidgets.org/Updating_to_the_Latest_Version_of_wxWidgets#wxUSE_STL).