### PR TITLE
Fix dangling reference in CML reaction writer

### DIFF
--- a/src/formats/xml/cmlreactformat.cpp
+++ b/src/formats/xml/cmlreactformat.cpp
@@ -657,7 +657,7 @@ bool CMLReactFormat::WriteMolecule(OBBase* pOb, OBConversion* pConv)
 
       //Send to real output stream with the moleculeList first
       string::size_type reaclistPos, mollistPos, footerPos;
-      const string& s = ssout.str();
+      const string s = ssout.str();
       reaclistPos = s.find("<reactionList");
       if(reaclistPos!=string::npos)
         mollistPos = s.find("<moleculeList",reaclistPos+1);


### PR DESCRIPTION
Store the stringstream contents by value before searching the generated CML, rather than binding a const reference to the temporary returned by str().