### PR TITLE
Implement fuzz_convert fuzzer

### DIFF
--- a/src/data.cpp
+++ b/src/data.cpp
@@ -704,7 +704,7 @@ namespace OpenBabel
                 strncpy(charBuffer, p1, (p2 - p1));
                 charBuffer[(p2 - p1)] = '\0';
                 ParseLine(charBuffer);
-                p1 = ++p2;
+                p1 = p2 + 1;
               }
         }
       else

--- a/src/formats/MCDLformat.cpp
+++ b/src/formats/MCDLformat.cpp
@@ -239,7 +239,7 @@ private:
     char strg[MAXFRAGS+1];
     char * strngs[MAXFRAGS+1];
     char tstr[MAXFRAGS+1];
-    int  numdups, dupfrag, jump;
+    int  numdups = 0, dupfrag, jump;
     bool jflag;
     int  ix[MAXFRAGS],conntab[MAXBONDS][4],cx[MAXFRAGS];
     int  mx[MAXFRAGS];

--- a/src/formats/abinitformat.cpp
+++ b/src/formats/abinitformat.cpp
@@ -220,6 +220,9 @@ namespace OpenBabel
 
     mol.EndModify();
 
+    if (natom == 0)
+      return false;
+
     int numConformers = atomPositions.size() / natom;
     for (int i = 0; i < numConformers; ++i) {
       double *coordinates = new double[natom * 3];

--- a/src/formats/adfformat.cpp
+++ b/src/formats/adfformat.cpp
@@ -868,7 +868,7 @@ bool OBT41Format::ReadASCII( OBBase* pOb, OBConversion* pConv )
 
       string buf;
       // nuuc
-      while( buf != "Geometry" ) ifs >> buf; cout << buf << endl;
+      while( buf != "Geometry" && ifs ) ifs >> buf; cout << buf << endl;
       ifs >> buf; cout << buf << endl;
       if( buf != "nnuc" )
       {

--- a/src/formats/gulpformat.cpp
+++ b/src/formats/gulpformat.cpp
@@ -332,7 +332,8 @@ namespace OpenBabel {
             enthalpy_eV = atof(vs[4].c_str());
           }
 
-          ifs.getline(buffer,BUFF_SIZE);
+          if (!ifs.getline(buffer,BUFF_SIZE))
+            break;
         }
         if (hasPV)
           pmol->SetEnergy((enthalpy_eV - pv_eV) * EV_TO_KCAL_PER_MOL);

--- a/src/formats/xsfformat.cpp
+++ b/src/formats/xsfformat.cpp
@@ -168,6 +168,9 @@ namespace OpenBabel
     mol.EndModify();
 
     int natom = mol.NumAtoms();
+    if (natom == 0)
+      return false;
+
     int numConformers = atomPositions.size() / natom;
     for (int i = 0; i < numConformers; ++i) {
       double *coordinates = new double[natom * 3];

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -325,4 +325,7 @@ if(DEFINED ENV{LIB_FUZZING_ENGINE})
   add_executable(fuzz_obconversion_sdf fuzz/fuzz_obconversion.cpp)
   target_compile_definitions(fuzz_obconversion_sdf PRIVATE -DFUZZ_INPUT_FORMAT="SDF")
   target_link_libraries(fuzz_obconversion_sdf ${libs} $ENV{LIB_FUZZING_ENGINE})
+
+  add_executable(fuzz_convert fuzz/fuzz_convert.cpp)
+  target_link_libraries(fuzz_convert ${libs} $ENV{LIB_FUZZING_ENGINE})
 endif()

--- a/test/fuzz/fuzz_convert.cpp
+++ b/test/fuzz/fuzz_convert.cpp
@@ -1,0 +1,41 @@
+#include <openbabel/babelconfig.h>
+#include <openbabel/mol.h>
+#include <openbabel/obconversion.h>
+#include <cstdlib>
+#include <stdio.h>
+#include <sstream>
+
+#include <fuzzer/FuzzedDataProvider.h>
+
+std::vector<std::string> getAllFormats() {
+    std::vector<std::string> formats;
+    OpenBabel::OBPlugin::ListAsVector("formats", "ids", formats);
+    std::sort(formats.begin(), formats.end());
+    return formats;
+}
+
+const char *randomFormat(FuzzedDataProvider &fdp) {
+    static std::vector<std::string> formats = getAllFormats();
+    return formats[fdp.ConsumeIntegralInRange<int>(0, formats.size() - 1)].c_str();
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    using namespace OpenBabel;
+    obErrorLog.StopLogging();
+
+    FuzzedDataProvider fdp(Data, Size);
+    OBConversion conv;
+    conv.SetInFormat(randomFormat(fdp));
+    conv.SetOutFormat(randomFormat(fdp));
+
+    std::ostringstream outStream;
+    std::istringstream inStream(fdp.ConsumeRandomLengthString());
+
+    try {
+        conv.Convert(&inStream, &outStream);
+    } catch (...) {
+        // no error handling
+    }
+
+    return 0;
+}


### PR DESCRIPTION
A new fuzzer is implemented - fuzz_convert. It tests `OBConversion::Convert` function will randomized input/output formats and data. It will help to find many crashes - some of them I will report one by one later, but we already can merge this PR to increase coverage. Additional changes in this PR:

1. src/data.cpp: oot of bound read in `OBGlobalDataBase::Init()`
2. src/formats/MCDLformat.cpp: usage of uninitialized variable `numdups` that leads to OOM or crashes
3. src/formats/adfformat.cpp: fix infinite loop in case of unexpected end of input
4. src/formats/abinitformat.cpp: prevent division by zero
5. src/formats/gulpformat.cpp: fix infinite loop in case of unexpected end of input
6. src/formats/xsfformat.cpp: prevent division by zero