### PR TITLE
Fix memory leak in Smilesformat

### DIFF
--- a/src/formats/smilesformat.cpp
+++ b/src/formats/smilesformat.cpp
@@ -394,17 +394,21 @@ namespace OpenBabel {
     if (!ParseSmiles(mol, s) || (!mol.IsReaction() && mol.NumAtoms() == 0))
       {
         mol.Clear();
+        for (auto i = _tetrahedralMap.begin(); i != _tetrahedralMap.end(); ++i)
+          delete i->second;
+        _tetrahedralMap.clear();
+
+        for (auto j = _squarePlanarMap.begin(); j != _squarePlanarMap.end(); ++j)
+          delete j->second;
+        _squarePlanarMap.clear();
         return(false);
       }
 
-    // TODO: Is the following a memory leak? - there are return statements above
-    map<OBAtom*, OBTetrahedralStereo::Config*>::iterator i;
-    for (i = _tetrahedralMap.begin(); i != _tetrahedralMap.end(); ++i)
+    for (auto i = _tetrahedralMap.begin(); i != _tetrahedralMap.end(); ++i)
       delete i->second;
     _tetrahedralMap.clear();
 
-    map<OBAtom*, OBSquarePlanarStereo::Config*>::iterator j;
-    for (j = _squarePlanarMap.begin(); j != _squarePlanarMap.end(); ++j)
+    for (auto j = _tetrahedralMap.begin(); j != _tetrahedralMap.end(); ++j)
       delete j->second;
     _squarePlanarMap.clear();
 


### PR DESCRIPTION
==============================
*** Open Babel Warning  in ParseRingBond
  Invalid SMILES: Ring closures imply atom bonded to itself.

================================================================= ==35113==ERROR: LeakSanitizer: detected memory leaks
                                                                                                                                                  
Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x5a01b134203d in operator new(unsigned long) (/home/uos/poc_openbabel/1poc+0xdd03d) (BuildId: 0a293d1623e155ad39e4ad53d549349de7a0bb57)   
    #1 0x78faa6d2c6d5 in OpenBabel::OBSmilesParser::ParseComplex(OpenBabel::OBMol&) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/formats/smilesformat.cpp:1750:41
    #2 0x78faa6d16601 in OpenBabel::OBSmilesParser::ParseSmiles(OpenBabel::OBMol&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/formats/smilesformat.cpp:481:14
    #3 0x78faa6d138b9 in OpenBabel::OBSmilesParser::SmiToMol(OpenBabel::OBMol&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/formats/smilesformat.cpp:394:10
    #4 0x78faa6d132e9 in OpenBabel::SMIBaseFormat::ReadMolecule(OpenBabel::OBBase*, OpenBabel::OBConversion*) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/formats/smilesformat.cpp:380:15
    #5 0x78faae550f1f in OpenBabel::OBConversion::Read(OpenBabel::OBBase*, std::istream*) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/obconversion.cpp:873:30
    #6 0x78faae5553bc in OpenBabel::OBConversion::ReadString(OpenBabel::OBBase*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/obconversion.cpp:1077:12
    #7 0x5a01b1344b8a in main /home/uos/poc_openbabel/poc.cc:42:12
    #8 0x78faaca29d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x5a01b134203d in operator new(unsigned long) (/home/uos/poc_openbabel/1poc+0xdd03d) (BuildId: 0a293d1623e155ad39e4ad53d549349de7a0bb57)   
    #1 0x78faaddbf4d7 in __gnu_cxx::new_allocator<unsigned long>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:127:27
    #2 0x78faaddbf40a in std::allocator_traits<std::allocator<unsigned long> >::allocate(std::allocator<unsigned long>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:464:20
    #3 0x78faaddbf39f in std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_M_allocate(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:346:20
    #4 0x78faaddbeec3 in std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_M_create_storage(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:361:33
    #5 0x78faaddbe5f3 in std::_Vector_base<unsigned long, std::allocator<unsigned long> >::_Vector_base(unsigned long, std::allocator<unsigned long> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:305:9
    #6 0x78faa6d7e381 in std::vector<unsigned long, std::allocator<unsigned long> >::vector(unsigned long, unsigned long const&, std::allocator<unsigned long> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_vector.h:524:9
    #7 0x78faa6d2c8d5 in OpenBabel::OBSmilesParser::ParseComplex(OpenBabel::OBMol&) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/formats/smilesformat.cpp:1751:45
    #8 0x78faa6d16601 in OpenBabel::OBSmilesParser::ParseSmiles(OpenBabel::OBMol&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/formats/smilesformat.cpp:481:14
    #9 0x78faa6d138b9 in OpenBabel::OBSmilesParser::SmiToMol(OpenBabel::OBMol&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/formats/smilesformat.cpp:394:10
    #10 0x78faa6d132e9 in OpenBabel::SMIBaseFormat::ReadMolecule(OpenBabel::OBBase*, OpenBabel::OBConversion*) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/formats/smilesformat.cpp:380:15
    #11 0x78faae550f1f in OpenBabel::OBConversion::Read(OpenBabel::OBBase*, std::istream*) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/obconversion.cpp:873:30
    #12 0x78faae5553bc in OpenBabel::OBConversion::ReadString(OpenBabel::OBBase*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) /home/uos/poc_openbabel/openbabel-openbabel-3-1-1/src/obconversion.cpp:1077:12
    #13 0x5a01b1344b8a in main /home/uos/poc_openbabel/poc.cc:42:12
    #14 0x78faaca29d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

SUMMARY: AddressSanitizer: 80 byte(s) leaked in 2 allocation(s).