### PR TITLE
Fix crash on specific CML format

### DIFF
--- a/src/formats/xml/cmlformat.cpp
+++ b/src/formats/xml/cmlformat.cpp
@@ -1113,7 +1113,7 @@ namespace OpenBabel
                     pbond2 = _pmol->GetBond(AtomRefIdx[2],AtomRefIdx[3]);
                   }
 
-                if(!pbond1 || !pbond2)
+                if(!pbond1 || !pbond2 || AtomRefIdx.empty())
                   continue;
 
                 // Create the list of 4 atomrefs


### PR DESCRIPTION
Fixes crash which happens for this structure:
```xml
<molecule molID="m1">
  <atomArray atomID="a1 a2 a3 a4 a5 a6" elementType="C O C O C O" />
  <bondArray>
    <bond id="b1" atomRefs2="a1 a2" order="2">
      <bondStereo>C</bondStereo>
    </bond>
    <bond id="b2" atomRefs2="a2 a3" order="1" />
    <bond id="b3" atomRefs2="a3 a4" order="2">
      <bondStereo>C</bondStereo>
    </bond>
    <bond id="b4" atomRefs2="a4 a5" order="1" />
    <bond id="b5" atomRefs2="a5 a6" order="2">
      <bondStereo>C</bondStereo>
    </bond>
    <bond id="b6" atomRefs2="a1 a6" order="1" />
  </bondArray>
</molecule>

```