### PR TITLE
Fix: Remove debug print statements from PQR format reader

### DIFF
--- a/src/formats/pqrformat.cpp
+++ b/src/formats/pqrformat.cpp
@@ -164,7 +164,7 @@ namespace OpenBabel
       // WARNING: Atom index issue here
       a->SetPartialCharge(charges[a->GetIdx() - 1]);
 
-      cerr << " charge : " << charges[a->GetIdx() - 1] << endl;
+      // cerr << " charge : " << charges[a->GetIdx() - 1] << endl;
 
       if (!a->HasData("Radius")) {
         std::ostringstream s;
@@ -175,7 +175,7 @@ namespace OpenBabel
         a->SetData(p);
       }
 
-      cerr << " radius : " << radii[a->GetIdx() - 1] << endl;
+      // cerr << " radius : " << radii[a->GetIdx() - 1] << endl;
 
     }
     mol.SetPartialChargesPerceived();


### PR DESCRIPTION
Fixes #2841

## Problem
When reading PQR files via the Python package, debug print statements were outputting charge and radius for every atom. This caused significant performance degradation when processing large batches of molecules.

## Solution
Commented out the two  statements on lines 167 and 178 in  that were printing these debug messages.

## Impact
- Removes unwanted stdout/stderr pollution
- Improves performance when processing large PQR file batches
- No functional changes to the PQR reading logic

## Testing
The fix is minimal - simply removing debug output. The actual charge and radius setting logic remains unchanged.