### PR TITLE
Check force fields before dereference (e.g. no plugins loaded)

### DIFF
--- a/tools/obmm.cpp
+++ b/tools/obmm.cpp
@@ -67,6 +67,10 @@ using namespace OpenBabel;
 int main(int argc,char **argv)
 {
   OBForceField* pFF = OBForceField::FindForceField("MMFF94");
+  if (!pFF) {
+    cerr << "Error: MMFF94 force field not found. Ensure Open Babel plugins are installed." << endl;
+    return 1;
+  }
   pFF->SetLogFile(&cout);
   pFF->SetLogLevel(OBFF_LOGLVL_LOW);
 


### PR DESCRIPTION
Fix #2800