### PR TITLE
Fix 3 CVE security bugs: heap-buffer-overflow, SEGV, NULL deref

### DIFF
--- a/src/formats/mol2format.cpp
+++ b/src/formats/mol2format.cpp
@@ -418,10 +418,11 @@ namespace OpenBabel
             {
               int charge = 0;
               sscanf(buffer,"%*s %d",&charge);
-              if(aid <= mol.NumAtoms()) 
+              if(aid >= 1 && aid <= (int)mol.NumAtoms())
               {
                 OBAtom *atom = mol.GetAtom(aid);
-                atom->SetFormalCharge(charge);
+                if (atom != nullptr)
+                  atom->SetFormalCharge(charge);
               }
             }
           }

--- a/src/formats/xml/cdxmlformat.cpp
+++ b/src/formats/xml/cdxmlformat.cpp
@@ -264,8 +264,11 @@ bool ChemDrawXMLFormat::EndElement(const string& name)
     
     // Add implicit hydrogens on atoms without "hydrogens" property
     for (vector<unsigned int>::iterator vit = _handleImplicitHydrogens.begin();
-         vit != _handleImplicitHydrogens.end(); ++vit)
-           OBAtomAssignTypicalImplicitHydrogens(_pmol->GetAtom(atoms[*vit]));
+         vit != _handleImplicitHydrogens.end(); ++vit) {
+           OBAtom *atom = _pmol->GetAtom(atoms[*vit]);
+           if (atom != nullptr)
+             OBAtomAssignTypicalImplicitHydrogens(atom);
+    }
 
     _pmol->EndModify();
 

--- a/src/math/transform3d.cpp
+++ b/src/math/transform3d.cpp
@@ -57,8 +57,10 @@ namespace OpenBabel
             r << ",";
           n = static_cast<int> (floor((*v)[i] * 12.0 + 0.1));
           j = 0;
-          while ((*m)(i, j) == 0.)
+          while (j < 3 && (*m)(i, j) == 0.)
             j++;
+          if (j >= 3)
+            continue;
           neg = (*m)(i, j) < 0.;
           switch (n)
             {


### PR DESCRIPTION
## Summary
Fixes 3 CVE security vulnerabilities reported in #2848 (CVE-2026-2704, CVE-2026-2705):

### 1. Heap-buffer-overflow in `transform3d::DescribeAsString` (transform3d.cpp)
The `while ((*m)(i, j) == 0.) j++;` loop scans for the first non-zero element in a matrix row but has no upper bound on `j`. When a malformed CIF file produces a transformation matrix with an all-zero row, `j` increments past 2 and reads beyond the 96-byte (12-double) `transform3d` buffer.

**Fix:** Add `j < 3` bounds check and `continue` when the entire row is zero.

### 2. SEGV (NULL write) in `MOL2Format::ReadMolecule` (mol2format.cpp)
When parsing `@<TRIPOS>UNITY_ATOM_ATTR`, `mol.GetAtom(aid)` can return NULL for malformed MOL2 files with invalid atom IDs, but the return value is dereferenced unconditionally to call `SetFormalCharge`.

**Fix:** Add NULL check after `GetAtom()` and tighten range validation to reject `aid < 1`.

### 3. SEGV (NULL deref) in `ChemDrawXMLFormat::EndElement` (cdxmlformat.cpp)
In the `"fragment"` end handler, `_pmol->GetAtom(atoms[*vit])` can return NULL for malformed CDXML files where atom index lookups fail, but the pointer is passed directly to `OBAtomAssignTypicalImplicitHydrogens`.

**Fix:** Add NULL check before calling `OBAtomAssignTypicalImplicitHydrogens`.

## Test plan
- [ ] Build with ASAN enabled and verify all 3 crash reproducers no longer trigger
- [ ] Existing test suite should pass (changes only add guards, no behavioral change for valid input)

Fixes #2848
