### PR TITLE
document silent deps: maeparser and CoordgenLibs

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -12,7 +12,8 @@ Requirements
  -- libxml2 (optional)
  -- zlib (optional)
  -- wxWidgets 2.8 (optional, needed to build GUI)
-
+ -- maeparser (optional, will download and auto-build if not present)
+ -- CoordgenLibs (optional, will download and auto-build if not present)
 
 Basic Installation
 ==================


### PR DESCRIPTION
Packagers need to know of these silent dependencies like maeparser and CoordgenLibs so that they can be properly managed. Otherwise re-building the package is not reproducible.