### PR TITLE
Don't crash on an invalid InChI

### DIFF
--- a/src/formats/inchiformat.cpp
+++ b/src/formats/inchiformat.cpp
@@ -97,7 +97,7 @@ bool InChIFormat::ReadMolecule(OBBase* pOb, OBConversion* pConv)
 
   if (ret!=inchi_Ret_OKAY)
   {
-    string mes = out.szMessage;
+    string mes = out.szMessage ? out.szMessage : "";
     if (!mes.empty()) {
       Trim(mes);
       obErrorLog.ThrowError("InChI code", "For " + inchi + "\n  " + mes, obWarning);


### PR DESCRIPTION
This fixes a crash when an invalid InChI is provided. For example: `InChI=1S/H2O_h1H2`