### PR TITLE
Add missing include of <ctime> to fix build with glibc 2.36

### DIFF
--- a/include/openbabel/obutil.h
+++ b/include/openbabel/obutil.h
@@ -36,6 +36,10 @@ GNU General Public License for more details.
 #endif
 #endif
 
+#if HAVE_CLOCK_T
+#include <ctime>
+#endif
+
 #include <math.h>
 
 #ifndef M_PI


### PR DESCRIPTION
| include/openbabel/obutil.h:65:14: error: 'clock' was not declared in this scope
|    65 |       start= clock();
|       |              ^~~~~
| include/openbabel/obutil.h:40:1: note: 'clock' is defined in header '<ctime>'; did you forget to '#include <ctime>'?
|    39 | #include <math.h>
|   +++ |+#include <ctime>
|    40 |
| include/openbabel/obutil.h: In member function 'double OpenBabel::OBStopwatch::Lap()':
| include/openbabel/obutil.h:70:13: error: 'clock' was not declared in this scope
|    70 |       stop= clock();
|       |             ^~~~~
| include/openbabel/obutil.h:70:13: note: 'clock' is defined in header '<ctime>'; did you forget to '#include <ctime>'?
| include/openbabel/obutil.h:71:40: error: 'CLOCKS_PER_SEC' was not declared in this scope
|    71 |       return((stop - start) / (double) CLOCKS_PER_SEC);
|       |                                        ^~~~~~~~~~~~~~
| include/openbabel/obutil.h:71:40: note: the macro 'CLOCKS_PER_SEC' had not yet been defined

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>