### PR TITLE
Fix an OSS-Fuzz bug with line endings in V3000

### DIFF
--- a/include/openbabel/lineend.h
+++ b/include/openbabel/lineend.h
@@ -138,7 +138,7 @@ namespace OpenBabel
       {
         if( result < 0 || result > UCHAR_MAX )
           std::cerr << "FilteringInputStreambuf error" << std::endl;
-        myBuffer = result ;
+        myBuffer = static_cast<char>(static_cast<unsigned char>(result)) ;
         setg( &myBuffer , &myBuffer , &myBuffer + 1 ) ;
       }
     }

--- a/src/formats/mdlformat.cpp
+++ b/src/formats/mdlformat.cpp
@@ -1495,6 +1495,7 @@ namespace OpenBabel
       {
         if(!ReadV3000Line(ifs,vs)) return false;
         if(vs[2]=="END") break;
+        if(vs.size() < 7) return false; // need index, type, x, y, z
 
         indexmap[ReadUIntField(vs[2].c_str())] = obindex;
         atom.SetVector(atof(vs[4].c_str()), atof(vs[5].c_str()), atof(vs[6].c_str()));
@@ -1569,6 +1570,7 @@ namespace OpenBabel
       {
         if(!ReadV3000Line(ifs,vs)) return false;
         if(vs[2]=="END") break;
+        if(vs.size() < 6) return false; // need index, order, atom1, atom2
 
         unsigned flag=0;
 

--- a/test/fuzz/corpus/fuzz_obconversion_sdf/clusterfuzz-testcase-minimized-fuzz_obconversion_sdf-4568207441854464
+++ b/test/fuzz/corpus/fuzz_obconversion_sdf/clusterfuzz-testcase-minimized-fuzz_obconversion_sdf-4568207441854464
@@ -1,0 +1,7 @@
+
+
+
+V3000  ÿº
+M V30 BEGIN  ATOM 
+M V30  ÿ
+M    ÿ 


### PR DESCRIPTION
mdlformat.cpp:
ReadAtomBlock: reject lines <7 tokens before atom
ReadBondBlock: reject lines <6 tokens before bond

lineend.h:
Fixed implicit int -> char conversion in underflow()