### PR TITLE
test: remove ADD_PYTHON_TEST

### DIFF
--- a/cmake/modules/UsePythonTest.cmake
+++ b/cmake/modules/UsePythonTest.cmake
@@ -1,8 +1,3 @@
-# Usage:
-# SET_SOURCE_FILES_PROPERTIES(test.py PROPERTIES PYTHONPATH
-#   "${LIBRARY_OUTPUT_PATH}:${VTK_DIR}")
-# ADD_PYTHON_TEST(PYTHON-TEST test.py)
-#
 #  Copyright (c) 2006-2010 Mathieu Malaterre <mathieu.malaterre@gmail.com>
 #
 #  Redistribution and use is allowed according to the terms of the New
@@ -26,16 +21,6 @@ if(NOT Python_EXECUTABLE)
   endif()
   return()
 endif(NOT Python_EXECUTABLE)
-
-MACRO(ADD_PYTHON_TEST TESTNAME FILENAME)
-  GET_SOURCE_FILE_PROPERTY(loc ${FILENAME} LOCATION)
-  GET_SOURCE_FILE_PROPERTY(pyenv ${FILENAME} PYTHONPATH)
-  GET_SOURCE_FILE_PROPERTY(ob_libdir ${FILENAME} BABEL_LIBDIR)
-  GET_SOURCE_FILE_PROPERTY(ob_datadir ${FILENAME} BABEL_DATADIR)
-  STRING(REGEX REPLACE ";" " " wo_semicolumn "${ARGN}")
-  ADD_TEST(NAME ${TESTNAME} COMMAND ${Python_EXECUTABLE} ${loc} ${wo_semicolumn})
-  SET_TESTS_PROPERTIES(${TESTNAME} PROPERTIES ENVIRONMENT "PYTHONPATH=${pyenv};LD_LIBRARY_PATH=${pyenv}:$ENV{LD_LIBRARY_PATH};BABEL_LIBDIR=${ob_libdir};BABEL_DATADIR=${ob_datadir}")
-ENDMACRO(ADD_PYTHON_TEST)
 
 # Byte compile recursively a directory (DIRNAME)
 MACRO(ADD_PYTHON_COMPILEALL_TEST DIRNAME)

--- a/cmake/modules/UsePythonTest.cmake
+++ b/cmake/modules/UsePythonTest.cmake
@@ -1,12 +1,3 @@
-# Add a python test from a python file
-# One cannot simply do:
-# SET(ENV{PYTHONPATH} ${LIBRARY_OUTPUT_PATH})
-# SET(my_test "from test_mymodule import *\;test_mymodule()")
-# ADD_TEST(PYTHON-TEST-MYMODULE  python -c ${my_test})
-# Since cmake is only transmitting the ADD_TEST line to ctest thus you are loosing
-# the env var. The only way to store the env var is to physically write in the cmake script
-# whatever PYTHONPATH you want and then add the test as 'cmake -P python_test.cmake'
-# 
 # Usage:
 # SET_SOURCE_FILES_PROPERTIES(test.py PROPERTIES PYTHONPATH
 #   "${LIBRARY_OUTPUT_PATH}:${VTK_DIR}")
@@ -42,31 +33,8 @@ MACRO(ADD_PYTHON_TEST TESTNAME FILENAME)
   GET_SOURCE_FILE_PROPERTY(ob_libdir ${FILENAME} BABEL_LIBDIR)
   GET_SOURCE_FILE_PROPERTY(ob_datadir ${FILENAME} BABEL_DATADIR)
   STRING(REGEX REPLACE ";" " " wo_semicolumn "${ARGN}")
-  FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME}.cmake
-"
-  SET(ENV{PYTHONPATH} ${pyenv})
-  SET(ENV{LD_LIBRARY_PATH} ${pyenv}:\$ENV{LD_LIBRARY_PATH})
-  SET(ENV{BABEL_LIBDIR} ${ob_libdir})
-  SET(ENV{BABEL_DATADIR} ${ob_datadir})
-  MESSAGE(\"${pyenv}\")
-  EXECUTE_PROCESS(
-  	COMMAND ${Python_EXECUTABLE} ${loc} ${wo_semicolumn}
-  	#WORKING_DIRECTORY @LIBRARY_OUTPUT_PATH@
-  	RESULT_VARIABLE import_res
-  	OUTPUT_VARIABLE import_output
-  	ERROR_VARIABLE  import_output
-  )
-  
-  # Pass the output back to ctest
-  IF(import_output)
-    MESSAGE(\${import_output})
-  ENDIF(import_output)
-  IF(import_res)
-    MESSAGE(SEND_ERROR \${import_res})
-  ENDIF(import_res)
-"
-)
-  ADD_TEST(${TESTNAME} ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/${TESTNAME}.cmake)
+  ADD_TEST(NAME ${TESTNAME} COMMAND ${Python_EXECUTABLE} ${loc} ${wo_semicolumn})
+  SET_TESTS_PROPERTIES(${TESTNAME} PROPERTIES ENVIRONMENT "PYTHONPATH=${pyenv};LD_LIBRARY_PATH=${pyenv}:$ENV{LD_LIBRARY_PATH};BABEL_LIBDIR=${ob_libdir};BABEL_DATADIR=${ob_datadir}")
 ENDMACRO(ADD_PYTHON_TEST)
 
 # Byte compile recursively a directory (DIRNAME)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -239,15 +239,10 @@ if(NOT MINGW AND NOT CYGWIN)
       babel gauss sym smartssym fastsearch distgeom unique kekule pdbformat RInChI)
 
     foreach(pytest ${pytests})
-      SET_SOURCE_FILES_PROPERTIES(test${pytest}.py PROPERTIES
-        PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}"
-        BABEL_LIBDIR "${FORMATDIR}"
-        BABEL_DATADIR "${CMAKE_SOURCE_DIR}/data"
-        LD_LIBRARY_PATH "${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}:$ENV{LD_LIBRARY_PATH}"
-      )
-      ADD_PYTHON_TEST(pytest_${pytest} test${pytest}.py)
+      ADD_TEST(NAME pytest_${pytest} COMMAND ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/test${pytest}.py")
       set_tests_properties(pytest_${pytest} PROPERTIES
         FAIL_REGULAR_EXPRESSION "ERROR;FAIL;Test failed"
+        ENVIRONMENT "PYTHONPATH=${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX};BABEL_LIBDIR=${FORMATDIR};BABEL_DATADIR=${CMAKE_SOURCE_DIR}/data;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}:$ENV{LD_LIBRARY_PATH}"
       )
     endforeach(pytest ${pytests})
   endif(Python_EXECUTABLE)
@@ -269,22 +264,16 @@ if(PYTHON_BINDINGS)
   )
 
   foreach(pybindtest ${pybindtests})
-    SET_SOURCE_FILES_PROPERTIES(test${pybindtest}.py PROPERTIES
-      PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}"
-      BABEL_LIBDIR "${FORMATDIR}"
-      BABEL_DATADIR "${CMAKE_SOURCE_DIR}/data"
-      LD_LIBRARY_PATH "${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}:$ENV{LD_LIBRARY_PATH}"
-    )
-
-    if(MSVC)
-      SET_SOURCE_FILES_PROPERTIES(test${pybindtest}.py PROPERTIES
-        PYTHONPATH "\"${CMAKE_SOURCE_DIR}/scripts/python;${CMAKE_BINARY_DIR}/bin/Release\""
-      )
+    if(NOT MSVC)
+      set(PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python:${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}")
+    else()
+      set(PYTHONPATH "${CMAKE_SOURCE_DIR}/scripts/python\;${CMAKE_BINARY_DIR}/bin/Release")
     endif()
 
-    ADD_PYTHON_TEST(pybindtest_${pybindtest} test${pybindtest}.py)
+    ADD_TEST(NAME pybindtest_${pybindtest} COMMAND ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/test${pybindtest}.py")
     set_tests_properties(pybindtest_${pybindtest} PROPERTIES
       FAIL_REGULAR_EXPRESSION "ERROR;FAIL;Test failed"
+      ENVIRONMENT "PYTHONPATH=${PYTHONPATH};BABEL_LIBDIR=${FORMATDIR};BABEL_DATADIR=${CMAKE_SOURCE_DIR}/data;LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib${LIB_SUFFIX}:$ENV{LD_LIBRARY_PATH}"
     )
   endforeach(pybindtest ${pybindtests})
 endif(PYTHON_BINDINGS)


### PR DESCRIPTION
At the moment ADD_PYTHON_TEST writes the command to a cmake file and execute it, but we don’t have to do that in such a way since environment variables can be set via test property.