### PR TITLE
Use include and source dirs provided by conda if in cond environment

### DIFF
--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -44,8 +44,8 @@ def locate_ob():
     otherwise guess default location."""
     CONDA_PREFIX = os.environ.get("CONDA_PREFIX", False)
     if CONDA_PREFIX is not False:
-        include_dirs = "${CONDA_PREFIX}/include/openbabel3/"
-        library_dirs = "${CONDA_PREFIX}/include/lib/"
+        include_dirs = f"{CONDA_PREFIX}/include/openbabel3/"
+        library_dirs = f"{CONDA_PREFIX}/include/lib/"
         print('Open Babel found in current conda environment:')
         return include_dirs, library_dirs
     try:

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -40,7 +40,14 @@ def pkgconfig(package, option):
 
 
 def locate_ob():
-    """Try use pkgconfig to locate Open Babel, otherwise guess default location."""
+    """Try to located openbable if installed in a conda env, then use pkgconfig to locate Open Babel, 
+    otherwise guess default location."""
+    CONDA_PREFIX = os.environ.get("CONDA_PREFIX", False)
+    if CONDA_PREFIX is not False:
+        include_dirs = "${CONDA_PREFIX}/include/openbabel3/"
+        library_dirs = "${CONDA_PREFIX}/include/lib/"
+        print('Open Babel found in current conda environment:')
+        return include_dirs, library_dirs
     try:
         # Warn if the (major, minor) version of the installed OB doesn't match these python bindings
         py_ver = StrictVersion(find_version())

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -40,12 +40,12 @@ def pkgconfig(package, option):
 
 
 def locate_ob():
-    """Try to located openbable if installed in a conda env, then use pkgconfig to locate Open Babel, 
+    """Try to located Open Babel if installed in a conda env, then use pkgconfig, 
     otherwise guess default location."""
     CONDA_PREFIX = os.environ.get("CONDA_PREFIX", False)
     if CONDA_PREFIX is not False:
-        include_dirs = f"{CONDA_PREFIX}/include/openbabel3/"
-        library_dirs = f"{CONDA_PREFIX}/include/lib/"
+        include_dirs = f"{CONDA_PREFIX}/include/openbabel3"
+        library_dirs = f"{CONDA_PREFIX}/include/lib"
         print('Open Babel found in current conda environment:')
         return include_dirs, library_dirs
     try:

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -42,16 +42,18 @@ def pkgconfig(package, option):
 def locate_ob():
     """Try to located Open Babel if installed in a conda env, then use pkgconfig, 
     otherwise guess default location."""
-    CONDA_PREFIX = os.environ.get("CONDA_PREFIX", False)
-    if CONDA_PREFIX is not False:
-        include_dirs = f"{CONDA_PREFIX}/include/openbabel3"
-        library_dirs = f"{CONDA_PREFIX}/include/lib"
-        print('Open Babel found in current conda environment:')
-        return include_dirs, library_dirs
     try:
         # Warn if the (major, minor) version of the installed OB doesn't match these python bindings
         py_ver = StrictVersion(find_version())
         py_major_ver, py_minor_ver = py_ver.version[:2]
+
+        CONDA_PREFIX = os.environ.get("CONDA_PREFIX", False)
+        if CONDA_PREFIX is not False:
+            include_dirs = f"{CONDA_PREFIX}/include/openbabel{py_major_ver}"
+            library_dirs = f"{CONDA_PREFIX}/include/lib"
+            print('Open Babel found in current conda environment:')
+            return include_dirs, library_dirs
+
         pcfile = 'openbabel-{}'.format(py_major_ver)
         ob_ver = StrictVersion(pkgconfig(pcfile, '--modversion'))
         if not ob_ver.version[:2] == py_ver.version[:2]:


### PR DESCRIPTION
This is mean to solve the problem that it is impossible to build a wheel for openbabel:

```
$ pip wheel openbabel --no-cache-dir
Collecting openbabel
  Downloading openbabel-3.1.1.1.tar.gz (82 kB)
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: openbabel
  Building wheel for openbabel (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [66 lines of output]
      running bdist_wheel
      running build
      running build_ext
      Warning: invalid version number '3.1.1.1'.
      Guessing Open Babel location:
      - include_dirs: ['/home/cvjjm/miniforge3/envs/conformer_generator/include/python3.12', '/usr/local/include/openbabel3']
      - library_dirs: ['/usr/local/lib']
      building 'openbabel._openbabel' extension
      swigging openbabel/openbabel-python.i to openbabel/openbabel-python_wrap.cpp
      swig -python -c++ -small -O -templatereduce -naturalvar -I/home/cvjjm/miniforge3/envs/conformer_generator/include/python3.12 -I/usr/local/include/openbabel3 -o openbabel/openbabel-python_wrap.cpp openbabel/openbabel-python.i
      openbabel/openbabel-python.i:246: Error: Unable to find 'openbabel/babelconfig.h'
      openbabel/openbabel-python.i:248: Error: Unable to find 'openbabel/data.h'
      openbabel/openbabel-python.i:249: Error: Unable to find 'openbabel/obutil.h'
      openbabel/openbabel-python.i:250: Error: Unable to find 'openbabel/math/vector3.h'
      openbabel/openbabel-python.i:252: Error: Unable to find 'openbabel/math/matrix3x3.h'
      openbabel/openbabel-python.i:253: Error: Unable to find 'openbabel/math/transform3d.h'
      openbabel/openbabel-python.i:254: Error: Unable to find 'openbabel/math/spacegroup.h'
      openbabel/openbabel-python.i:256: Error: Unable to find 'openbabel/bitvec.h'
      openbabel/openbabel-python.i:260: Error: Unable to find 'openbabel/base.h'
      openbabel/openbabel-python.i:262: Error: Unable to find 'openbabel/generic.h'
      openbabel/openbabel-python.i:265: Error: Unable to find 'openbabel/griddata.h'
      openbabel/openbabel-python.i:267: Error: Unable to find 'openbabel/chains.h'
      openbabel/openbabel-python.i:268: Error: Unable to find 'openbabel/typer.h'
      openbabel/openbabel-python.i:276: Error: Unable to find 'openbabel/plugin.h'
      openbabel/openbabel-python.i:281: Error: Unable to find 'openbabel/oberror.h'
      openbabel/openbabel-python.i:282: Error: Unable to find 'openbabel/format.h'
      openbabel/openbabel-python.i:283: Error: Unable to find 'openbabel/obconversion.h'
      openbabel/openbabel-python.i:284: Error: Unable to find 'openbabel/obfunctions.h'
      openbabel/openbabel-python.i:295: Error: Unable to find 'openbabel/elements.h'
      openbabel/openbabel-python.i:296: Error: Unable to find 'openbabel/residue.h'
      openbabel/openbabel-python.i:297: Error: Unable to find 'openbabel/internalcoord.h'
      openbabel/openbabel-python.i:298: Error: Unable to find 'openbabel/atom.h'
      openbabel/openbabel-python.i:299: Error: Unable to find 'openbabel/bond.h'
      openbabel/openbabel-python.i:300: Error: Unable to find 'openbabel/reaction.h'
      openbabel/openbabel-python.i:301: Error: Unable to find 'openbabel/reactionfacade.h'
      openbabel/openbabel-python.i:319: Error: Unable to find 'openbabel/mol.h'
      openbabel/openbabel-python.i:326: Error: Unable to find 'openbabel/ring.h'
      openbabel/openbabel-python.i:327: Error: Unable to find 'openbabel/parsmart.h'
      openbabel/openbabel-python.i:328: Error: Unable to find 'openbabel/alias.h'
      openbabel/openbabel-python.i:330: Error: Unable to find 'openbabel/fingerprint.h'
      openbabel/openbabel-python.i:332: Error: Unable to find 'openbabel/descriptor.h'
      openbabel/openbabel-python.i:343: Error: Unable to find 'openbabel/forcefield.h'
      openbabel/openbabel-python.i:345: Error: Unable to find 'openbabel/builder.h'
      openbabel/openbabel-python.i:346: Error: Unable to find 'openbabel/op.h'
      openbabel/openbabel-python.i:348: Error: Unable to find 'openbabel/chargemodel.h'
      openbabel/openbabel-python.i:351: Error: Unable to find 'openbabel/phmodel.h'
      openbabel/openbabel-python.i:352: Error: Unable to find 'openbabel/graphsym.h'
      openbabel/openbabel-python.i:353: Error: Unable to find 'openbabel/isomorphism.h'
      openbabel/openbabel-python.i:354: Error: Unable to find 'openbabel/query.h'
      openbabel/openbabel-python.i:355: Error: Unable to find 'openbabel/canon.h'
      openbabel/openbabel-python.i:357: Error: Unable to find 'openbabel/stereo/stereo.h'
      openbabel/openbabel-python.i:361: Error: Unable to find 'openbabel/rotor.h'
      openbabel/openbabel-python.i:363: Error: Unable to find 'openbabel/rotamer.h'
      openbabel/openbabel-python.i:364: Error: Unable to find 'openbabel/spectrophore.h'
      openbabel/openbabel-python.i:435: Error: Unable to find 'openbabel/obiter.h'
      openbabel/stereo.i:1: Error: Unable to find 'openbabel/stereo/tetranonplanar.h'
      openbabel/stereo.i:2: Error: Unable to find 'openbabel/stereo/tetraplanar.h'
      openbabel/stereo.i:3: Error: Unable to find 'openbabel/stereo/tetrahedral.h'
      openbabel/stereo.i:4: Error: Unable to find 'openbabel/stereo/cistrans.h'
      openbabel/stereo.i:5: Error: Unable to find 'openbabel/stereo/squareplanar.h'
      openbabel/stereo.i:6: Error: Unable to find 'openbabel/stereo/bindings.h'

      Error: SWIG failed. Is Open Babel installed?
      You may need to manually specify the location of Open Babel include and library directories. For example:
        python setup.py build_ext -I/usr/local/include/openbabel3 -L/usr/local/lib
        python setup.py install
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for openbabel
  Running setup.py clean for openbabel
Failed to build openbabel
ERROR: Failed to build one or more wheels
```

This alone would not be that bad, but because of the invalid version of openbael (see `invalid version number '3.1.1.1'` error message above), even if the correct version of openbabel is already installed via pip or conda in the active conda environment, if I then install a package that depends on openbabel, pip tries (for some reaons) to build a wheel of openbabel, which fails in the same way as the `pip wheel` command above.

At least if openbabel is already installed in the currently active conda environment, the change of this MR should enable the building of a wheel of openbable and thus allow for the pip installation of packages that depend on openbabel.