### PR TITLE
Do not cast `istream.get()` to a char before comparing it with EOF

### DIFF
--- a/src/formats/getinchi.cpp
+++ b/src/formats/getinchi.cpp
@@ -159,12 +159,14 @@ string GetInChI(istream& is)
   string result;
   enum statetype {before_inchi, match_inchi, unquoted, quoted};
   statetype state = before_inchi;
+  int ch_int;
   char ch, lastch=0, qch=0;
   size_t split_pos = 0;
   bool inelement=false, afterelement=false;
 
-  while((ch=is.get())!=EOF)
+  while((ch_int=is.get())!=EOF)
   {
+    ch = (char)ch_int;
     if(state==before_inchi)
     {
       if(ch>=0 && !isspace(ch))


### PR DESCRIPTION
This is a fix required to make the code work on arm architectures.

Casting the result of an `fgetc` or `istream.get` (not sure if others) to a char before comparing it to EOF will cause an infinite loop do to it being unsigned by default and never being -1.
See for example https://bugs.webkit.org/show_bug.cgi?id=144439

You can easily reproduce this with a test program such as (where switching the char to an int) will make the loop terminate normally

```c++
#include <iostream>
#include <fstream>
#include <string>

int main() {
    std::ifstream file("test.txt");
    if (!file.is_open()) {
        std::cerr << "Failed to open the file." << std::endl;
        return 1;
    }

    int cnt = 0;
    char ch;
    while ((ch = file.get()) != EOF) {
        std::cout << (char)ch; // Output the character read from the file
        cnt++;
        if (cnt > 1000) { // Prevent infinite loop in case of an error
            std::cerr << "Too many characters read, stopping to prevent infinite loop." << std::endl;
            break;
        }
    }

    file.close();
    return 0;
}
```

You can see which test failures this PR addresses in

- https://github.com/easybuilders/easybuild-easyconfigs/pull/25222#issuecomment-3859867392

where in some cases it would cause a test timeout and in other a `std::bad_alloc` exception.

The proposed patch was used on a neoverse_v1 machine to fix the first 4 test failure described in the aforementioned link successfully.