### PR TITLE
feat(stl): add support for bond visualization to STL export

### DIFF
--- a/src/formats/stlformat.cpp
+++ b/src/formats/stlformat.cpp
@@ -456,15 +456,14 @@ namespace OpenBabel
         const OBAtom& begin = *b->GetBeginAtom();
         const OBAtom& end = *b->GetEndAtom();
 
-        StlBondModelInfo bond_info{
-          .radius = bond_radius,
-          .spacing = bond_spacing,
-          .origin = begin.GetVector(),
-          .direction_and_length = (end.GetVector() - begin.GetVector()),
-          .first_half_colour = (cpk_colours) ? stl_colour(begin.GetAtomicNum(), colour_order) : NoColor,
-          .second_half_colour = (cpk_colours) ? stl_colour(end.GetAtomicNum(), colour_order) : NoColor,
-          .order = b->GetBondOrder()
-        };
+        StlBondModelInfo bond_info{};
+        bond_info.radius = bond_radius;
+        bond_info.spacing = bond_spacing;
+        bond_info.origin = begin.GetVector();
+        bond_info.direction_and_length = (end.GetVector() - begin.GetVector());
+        bond_info.first_half_colour = (cpk_colours) ? stl_colour(begin.GetAtomicNum(), colour_order) : NoColor;
+        bond_info.second_half_colour = (cpk_colours) ? stl_colour(end.GetAtomicNum(), colour_order) : NoColor;
+        bond_info.order = b->GetBondOrder();
 
         model_bond(triangles, bond_info);
       }

--- a/src/formats/stlformat.cpp
+++ b/src/formats/stlformat.cpp
@@ -286,7 +286,7 @@ namespace OpenBabel
       if( !isfinite(probe_radius) || probe_radius < 0. ) { probe_radius = 0.; }
     }
     if( pConv->IsOption( "s" ) ) {
-      probe_radius = atof( pConv->IsOption("s", OBConversion::OUTOPTIONS) );
+      scale_factor = atof( pConv->IsOption("s", OBConversion::OUTOPTIONS) );
       if( !isfinite(scale_factor) || scale_factor < 0. ) { scale_factor = 0.; }
     }
     if( pConv->IsOption( "c" ) ) {


### PR DESCRIPTION
# Description

This pull request enhances the STL export functionality in `openbabel` by visualizing the bonds between atoms.
Previously, the STL output represented only atoms as spheres. With this change:

- Bonds can be visualized as cylinders connecting the bonding atoms (`-xb` option),
- Bond radius and spacing can be adjusted (`--bond-radius`/`--bond-spacing` options), and
- Bonds can be coloured according to [CPK coloring](https://en.wikipedia.org/wiki/CPK_coloring) (`-xc` option).

TLDR; This PR adds support for the [Ball-and-stick model](https://en.wikipedia.org/wiki/Ball-and-stick_model) in the STL export. 

# Implementation notes

- Implementation is limited to `stlformat.cpp`
- Unfortunately, testing was only performed locally since no tests for the STL format were found :(
- Added options: `--bond-radius`, `--bond-spacing`
- Modified options:
  - `-xc` now colours atoms and bonds (if the bond visualization is enabled)
  - `-xs <scaling_factor>` scales atom and bond size (if the bond visualization is enabled)

# Examples

| Molecule | No bonds [1] | With bonds [2] | With bonds + colour [3] |
|:--------:|:------------:|:--------------:|:-----------------------:|
| FH       | <img width="464" height="391" alt="fh" src="https://github.com/user-attachments/assets/9d5584f6-cd9a-4686-ac6c-a4d0c1653f61" /> | <img width="527" height="250" alt="fh_bonds" src="https://github.com/user-attachments/assets/741052d9-1a1b-4adc-8e5d-af8252a86955" /> | <img width="946" height="439" alt="fh_bonds+color" src="https://github.com/user-attachments/assets/72bef647-1a6c-4232-9666-a040655b675d" /> |
| C2H4     | <img width="464" height="455" alt="c2h4" src="https://github.com/user-attachments/assets/aaee5e3c-62d9-4211-a6d4-2bcddf33b1db" /> | <img width="736" height="533" alt="c2h4_bonds" src="https://github.com/user-attachments/assets/2f9bd7ab-bc03-4716-a810-63dc1d2b2f8f" /> | <img width="926" height="647" alt="c2h4_bonds+color" src="https://github.com/user-attachments/assets/268b7e16-361e-440f-8c3a-dd6189a5639c" /> |
| [Caffeine](https://pubchem.ncbi.nlm.nih.gov/compound/Caffeine) | <img width="621" height="541" alt="caffeine" src="https://github.com/user-attachments/assets/f045dedd-f06f-466f-b374-25cffc867ec6" /> |  <img width="682" height="612" alt="caffeine_bonds" src="https://github.com/user-attachments/assets/a16fc341-eb8b-404e-ab32-2f454c69388c" /> | <img width="607" height="535" alt="caffeine_bonds+color" src="https://github.com/user-attachments/assets/864d9beb-9c66-47bf-bef0-9a2283976bc8" /> |

> Examples are screenshots of  [viewstl.com](https://www.viewstl.com/#!)'s render of the models (unfortunately, wihtout any anti-aliasing)

[1]: No additional options
[2]: Options `-xs 0.2 -xb`
[3]: Options `-xs 0.2 -xb -xc`

Please let me know if there are any changes or additions you'd recommend!