### PR TITLE
Bump cmake minimum to 3.5, add fixes to support python 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Please ensure that any changes remain compliant with 3.1.
 if(NOT EMBED_OPENBABEL)
-  cmake_minimum_required(VERSION 4.0)
+  cmake_minimum_required(VERSION 3.5)
 endif()
 
 project(openbabel)
@@ -11,7 +11,7 @@ set (CMAKE_CXX_STANDARD 11)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
   if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 NEW)
+    cmake_policy(SET CMP0042 OLD)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Please ensure that any changes remain compliant with 3.1.
 if(NOT EMBED_OPENBABEL)
-  cmake_minimum_required(VERSION 3.1)
+  cmake_minimum_required(VERSION 4.0)
 endif()
 
 project(openbabel)
@@ -11,7 +11,7 @@ set (CMAKE_CXX_STANDARD 11)
 if(COMMAND cmake_policy)
   cmake_policy(SET CMP0003 NEW)
   if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 OLD)
+    cmake_policy(SET CMP0042 NEW)
   endif()
 endif()
 

--- a/doc/examples/static_executable/CMakeLists.txt
+++ b/doc/examples/static_executable/CMakeLists.txt
@@ -25,7 +25,7 @@
 #
 
 # This line is required for cmake backwards compatibility.
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.5)
 
 # Name of your project
 project(myproject)

--- a/doc/examples/static_executable/CMakeLists.txt
+++ b/doc/examples/static_executable/CMakeLists.txt
@@ -25,7 +25,7 @@
 #
 
 # This line is required for cmake backwards compatibility.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 4.0)
 
 # Name of your project
 project(myproject)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.0)
+cmake_minimum_required(VERSION 4.0)
 # Library versioning (used in Mac Python bindings)x
 set(SOVERSION 4)
 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -108,24 +108,6 @@ if (DO_PYTHON_BINDINGS)
             PREFIX ""
             LIBRARY_OUTPUT_DIRECTORY "${openbabel_SOURCE_DIR}/scripts/python/openbabel/"
             SUFFIX .so )
-      if( "${PYTHON_INSTDIR}" STREQUAL "" )
-        execute_process(
-          COMMAND
-	  ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('purelib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}))"
-          OUTPUT_VARIABLE PYTHON_INSTDIR
-          OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-	#workaround for https://bugs.launchpad.net/ubuntu/+source/python3-defaults/+bug/1814653
-	if(NOT ${PYTHON_INSTDIR} MATCHES "python[0-9].[0-9]")
-	  execute_process(
-           COMMAND
-	   ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}))"
-           OUTPUT_VARIABLE PYTHON_INSTDIR
-           OUTPUT_STRIP_TRAILING_WHITESPACE
-          )
-          set(PYTHON_INSTDIR "${PYTHON_INSTDIR}/dist-packages")
-	endif()
-      endif()
         if(NOT BINDINGS_ONLY)
             add_dependencies(bindings_python openbabel)
         endif()

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 2.6.0)
 # Library versioning (used in Mac Python bindings)x
 set(SOVERSION 4)
 
@@ -111,7 +111,7 @@ if (DO_PYTHON_BINDINGS)
       if( "${PYTHON_INSTDIR}" STREQUAL "" )
         execute_process(
           COMMAND
-          ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix='${CMAKE_INSTALL_PREFIX}'))"
+	  ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('purelib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}))"
           OUTPUT_VARIABLE PYTHON_INSTDIR
           OUTPUT_STRIP_TRAILING_WHITESPACE
         )
@@ -119,7 +119,7 @@ if (DO_PYTHON_BINDINGS)
 	if(NOT ${PYTHON_INSTDIR} MATCHES "python[0-9].[0-9]")
 	  execute_process(
            COMMAND
-           ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,1,prefix='${CMAKE_INSTALL_PREFIX}'))"
+	   ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}))"
            OUTPUT_VARIABLE PYTHON_INSTDIR
            OUTPUT_STRIP_TRAILING_WHITESPACE
           )
@@ -149,7 +149,7 @@ if (DO_PYTHON_BINDINGS)
             SUFFIX .pyd )
         execute_process(
           COMMAND
-          ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix='${CMAKE_INSTALL_PREFIX}'))"
+	  ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}))"
           OUTPUT_VARIABLE PYTHON_INSTDIR
           OUTPUT_STRIP_TRAILING_WHITESPACE
         )

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -108,6 +108,14 @@ if (DO_PYTHON_BINDINGS)
             PREFIX ""
             LIBRARY_OUTPUT_DIRECTORY "${openbabel_SOURCE_DIR}/scripts/python/openbabel/"
             SUFFIX .so )
+	if( "${PYTHON_INSTDIR}" STREQUAL "" )
+          execute_process(
+            COMMAND
+           ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'base': '${CMAKE_INSTALL_PREFIX}'}))"
+            OUTPUT_VARIABLE PYTHON_INSTDIR
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+        endif()
         if(NOT BINDINGS_ONLY)
             add_dependencies(bindings_python openbabel)
         endif()

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -40,6 +40,7 @@ def pkgconfig(package, option):
 def locate_ob():
     """Try use pkgconfig to locate Open Babel, otherwise guess default location."""
     try:
+        # Warn if the (major, minor) version of the installed OB doesn't match these python bindings
         py_ver = Version(find_version())
         py_major_ver, py_minor_ver = py_ver.release[:2]
         pcfile = f'openbabel-{py_major_ver}'
@@ -84,6 +85,8 @@ class CustomSdist(sdist):
 class CustomBuildExt(build_ext):
     """Custom build_ext to set SWIG options and print a better error message."""
     def finalize_options(self):
+        # Setting include_dirs, library_dirs, swig_opts here instead of in Extension constructor allows them to be
+        # overridden using -I and -L command line options to python setup.py build_ext.
         super().finalize_options()
         self.ob_include_dir, self.ob_library_dir = locate_ob()
         self.include_dirs.append(self.ob_include_dir)
@@ -149,4 +152,3 @@ setup(
         'Topic :: Software Development :: Libraries'
     ]
 )
-

--- a/scripts/python/setup.py
+++ b/scripts/python/setup.py
@@ -4,14 +4,12 @@ import os
 import re
 import subprocess
 import sys
-from distutils.command.build import build
-from distutils.command.sdist import sdist
-from distutils.errors import DistutilsExecError
-from distutils.version import StrictVersion
+from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install
-from setuptools import setup, Extension
-
+from setuptools.command.sdist import sdist
+from setuptools.command.build import build
+from packaging.version import Version
 
 # Path to the directory that contains this setup.py file.
 base_dir = os.path.abspath(os.path.dirname(__file__))
@@ -42,19 +40,18 @@ def pkgconfig(package, option):
 def locate_ob():
     """Try use pkgconfig to locate Open Babel, otherwise guess default location."""
     try:
-        # Warn if the (major, minor) version of the installed OB doesn't match these python bindings
-        py_ver = StrictVersion(find_version())
-        py_major_ver, py_minor_ver = py_ver.version[:2]
-        pcfile = 'openbabel-{}'.format(py_major_ver)
-        ob_ver = StrictVersion(pkgconfig(pcfile, '--modversion'))
-        if not ob_ver.version[:2] == py_ver.version[:2]:
-            print('Warning: Open Babel {}.{}.x is required. Your version ({}) may not be compatible.'
-                  .format(py_major_ver, py_minor_ver, ob_ver))
+        py_ver = Version(find_version())
+        py_major_ver, py_minor_ver = py_ver.release[:2]
+        pcfile = f'openbabel-{py_major_ver}'
+        ob_ver = Version(pkgconfig(pcfile, '--modversion'))
+        if ob_ver.release[:2] != (py_major_ver, py_minor_ver):
+            print(f'Warning: Open Babel {py_major_ver}.{py_minor_ver}.x is required. '
+                  f'Your version ({ob_ver}) may not be compatible.')
         include_dirs = pkgconfig(pcfile, '--variable=pkgincludedir')
         library_dirs = pkgconfig(pcfile, '--variable=libdir')
         print('Open Babel location automatically determined by pkg-config:')
     except Exception as e:
-        print('Warning: %s.\nGuessing Open Babel location:' % e)
+        print(f'Warning: {e}.\nGuessing Open Babel location:')
         include_dirs = '/usr/local/include/openbabel3'
         library_dirs = '/usr/local/lib'
     return include_dirs, library_dirs
@@ -64,20 +61,20 @@ class CustomBuild(build):
     """Ensure build_ext runs first in build command."""
     def run(self):
         self.run_command('build_ext')
-        build.run(self)
+        super().run()
 
 
 class CustomInstall(install):
     """Ensure build_ext runs first in install command."""
     def run(self):
         self.run_command('build_ext')
-        install.run(self)
+        super().run()
 
 
 class CustomSdist(sdist):
     """Add swig interface files into distribution from parent directory."""
     def make_release_tree(self, base_dir, files):
-        sdist.make_release_tree(self, base_dir, files)
+        super().make_release_tree(base_dir, files)
         link = 'hard' if hasattr(os, 'link') else None
         pkg_dir = os.path.join(base_dir, 'openbabel')
         self.copy_file(os.path.join('..', 'stereo.i'), pkg_dir, link=link)
@@ -87,9 +84,7 @@ class CustomSdist(sdist):
 class CustomBuildExt(build_ext):
     """Custom build_ext to set SWIG options and print a better error message."""
     def finalize_options(self):
-        # Setting include_dirs, library_dirs, swig_opts here instead of in Extension constructor allows them to be
-        # overridden using -I and -L command line options to python setup.py build_ext.
-        build_ext.finalize_options(self)
+        super().finalize_options()
         self.ob_include_dir, self.ob_library_dir = locate_ob()
         self.include_dirs.append(self.ob_include_dir)
         self.library_dirs.append(self.ob_library_dir)
@@ -99,21 +94,21 @@ class CustomBuildExt(build_ext):
 
     def swig_sources(self, sources, extension):
         try:
-            return build_ext.swig_sources(self, sources, extension)
-        except DistutilsExecError:
+            return super().swig_sources(sources, extension)
+        except Exception:
             print('\nError: SWIG failed. Is Open Babel installed?',
                   'You may need to manually specify the location of Open Babel include and library directories. '
                   'For example:',
-                  '  python setup.py build_ext -I{} -L{}'.format(self.ob_include_dir, self.ob_library_dir),
+                  f'  python setup.py build_ext -I{self.ob_include_dir} -L{self.ob_library_dir}',
                   '  python setup.py install',
                   sep='\n')
             sys.exit(1)
 
 
 obextension = Extension(
-    'openbabel._openbabel', [os.path.join('openbabel', 'openbabel-python.i')], libraries=['openbabel']
+    'openbabel._openbabel', [os.path.join('openbabel', 'openbabel-python.i')],
+    libraries=['openbabel']
 )
-
 
 setup(
     name='openbabel',
@@ -125,7 +120,12 @@ setup(
     description='Python interface to the Open Babel chemistry library',
     long_description=open(os.path.join(base_dir, 'README.rst')).read(),
     zip_safe=False,
-    cmdclass={'build': CustomBuild, 'build_ext': CustomBuildExt, 'install': CustomInstall, 'sdist': CustomSdist},
+    cmdclass={
+        'build': CustomBuild,
+        'build_ext': CustomBuildExt,
+        'install': CustomInstall,
+        'sdist': CustomSdist
+    },
     packages=['openbabel'],
     ext_modules=[obextension],
     classifiers=[
@@ -149,3 +149,4 @@ setup(
         'Topic :: Software Development :: Libraries'
     ]
 )
+

--- a/src/doxygen_pages.cpp
+++ b/src/doxygen_pages.cpp
@@ -36,7 +36,7 @@ namespace OpenBabel {
  * @b CMakeLists.txt
  * @code
 # this line is required for cmake backwards compatibility
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 4.0)
 
 # name of your project
 project(myproject)

--- a/src/doxygen_pages.cpp
+++ b/src/doxygen_pages.cpp
@@ -36,7 +36,7 @@ namespace OpenBabel {
  * @b CMakeLists.txt
  * @code
 # this line is required for cmake backwards compatibility
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.5)
 
 # name of your project
 project(myproject)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -152,6 +152,7 @@ endif()
 
 add_executable(test_runner ${srclist} obtest.cpp)
 target_link_libraries(test_runner ${libs})
+set_target_properties(test_runner PROPERTIES ENABLE_EXPORTS TRUE)
 
 if(NOT BUILD_SHARED AND NOT BUILD_MIXED)
   set_target_properties(test_runner PROPERTIES LINK_SEARCH_END_STATIC TRUE)


### PR DESCRIPTION
This is similar to what was started in https://github.com/openbabel/openbabel/pull/2784. I'm unable to get the changes from that PR to compile and pass all tests, so I'm submitting this PR. This PR also removes `distutils` as support for it ended in python 3.10 and is completely removed in python 3.13. It is replaced with `setuptools`

I am able to compile on Ubuntu with:

```
cmake version 3.28.3
gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
```
and python 3.13 installed from conda.

I used `cmake .. -DWITH_INCHI=ON -DPYTHON_EXECUTABLE=$(which python) -DPYTHON_BINDINGS=ON -DRUN_SWIG=ON -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DENABLE_TESTS=ON -DENABLE_PNG=ON`

I'm not super familiar with openbabel, or maintaining C++ packages, so let me know if there are other compile flags I should be using to test this PR.

All the tests pass after running `make test` including `charge_mmff94` and `charge_gasteiger`.

I haven't tested with cmake 4.0 yet, but I can do that in the meantime.