### PR TITLE
Fix bug in pubchem json coordinate writing

### DIFF
--- a/src/formats/json/pubchemjsonformat.cpp
+++ b/src/formats/json/pubchemjsonformat.cpp
@@ -760,7 +760,7 @@ class PubChemJSONFormat : public OBMoleculeFormat
       // Coordinates
       // TODO: An option to round coordinates to n decimal places?
       xcoords.PushBack(rapidjson::Value(patom->GetX()).Move(), al);
-      ycoords.PushBack(rapidjson::Value(patom->GetX()).Move(), al);
+      ycoords.PushBack(rapidjson::Value(patom->GetY()).Move(), al);
       if (pmol->GetDimension() == 3) {
         zcoords.PushBack(rapidjson::Value(patom->GetZ()).Move(), al);
       }


### PR DESCRIPTION
In current master, when converting to pubchem json, x coordinates are always identical to y coordinates. This PR fixes that bug.