### PR TITLE
Fix Python bindings when Python is not installed in /usr/local/bin

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -111,20 +111,20 @@ if (DO_PYTHON_BINDINGS)
       if( "${PYTHON_INSTDIR}" STREQUAL "" )
         execute_process(
           COMMAND
-          ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix='${CMAKE_INSTALL_PREFIX}'))"
+          ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0))"
           OUTPUT_VARIABLE PYTHON_INSTDIR
           OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-	#workaround for https://bugs.launchpad.net/ubuntu/+source/python3-defaults/+bug/1814653
-	if(NOT ${PYTHON_INSTDIR} MATCHES "python[0-9].[0-9]")
-	  execute_process(
+        #workaround for https://bugs.launchpad.net/ubuntu/+source/python3-defaults/+bug/1814653
+        if(NOT ${PYTHON_INSTDIR} MATCHES "python[0-9].[0-9]")
+          execute_process(
            COMMAND
-           ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,1,prefix='${CMAKE_INSTALL_PREFIX}'))"
+           ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,1))"
            OUTPUT_VARIABLE PYTHON_INSTDIR
            OUTPUT_STRIP_TRAILING_WHITESPACE
           )
           set(PYTHON_INSTDIR "${PYTHON_INSTDIR}/dist-packages")
-	endif()
+        endif()
       endif()
         if(NOT BINDINGS_ONLY)
             add_dependencies(bindings_python openbabel)
@@ -149,7 +149,7 @@ if (DO_PYTHON_BINDINGS)
             SUFFIX .pyd )
         execute_process(
           COMMAND
-          ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix='${CMAKE_INSTALL_PREFIX}'))"
+          ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0))"
           OUTPUT_VARIABLE PYTHON_INSTDIR
           OUTPUT_STRIP_TRAILING_WHITESPACE
         )


### PR DESCRIPTION
This PR fixes an issue Python binding does not work when `python` is not in `/usr/local/bin`. This issue has been mentioned before, like https://github.com/openbabel/openbabel/issues/2413.
Current implementation sets PYTHON_INSTDIR using the get_python_lib() method with the `prefix` parameter, but I believe that CMAKE_INSTALL_PREFIX is not related to the location of Python packages. I believe just removing the `prefix` parameter works.