### PR TITLE
Support for segment names in pdb files

### DIFF
--- a/include/openbabel/residue.h
+++ b/include/openbabel/residue.h
@@ -79,6 +79,8 @@ namespace OpenBabel {
     //! MODRES records for modified residues:
     //! http://www.rcsb.org/pdb/file_formats/pdb/pdbguide2.2/part_36.html
     void    SetName(const std::string &resname);
+    //! \brief Set the segment name of this residue (max four characters)
+    void    SetSegName(const std::string &segname);    
     //! Set the residue number (in the sequence)
     void    SetNum(const unsigned int resnum);
     void    SetNum(const std::string  resnum);
@@ -104,6 +106,8 @@ namespace OpenBabel {
 
     //! \return The residue name
     std::string    GetName(void)                  const;
+    //! \return The residue segment name
+    std::string    GetSegName(void)                  const;    
     //! \return The residue number (in the sequence)
     int    GetNum(void);
     std::string     GetNumString(void);
@@ -177,6 +181,7 @@ namespace OpenBabel {
     unsigned int              _reskey;//!< Residue key ID -- see SetResidueKeys()
     std::string               _resnum;//!< Residue number (i.e., in file) 23, 1B, etc.
     std::string               _resname;//!<Residue text name
+    std::string               _segname;//!<Segment text name
     char                _insertioncode;//!<PBB insertion code
 
     std::vector<bool>         _hetatm;//!< Is a given atom a HETAM

--- a/include/openbabel/residue.h
+++ b/include/openbabel/residue.h
@@ -107,7 +107,7 @@ namespace OpenBabel {
     //! \return The residue name
     std::string    GetName(void)                  const;
     //! \return The residue segment name
-    std::string    GetSegName(void)                  const;    
+    std::string    GetSegName(void)               const;    
     //! \return The residue number (in the sequence)
     int    GetNum(void);
     std::string     GetNumString(void);

--- a/src/residue.cpp
+++ b/src/residue.cpp
@@ -961,6 +961,11 @@ namespace OpenBabel
     SetResidueKeys(_resname.c_str(), _reskey, _aakey);
   }
 
+  void OBResidue::SetSegName(const string &name)
+  {
+    _segname = name;
+  }  
+
   void OBResidue::SetNum(const unsigned int resnum)
   {
     stringstream temp;
@@ -1035,6 +1040,11 @@ namespace OpenBabel
   string OBResidue::GetName(void) const
   {
     return _resname;
+  }
+
+  string OBResidue::GetSegName(void) const
+  {
+    return _segname;
   }
 
   std::string OBResidue::GetNumString(void)

--- a/test/testpdbformat.py
+++ b/test/testpdbformat.py
@@ -18,10 +18,33 @@ and so you can quickly develop the tests and try them out.
 import unittest
 
 from testbabel import run_exec, executable, BaseTest
+from testbindings import pybel
 
 class TestPDBFormat(BaseTest):
     """A series of tests relating to PDB"""
 
+    def testSegname(self):
+      """Test that different segments are put in different residues"""
+      mol = pybel.readstring('pdb','''ATOM    102  N   CYS A  16      59.916  27.715  54.719  1.00 30.93         A N
+ATOM    104  C   CYS A  16      61.349  29.663  54.116  1.00 31.27         A C
+ATOM    105  O   CYS A  16      62.398  30.296  54.175  1.00 31.42         A O
+ATOM    106  CB  CYS A  16      62.233  27.349  54.045  1.00 30.95         A C
+ATOM    107  SG  CYS A  16      62.584  25.823  54.921  1.00 31.06         A S
+ATOM   2492  N   CYS A  16      46.752  17.445  54.719  1.00 30.93         B N
+ATOM   2493  CA  CYS A  16      45.412  16.879  54.750  1.00 31.03         B C
+ATOM   2494  C   CYS A  16      45.319  15.497  54.116  1.00 31.27         B C
+ATOM   2495  O   CYS A  16      44.270  14.864  54.175  1.00 31.42         B O
+ATOM   2496  CB  CYS A  16      44.435  17.811  54.045  1.00 30.95         B C
+ATOM   2497  SG  CYS A  16      44.084  19.337  54.921  1.00 31.06         B S
+''')
+      self.assertTrue(len(mol.residues) == 2)
+      cnts = {'A':0,'B':0}
+      for a in mol.atoms:
+          r = a.OBAtom.GetResidue()
+          cnts[r.GetSegName().strip()] += 1
+      self.assertEqual(cnts['A'],5)
+      self.assertEqual(cnts['B'],6)
+    
     def testInsertionCodes(self):
         """
         Testing a PDB entry with insertion codes to distinguish residues


### PR DESCRIPTION
This adds support for handling segment names in pdb files (they were previously ignored).  Importantly, atoms with different segments are now placed in different residues.  When building biological assemblies, Prody distinguishes between the mirrored chains of an assembly by setting their segment names.  Without this fix, you will end up with multiple residues within a single OBResidue.