### PR TITLE
Remove debug cerr output when reading PQR files

### DIFF
--- a/src/formats/pqrformat.cpp
+++ b/src/formats/pqrformat.cpp
@@ -164,8 +164,6 @@ namespace OpenBabel
       // WARNING: Atom index issue here
       a->SetPartialCharge(charges[a->GetIdx() - 1]);
 
-      cerr << " charge : " << charges[a->GetIdx() - 1] << endl;
-
       if (!a->HasData("Radius")) {
         std::ostringstream s;
         s << radii[ a->GetIdx()-1 ];
@@ -174,8 +172,6 @@ namespace OpenBabel
         p->SetValue( s.str() );
         a->SetData(p);
       }
-
-      cerr << " radius : " << radii[a->GetIdx() - 1] << endl;
 
     }
     mol.SetPartialChargesPerceived();


### PR DESCRIPTION
Fixes #2841

**Problem**
When reading PQR files, Open Babel was printing charge and radius values to stderr for each atom. This significantly slowed down workflows when processing large databases.

**Solution**
Removed the two debug  statements that were outputting:
- 
- 

These appear to be leftover debug statements from development.

**Impact**
- Reduces noise in output
- Improves performance when reading many PQR files
- No functional changes to data processing

**Lines changed**: 2 lines removed (4 deletions in diff)