### PR TITLE
Fix stack-buffer-overflow for MOPAC format parser

### DIFF
--- a/src/formats/mopacformat.cpp
+++ b/src/formats/mopacformat.cpp
@@ -161,7 +161,7 @@ namespace OpenBabel
             ifs.getline(buffer,BUFF_SIZE);	// column headings
             ifs.getline(buffer,BUFF_SIZE);
             tokenize(vs,buffer);
-            while (vs.size() == 5)
+            while (vs.size() == 5 && numTranslationVectors < 3)
               {
                 x = atof((char*)vs[2].c_str());
                 y = atof((char*)vs[3].c_str());
@@ -385,6 +385,9 @@ namespace OpenBabel
             }
             ifs.getline(buffer, BUFF_SIZE); // blank
 
+            if (frequencies.size() < displacements.size())
+              break;
+
             // now real work
             unsigned int prevModeCount = displacements.size();
             unsigned int newModes = frequencies.size() - displacements.size();
@@ -433,7 +436,7 @@ namespace OpenBabel
           {
             unsigned int currentIntensity = intensities.size();
             tokenize(vs, buffer);
-            if (vs.size() < 2)
+            if (vs.size() < 2 || frequencies.size() <= currentIntensity)
               break;
 
             double transDipole = atof(vs[1].c_str());
@@ -442,6 +445,7 @@ namespace OpenBabel
       }
 
     if (mol.NumAtoms() == 0) { // e.g., if we're at the end of a file PR#1737209
+      delete dipoleMoment;
       mol.EndModify();
       return false;
     }
@@ -456,6 +460,11 @@ namespace OpenBabel
 
     if (hasPartialCharges)
       {
+        if (mol.NumAtoms() >= charges.size()) {
+          delete dipoleMoment;
+          return false;
+        }
+
         mol.SetPartialChargesPerceived();
         FOR_ATOMS_OF_MOL(atom, mol) {
           atom->SetPartialCharge(charges[atom->GetIdx()-1]); // atom index issue


### PR DESCRIPTION
This patch fixes he following issue

```
==104422==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fd9cdb883e8 at pc 0x55eddadbfd07 bp 0x7ffeb11cd890 sp 0x7ffeb11cd888
WRITE of size 8 at 0x7fd9cdb883e8 thread T0
    #0 0x55eddadbfd06 in OpenBabel::vector3::Set(double, double, double) /home/misha/work/relax/github.com/openbabel/openbabel/include/openbabel/math/vector3.h:89:11
    #1 0x55eddae9d665 in OpenBabel::MOPACFormat::ReadMolecule(OpenBabel::OBBase*, OpenBabel::OBConversion*) /home/misha/work/relax/github.com/openbabel/openbabel/src/formats/mopacformat.cpp:171:61
    #2 0x55eddbb73fcf in OpenBabel::OBMoleculeFormat::ReadChemObjectImpl(OpenBabel::OBConversion*, OpenBabel::OBFormat*) /home/misha/work/relax/github.com/openbabel/openbabel/src/obmolecformat.cpp:101:18
    #3 0x55eddac0d366 in OpenBabel::OBMoleculeFormat::ReadChemObject(OpenBabel::OBConversion*) /home/misha/work/relax/github.com/openbabel/openbabel/include/openbabel/obmolecformat.h:104:12
    #4 0x55eddab3371b in OpenBabel::OBConversion::Convert() /home/misha/work/relax/github.com/openbabel/openbabel/src/obconversion.cpp:542:30
    #5 0x55eddab3173e in OpenBabel::OBConversion::Convert(std::istream*, std::ostream*) /home/misha/work/relax/github.com/openbabel/openbabel/src/obconversion.cpp:478:17
    #6 0x55eddab1d22d in LLVMFuzzerTestOneInput /home/misha/work/relax/github.com/openbabel/openbabel/test/fuzz/fuzz_convert.cpp:35:14
    #7 0x55eddaa28060 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/misha/work/relax/github.com/openbabel/openbabel/myfuzzing/prefix/bin/fuzz_convert+0x7a0060) (BuildId: 8e6fee1c136aeecc9ec010dd3bb6e6602f8d1f54)
    #8 0x55eddaa277d5 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (/home/misha/work/relax/github.com/openbabel/openbabel/myfuzzing/prefix/bin/fuzz_convert+0x79f7d5) (BuildId: 8e6fee1c136aeecc9ec010dd3bb6e6602f8d1f54)
    #9 0x55eddaa28fb5 in fuzzer::Fuzzer::MutateAndTestOne() (/home/misha/work/relax/github.com/openbabel/openbabel/myfuzzing/prefix/bin/fuzz_convert+0x7a0fb5) (BuildId: 8e6fee1c136aeecc9ec010dd3bb6e6602f8d1f54)
    #10 0x55eddaa29bc5 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (/home/misha/work/relax/github.com/openbabel/openbabel/myfuzzing/prefix/bin/fuzz_convert+0x7a1bc5) (BuildId: 8e6fee1c136aeecc9ec010dd3bb6e6602f8d1f54)
    #11 0x55eddaa17d2b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/misha/work/relax/github.com/openbabel/openbabel/myfuzzing/prefix/bin/fuzz_convert+0x78fd2b) (BuildId: 8e6fee1c136aeecc9ec010dd3bb6e6602f8d1f54)
    #12 0x55eddaa40d62 in main (/home/misha/work/relax/github.com/openbabel/openbabel/myfuzzing/prefix/bin/fuzz_convert+0x7b8d62) (BuildId: 8e6fee1c136aeecc9ec010dd3bb6e6602f8d1f54)
    #13 0x7fd9cef99d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #14 0x7fd9cef99e3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #15 0x55eddaa0d194 in _start (/home/misha/work/relax/github.com/openbabel/openbabel/myfuzzing/prefix/bin/fuzz_convert+0x785194) (BuildId: 8e6fee1c136aeecc9ec010dd3bb6e6602f8d1f54)

Address 0x7fd9cdb883e8 is located in stack of thread T0 at offset 33768 in frame
    #0 0x55eddae9bc3f in OpenBabel::MOPACFormat::ReadMolecule(OpenBabel::OBBase*, OpenBabel::OBConversion*) /home/misha/work/relax/github.com/openbabel/openbabel/src/formats/mopacformat.cpp:69

  This frame has 48 object(s):
    [32, 32800) 'buffer' (line 80)
    [33056, 33088) 'str' (line 81)
    [33120, 33152) 'str1' (line 81)
    [33184, 33208) 'vs' (line 84)
    [33248, 33272) 'charges' (line 85)
    [33312, 33320) 'energy' (line 87)
    [33344, 33352) 'dipoleMoment' (line 88)
    [33376, 33400) 'displacements' (line 90)
    [33440, 33464) 'frequencies' (line 91)
    [33504, 33528) 'intensities' (line 91)
    [33568, 33592) 'orbitalEnergies' (line 92)
    [33632, 33656) 'orbitalSymmetries' (line 93)
    [33696, 33768) 'translationVectors' (line 96) <== Memory access at offset 33768 overflows this variable
    [33808, 33832) 'vic' (line 227)
    [33872, 33896) 'indices' (line 228)
    [33936, 33944) 'ref.tmp' (line 229)
    [33968, 33976) 'coord313' (line 240)
    [34000, 34004) 'ref.tmp330' (line 246)
    [34016, 34020) 'ref.tmp337' (line 247)
    [34032, 34036) 'ref.tmp344' (line 248)
    [34048, 34064) 'ref.tmp358' (line 257)
    [34080, 34088) '__begin7' (line 257)
    [34112, 34120) '__end7' (line 257)
    [34144, 34152) 'ref.tmp506' (line 292)
    [34176, 34184) 'ref.tmp579' (line 318)
    [34208, 34216) 'ref.tmp648' (line 340)
    [34240, 34272) 'ref.tmp723' (line 362)
    [34304, 34305) 'ref.tmp724' (line 362)
    [34320, 34328) 'ref.tmp794' (line 383)
    [34352, 34376) 'displacement' (line 393)
    [34416, 34440) 'x841' (line 401)
    [34480, 34504) 'y842' (line 401)
    [34544, 34568) 'z843' (line 401)
    [34608, 34616) 'ref.tmp852' (line 405)
    [34640, 34648) 'ref.tmp877' (line 411)
    [34672, 34680) 'ref.tmp901' (line 418)
    [34704, 34728) 'ref.tmp932' (line 425)
    [34768, 34776) 'ref.tmp994' (line 442)
    [34800, 34816) 'ref.tmp1057' (line 465)
    [34832, 34840) '__begin2' (line 465)
    [34864, 34872) '__end2' (line 465)
    [34896, 34928) 'ref.tmp1100' (line 471)
    [34960, 34961) 'ref.tmp1101' (line 471)
    [34976, 35000) 'agg.tmp'
    [35040, 35064) 'agg.tmp1144'
    [35104, 35128) 'agg.tmp1148'
    [35168, 35192) 'agg.tmp1169'
    [35232, 35256) 'agg.tmp1171'
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow /home/misha/work/relax/github.com/openbabel/openbabel/include/openbabel/math/vector3.h:89:11 in OpenBabel::vector3::Set(double, double, double)
Shadow bytes around the buggy address:
  0x7fd9cdb88100: f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2 00 00 00 00
  0x7fd9cdb88180: f2 f2 f2 f2 00 00 00 f2 f2 f2 f2 f2 00 00 00 f2
  0x7fd9cdb88200: f2 f2 f2 f2 00 f2 f2 f2 00 f2 f2 f2 00 00 00 f2
  0x7fd9cdb88280: f2 f2 f2 f2 00 00 00 f2 f2 f2 f2 f2 00 00 00 f2
  0x7fd9cdb88300: f2 f2 f2 f2 00 00 00 f2 f2 f2 f2 f2 00 00 00 f2
=>0x7fd9cdb88380: f2 f2 f2 f2 00 00 00 00 00 00 00 00 00[f2]f2 f2
  0x7fd9cdb88400: f2 f2 f8 f8 f8 f2 f2 f2 f2 f2 f8 f8 f8 f2 f2 f2
  0x7fd9cdb88480: f2 f2 f8 f2 f2 f2 f8 f2 f2 f2 f8 f2 f8 f2 f8 f2
  0x7fd9cdb88500: f8 f8 f2 f2 f8 f2 f2 f2 f8 f2 f2 f2 f8 f2 f2 f2
  0x7fd9cdb88580: f8 f2 f2 f2 f8 f2 f2 f2 f8 f8 f8 f8 f2 f2 f2 f2
  0x7fd9cdb88600: f8 f2 f8 f2 f2 f2 f8 f8 f8 f2 f2 f2 f2 f2 f8 f8
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==104422==ABORTING
MS: 1 CopyPart-; base unit: d398c0f0a9e6e3713b3730c7b751405cd45b5a52
artifact_prefix='./'; Test unit written to ./crash-ebba29f4ee3ab06fd4d227379772225ce84266a0
```
[crash-ebba29f4ee3ab06fd4d227379772225ce84266a0.txt](https://github.com/user-attachments/files/18049056/crash-ebba29f4ee3ab06fd4d227379772225ce84266a0.txt)

and additionally:

- memory leak due to missing `delete dipoleMoment`
- buffer overflow for `frequencies` array
- integer overflow for expression `unsigned int newModes = frequencies.size() - displacements.size()`

All these fixes are about malformed inputs, so I'm unsure if I implemented error handling properly. Please let me know if it can be improved. All these issues were found by the new fuzzer introduced in https://github.com/openbabel/openbabel/pull/2737