### PR TITLE
refactor: replace std::random_shuffle with std::shuffle

### DIFF
--- a/test/canonstabletest.cpp
+++ b/test/canonstabletest.cpp
@@ -5,6 +5,7 @@
 #include <openbabel/obiter.h>
 
 #include <iostream>
+#include <random>
 #include <vector>
 #include <algorithm>
 
@@ -42,7 +43,7 @@ int canonstabletest(int argc, char *argv[])
 
     for (int i = 0; i < 5; ++i) {
       // shuffle the atoms
-      std::random_shuffle(atoms.begin(), atoms.end());
+      std::shuffle(atoms.begin(), atoms.end(), std::mt19937{std::random_device{}()});
       mol.RenumberAtoms(atoms);
 
       // get can smiles

--- a/test/lssrtest.cpp
+++ b/test/lssrtest.cpp
@@ -6,6 +6,7 @@
 #include <openbabel/obiter.h>
 
 #include <iostream>
+#include <random>
 #include <string>
 #include <vector>
 #include <algorithm>
@@ -61,7 +62,7 @@ bool doShuffleTestMolecule(OBMol &mol)
   
   for (int i = 0; i < N; ++i) {
     // shuffle the atoms
-    std::random_shuffle(atoms.begin(), atoms.end());
+    std::shuffle(atoms.begin(), atoms.end(), std::mt19937{std::random_device{}()});
     mol.RenumberAtoms(atoms);
     // get rings
     std::vector< std::vector<unsigned long> > rings = getIdRingPaths(mol);

--- a/test/shuffletest.cpp
+++ b/test/shuffletest.cpp
@@ -9,6 +9,7 @@
 #include <openbabel/canon.h>
 
 #include <iostream>
+#include <random>
 #include <vector>
 #include <algorithm>
 
@@ -130,7 +131,7 @@ bool doShuffleTest(const std::string &smiles)
   bool result = true;
   for (unsigned int i = 0; i < N; ++i) {
     // shuffle the atoms
-    std::random_shuffle(atoms.begin(), atoms.end());
+    std::shuffle(atoms.begin(), atoms.end(), std::mt19937{std::random_device{}()});
     mol.RenumberAtoms(atoms);
     // get can smiles
     std::string cansmi = canConv.WriteString(&mol, true);
@@ -172,7 +173,7 @@ bool doShuffleTestFile(const std::string &filename)
   bool result = true;
   for (unsigned int i = 0; i < N; ++i) {
     // shuffle the atoms
-    std::random_shuffle(atoms.begin(), atoms.end());
+    std::shuffle(atoms.begin(), atoms.end(), std::mt19937{std::random_device{}()});
     mol.RenumberAtoms(atoms);
 
     // get can smiles
@@ -217,7 +218,7 @@ bool doShuffleTestOnMultiFile(const std::string &filename)
     bool subresult = true;
     for (unsigned int i = 0; i < N; ++i) {
       // shuffle the atoms
-      std::random_shuffle(atoms.begin(), atoms.end());
+      std::shuffle(atoms.begin(), atoms.end(), std::mt19937{std::random_device{}()});
       mol.RenumberAtoms(atoms);
 
       // get can smiles

--- a/test/stereotest.cpp
+++ b/test/stereotest.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <openbabel/atom.h>
 #include <openbabel/obiter.h>
+#include <random>
 
 using namespace std;
 using namespace OpenBabel;
@@ -182,7 +183,7 @@ bool doStereoPerception3(OBMol &mol, const OBStereoUnitSet &refUnits = OBStereoU
     atoms.push_back(&*atom);
 
   for (int i = 0; i < 100; ++i) {
-    std::random_shuffle(atoms.begin(), atoms.end());
+    std::shuffle(atoms.begin(), atoms.end(), std::mt19937{std::random_device{}()});
     mol.RenumberAtoms(atoms);
 
     // need to calculate symmetry first


### PR DESCRIPTION
std::random_shuffle is deprecated in C++14 and removed in C++17; std::shuffle is available since C++11

https://clang.llvm.org/extra/clang-tidy/checks/modernize/replace-random-shuffle.html