### PR TITLE
Fix bug in distance geometry code

### DIFF
--- a/src/distgeom.cpp
+++ b/src/distgeom.cpp
@@ -529,10 +529,10 @@ namespace OpenBabel {
 
               float lBounds = _d->GetLowerBounds(a->GetIdx() - 1, d->GetIdx() - 1) + DIST14_TOL;
               float uBounds = _d->GetUpperBounds(a->GetIdx() - 1, d->GetIdx() - 1) - DIST14_TOL;
-              if (ct->IsTrans(a, d)) {
+              if (ct->IsTrans(a->GetId(), d->GetId())) {
                 // lower bounds should be trans (current upper bounds)
                 _d->SetLowerBounds(a->GetIdx() - 1, d->GetIdx() - 1, uBounds - DIST14_TOL);
-              } else if (ct->IsCis(a, d)) {
+              } else if (ct->IsCis(a->GetId(), d->GetId())) {
                 // upper bounds should be cis (current lower bounds)
                 _d->SetUpperBounds(a->GetIdx() - 1, d->GetIdx() - 1, lBounds + DIST14_TOL);
               }


### PR DESCRIPTION
This bug was discovered while testing out the new iterators. The old iterator marcos used iterators that had an operator bool() which implicitly converts into unsigned long. Instead of using the atom's id, a boolean value was used for IsCis/IsTrans.