### PR TITLE
Restore compatibility with libxml 2.12.7

### DIFF
--- a/src/formats/xml/xml.cpp
+++ b/src/formats/xml/xml.cpp
@@ -242,13 +242,12 @@ namespace OpenBabel
 
     if(result==-1)
     {
-      xmlError* perr = xmlGetLastError();
+      const xmlError* perr = xmlGetLastError();
       if(perr && perr->level!=XML_ERR_NONE)
         {
           obErrorLog.ThrowError("XML Parser " + GetInFilename(),
                                 perr->message, obError);
         }
-      xmlResetError(perr);
       GetInStream()->setstate(ios::eofbit);
       return false;
     }


### PR DESCRIPTION
This PR fixes the single incompatibility with libxml 2.12.7 which [has been reported on Debian package](https://bugs.debian.org/1073327). Please note this PR does not update the libxml sources as included under `include/libxml/`.