### PR TITLE
build: bump cmake_minimum_required to 3.10 for CMake 4.x compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,11 @@
-# Please ensure that any changes remain compliant with 3.1.
 if(NOT EMBED_OPENBABEL)
-  cmake_minimum_required(VERSION 3.1)
+  cmake_minimum_required(VERSION 3.10)
 endif()
 
 project(openbabel)
 set(CMAKE_MODULE_PATH ${openbabel_SOURCE_DIR}/cmake/modules)
 
 set (CMAKE_CXX_STANDARD 11)
-
-if(COMMAND cmake_policy)
-  cmake_policy(SET CMP0003 NEW)
-  if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 OLD)
-  endif()
-endif()
 
 include (CheckCXXCompilerFlag)
 

--- a/doc/examples/static_executable/CMakeLists.txt
+++ b/doc/examples/static_executable/CMakeLists.txt
@@ -25,7 +25,7 @@
 #
 
 # This line is required for cmake backwards compatibility.
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 # Name of your project
 project(myproject)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6.0)
+cmake_minimum_required(VERSION 3.10)
 # Library versioning (used in Mac Python bindings)x
 set(SOVERSION 4)
 


### PR DESCRIPTION
## Summary
- Bump `cmake_minimum_required` from 2.6/3.1 to 3.10 across all CMakeLists.txt files
- Remove the now-redundant `cmake_policy` block (CMP0003, CMP0042) from the root CMakeLists.txt
- Fixes build failure with CMake 4.x, which dropped support for policies older than 3.10

## Test plan
- [x] Verified the project configures and builds successfully with CMake 4.x
- [ ] Verify backward compatibility with CMake 3.10+

🤖 Generated with [Claude Code](https://claude.com/claude-code)