### PR TITLE
C++17 Compliance: Add <ctime> to Fix Errors due to Strictness with GCC 12+

### DIFF
--- a/include/openbabel/obutil.h
+++ b/include/openbabel/obutil.h
@@ -35,7 +35,8 @@ GNU General Public License for more details.
 #include <time.h>
 #endif
 #endif
-
+// Include C++ version for clock() and CLOCKS_PER_SEC (required for GCC 12+ with C++17)
+#include <ctime>
 #include <math.h>
 
 #ifndef M_PI


### PR DESCRIPTION
# Description

This PR improves OpenBabel's forward compatibility by adding a missing header (`#include <ctime>`) required for C++17 builds. Closes #2843 

# The Problem

Currently, `obutil.h` relies on `<time.h>` for `clock()` and `CLOCKS_PER_SEC`.

- This works fine in C++11 (OpenBabel's default).
    
- This fails in C++17 (used by downstream projects like _`mofid`_), where GCC 12+ enforces stricter header usage.

# The Fix

I added `#include <ctime>` to `include/openbabel/obutil.h`. This ensures that standard time functions are correctly resolved regardless of whether the project is built with C++11 or C++17.

**Validation** I verified this fix in the following environment:

- **Compiler:** GCC 12.3.0, GCC 14

- **Standard:** `CMAKE_CXX_STANDARD 17`
    
- **Result:** The previously failing build now compiles successfully. No functional changes were introduced.


**This change allows OpenBabel to be integrated into modern C++ pipelines that enforce newer standards, ensuring the library remains usable as compilers become stricter.**