### PR TITLE
Include <ctime> for clock()

### DIFF
--- a/include/openbabel/obutil.h
+++ b/include/openbabel/obutil.h
@@ -36,6 +36,10 @@ GNU General Public License for more details.
 #endif
 #endif
 
+#if HAVE_CLOCK_T
+#include <ctime>
+#endif
+
 #include <math.h>
 
 #ifndef M_PI


### PR DESCRIPTION
The code started to fail to build with gcc 12.2.0 here without this
patch, but including what is used should be a sensible thing anyway.