### PR TITLE
Fetch more recent rapidjson codebase rather than last release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,7 +571,7 @@ if(WITH_JSON)
   endif()
   # Otherwise download rapidjson to openbabel source directory
   if (NOT RAPIDJSON_FOUND OR RAPIDJSON_VERSION VERSION_LESS ${RAPIDJSON_VERSION_MIN})
-    set(RAPIDJSON_VERSION 1.1.0-dev)
+    set(RAPIDJSON_VERSION master)
     if(NOT EXISTS "${openbabel_SOURCE_DIR}/external/rapidjson-${RAPIDJSON_VERSION}")
       file(DOWNLOAD "https://github.com/Tencent/rapidjson/archive/refs/heads/master.zip"
         "${openbabel_SOURCE_DIR}/external/rapidjson-${RAPIDJSON_VERSION}.tar.gz" STATUS status)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,9 +571,9 @@ if(WITH_JSON)
   endif()
   # Otherwise download rapidjson to openbabel source directory
   if (NOT RAPIDJSON_FOUND OR RAPIDJSON_VERSION VERSION_LESS ${RAPIDJSON_VERSION_MIN})
-    set(RAPIDJSON_VERSION master)
+    set(RAPIDJSON_VERSION "7c73dd7de7c4f14379b781418c6e947ad464c818")
     if(NOT EXISTS "${openbabel_SOURCE_DIR}/external/rapidjson-${RAPIDJSON_VERSION}")
-      file(DOWNLOAD "https://github.com/Tencent/rapidjson/archive/refs/heads/master.zip"
+      file(DOWNLOAD "https://github.com/Tencent/rapidjson/archive/${RAPIDJSON_VERSION}.tar.gz"
         "${openbabel_SOURCE_DIR}/external/rapidjson-${RAPIDJSON_VERSION}.tar.gz" STATUS status)
       execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
         ${openbabel_SOURCE_DIR}/external/rapidjson-${RAPIDJSON_VERSION}.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,9 +571,9 @@ if(WITH_JSON)
   endif()
   # Otherwise download rapidjson to openbabel source directory
   if (NOT RAPIDJSON_FOUND OR RAPIDJSON_VERSION VERSION_LESS ${RAPIDJSON_VERSION_MIN})
-    set(RAPIDJSON_VERSION 1.1.0)
+    set(RAPIDJSON_VERSION 1.1.0-dev)
     if(NOT EXISTS "${openbabel_SOURCE_DIR}/external/rapidjson-${RAPIDJSON_VERSION}")
-      file(DOWNLOAD "https://github.com/Tencent/rapidjson/archive/v${RAPIDJSON_VERSION}.tar.gz"
+      file(DOWNLOAD "https://github.com/Tencent/rapidjson/archive/refs/heads/master.zip"
         "${openbabel_SOURCE_DIR}/external/rapidjson-${RAPIDJSON_VERSION}.tar.gz" STATUS status)
       execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
         ${openbabel_SOURCE_DIR}/external/rapidjson-${RAPIDJSON_VERSION}.tar.gz


### PR DESCRIPTION
Version 1.1.0 of rapidjson is now 8 years old, and building Open Babel is currently broken on recent Linux systems as a result. Using the current code incorporates the many patches since 2016 such as [this PR](https://github.com/Tencent/rapidjson/pull/719).