### PR TITLE
refactor testbabel

### DIFF
--- a/test/testRInChI.py
+++ b/test/testRInChI.py
@@ -53,18 +53,18 @@ class TestReactionInChIWriter(BaseTest):
         for eqm in [False, True]:
             for rsmi, rinchi in data:
                 if eqm:
-                    output, error = run_exec('obabel -:%s -ismi -orinchi -xe' % rsmi)
+                    output, error = run_exec(None, 'obabel -:%s -ismi -orinchi -xe' % rsmi)
                     ans = rinchi.replace("/d-", "/d=").replace("/d+", "/d=")
                     self.assertEqual(output.rstrip(), ans)
                 else:
-                    output, error = run_exec('obabel -:%s -ismi -orinchi' % rsmi)
+                    output, error = run_exec(None, 'obabel -:%s -ismi -orinchi' % rsmi)
                     self.assertEqual(output.rstrip(), rinchi)
 
     def testRInChIOfficialExamples(self):
         """These test RXN to RInChI using the examples in the RInChI distrib"""
         for rxnfile in glob.glob(os.path.join(here, "rinchi", "*.rxn")):
             dirname, fname = os.path.split(rxnfile)
-            output, error = run_exec('obabel %s -orinchi' % rxnfile)
+            output, error = run_exec(None, 'obabel %s -orinchi' % rxnfile)
             with open(os.path.join(dirname, fname.split(".")[0]+".txt")) as inp:
                 ans = inp.readlines()[0]
             self.assertEqual(output.rstrip(), ans.rstrip())

--- a/test/testRInChI.py
+++ b/test/testRInChI.py
@@ -53,18 +53,18 @@ class TestReactionInChIWriter(BaseTest):
         for eqm in [False, True]:
             for rsmi, rinchi in data:
                 if eqm:
-                    output, error = run_exec(None, 'obabel -:%s -ismi -orinchi -xe' % rsmi)
+                    output, error = run_exec(None, ['obabel', '-:%s' % rsmi, '-ismi', '-orinchi', '-xe'])
                     ans = rinchi.replace("/d-", "/d=").replace("/d+", "/d=")
                     self.assertEqual(output.rstrip(), ans)
                 else:
-                    output, error = run_exec(None, 'obabel -:%s -ismi -orinchi' % rsmi)
+                    output, error = run_exec(None, ['obabel', '-:%s' % rsmi, '-ismi', '-orinchi'])
                     self.assertEqual(output.rstrip(), rinchi)
 
     def testRInChIOfficialExamples(self):
         """These test RXN to RInChI using the examples in the RInChI distrib"""
         for rxnfile in glob.glob(os.path.join(here, "rinchi", "*.rxn")):
             dirname, fname = os.path.split(rxnfile)
-            output, error = run_exec(None, 'obabel %s -orinchi' % rxnfile)
+            output, error = run_exec(None, ['obabel', '%s' % rxnfile, '-orinchi'])
             with open(os.path.join(dirname, fname.split(".")[0]+".txt")) as inp:
                 ans = inp.readlines()[0]
             self.assertEqual(output.rstrip(), ans.rstrip())

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -30,16 +30,16 @@ def run_exec(text, commandline):
     With two arguments (stdin, commandline) it pipes
     the stdin through the executable.
 
-    Example: run_exec("CC(=O)Cl", "obabel -ismi -oinchi")
+    >>> run_exec("CC(=O)Cl", ["obabel", "-ismi", "-oinchi"])
+    ('InChI=1S/C2H3ClO/c1-2(3)4/h1H3\\n', '1 molecule converted\\n')
 
     Return a tuple (stdout, stderr)
     """
 
-    broken = commandline.split()
-    exe = executable(broken[0])
+    exe = executable(commandline[0])
     # Note that bufsize = -1 means default buffering
     # Without this, it's unbuffered and it takes 10x longer on MacOSX
-    p = subprocess.run([exe] + broken[1:], input=text, stdout=PIPE, stderr=PIPE,
+    p = subprocess.run([exe] + commandline[1:], input=text, stdout=PIPE, stderr=PIPE,
                        bufsize=-1, universal_newlines=True)
     stdout, stderr = p.stdout, p.stderr
 
@@ -102,7 +102,7 @@ class TestOBabel(BaseTest):
     def testNoInput(self):
         """Ensure that this does not segfault (PR#1818)"""
         self.canFindExecutable("obabel")
-        output, error = run_exec(None, "obabel -i")
+        output, error = run_exec(None, ["obabel", "-i"])
         self.assertGreater(len(output), 1, "Did not generate output")
         self.assertGreater(len(error), 1, "Did not generate error message")
 
@@ -110,12 +110,12 @@ class TestOBabel(BaseTest):
         # Test that -O can handle short file names
         # if not the command will show warning on 2D coords
         self.canFindExecutable("obabel")
-        _, errormsg = run_exec("CCC", "obabel -ismi -omol -Otf --gen2D")
+        _, errormsg = run_exec("CCC", ["obabel", "-ismi", "-omol", "-Otf", "--gen2D"])
         self.assertNotIn("No 2D or 3D coordinates", errormsg)
 
     def testSMItoInChI(self):
         self.canFindExecutable("obabel")
-        output, error = run_exec("CC(=O)Cl", "obabel -ismi -oinchi")
+        output, error = run_exec("CC(=O)Cl", ["obabel", "-ismi", "-oinchi"])
         self.assertEqual(output.rstrip(), "InChI=1S/C2H3ClO/c1-2(3)4/h1H3")
 
     def testRSMItoRSMI(self):
@@ -123,13 +123,13 @@ class TestOBabel(BaseTest):
         data = ["O>N>S", "O>>S", "O>N>", "O>>",
                 ">N>S", ">>S", ">>"]
         for rsmi in data:
-            output, error = run_exec(None, 'obabel -:%s -irsmi -orsmi' % rsmi)
+            output, error = run_exec(None, ['obabel', '-:%s' % rsmi, '-irsmi', '-orsmi'])
             self.assertEqual(output.rstrip(), rsmi)
         # Check handling of invalid rxn components
         data = ["Noel>N>S", "O>Noel>S", "O>N>Noel"]
         errors = ["reactant", "agent", "product"]
         for rsmi, error in zip(data, errors):
-            output, errormsg = run_exec(None, 'obabel -:%s -irsmi -orsmi' % rsmi)
+            output, errormsg = run_exec(None, ['obabel', '-:%s' % rsmi, '-irsmi', '-orsmi'])
             self.assertIn(error, errormsg)
 
     def sort(self, rsmi):
@@ -145,16 +145,16 @@ class TestOBabel(BaseTest):
         data = ["c1ccccc1", "c%11ccccc%11", "c%(1)ccccc%(1)", "c%(51)ccccc%51",
                 "c%(99999)ccccc%(99999)"]
         for smi in data:
-            output, error = run_exec(None, "obabel -:%s -osmi" % smi)
+            output, error = run_exec(None, ["obabel", "-:%s" % smi, "-osmi"])
             self.assertEqual("c1ccccc1", output.rstrip())
         # Test negatives
         data = ["c%1ccccc%1", "c%a1cccc%a1", "c%(a1)ccccc%(a1)",
                 "c%(000001)ccccc%(000001)", "c%(51)ccccc%(15)"]
         for smi in data:
-            output, error = run_exec(None, "obabel -:%s -osmi" % smi)
+            output, error = run_exec(None, ["obabel", "-:%s" % smi, "-osmi"])
             self.assertIn("0 molecules converted", error)
         # Now test writing of %(NNN) notation
-        output, error = run_exec(None, "obabel %s -osmi" % self.getTestFile("102Uridine.smi"))
+        output, error = run_exec(None, ["obabel", self.getTestFile("102Uridine.smi"), "-osmi"])
         self.assertIn("%(100)", output)
 
     def testPDBQT(self):
@@ -220,7 +220,7 @@ ENDBRANCH   9  10
 ENDBRANCH   1   9
 TORSDOF 5
 '''
-        output, error = run_exec(pdb, "obabel -ipdb -opdbqt")
+        output, error = run_exec(pdb, ["obabel", "-ipdb", "-opdbqt"])
         self.assertEqual(output.replace("\r", ""), pdbqt.replace("\r", ""))
 
     def testMissingPlugins(self):
@@ -276,7 +276,7 @@ TORSDOF 5
                 cofname = 'mol24' # Special case: 'internal name' not the same as file name
             coffile = self.getTestFile(coffilename)
             cansmi = CAN + '\t' + cofname # Expected SMILES line plus molecule name
-            output, error = run_exec(None, "obabel -icof -ocan %s" % coffile)
+            output, error = run_exec(None, ["obabel", "-icof", "-ocan", coffile])
             self.assertEqual(output.rstrip('\r\n'), cansmi)
 
     def testCOFtoMOL(self):
@@ -300,7 +300,7 @@ TORSDOF 5
             if(cofname == 'culgi_06'):
                 cofname = 'mol24'
             coffile = self.getTestFile(coffilename)
-            output, error = run_exec(None, "obabel -icof -omol %s" % coffile)
+            output, error = run_exec(None, ["obabel", "-icof", "-omol", coffile])
             molfilename = cofname + '.mol'
             molfile = self.getTestFile(molfilename)
 
@@ -335,7 +335,7 @@ TORSDOF 5
             coffilename = molname + '_from_mol.cof'
             coffile = self.getTestFile(coffilename)
             molfile = self.getTestFile(molfilename)
-            output, error = run_exec(None, "obabel -imol -ocof %s --partialcharge none" % molfile)
+            output, error = run_exec(None, ["obabel", "-imol", "-ocof", molfile, "--partialcharge", "none"])
 
             # Chop up the output and the baseline files into single lines
             # Skip first three lines: first line contains Culgi version,
@@ -368,7 +368,7 @@ TORSDOF 5
             if(cofname == 'culgi_06'):
                 cofname = 'mol24'
             coffile = self.getTestFile(coffilename)
-            output, error = run_exec(None, "obabel -icof -omol2 %s" % coffile)
+            output, error = run_exec(None, ["obabel", "-icof", "-omol2", coffile])
             mol2filename = cofname + '.mol2'
             mol2file = self.getTestFile(mol2filename)
 
@@ -401,7 +401,7 @@ TORSDOF 5
             coffilename = mol2name + '_from_mol2.cof'
             coffile = self.getTestFile(coffilename)
             mol2file = self.getTestFile(mol2filename)
-            output, error = run_exec(None, "obabel -imol2 -ocof %s" % mol2file)
+            output, error = run_exec(None, ["obabel", "-imol2", "-ocof", mol2file])
 
             # Chop up the output and the baseline files into single lines
             # Skip first three lines: first line contains Culgi version,
@@ -417,7 +417,7 @@ TORSDOF 5
         '''This is a regression test for a segfault, but could put
         other mol2 test here'''
         mol2file = self.getTestFile('5sun_protein.mol2')
-        outputerr = run_exec(None, "obabel -imol2 %s -osdf" % mol2file)
+        outputerr = run_exec(None, ["obabel", "-imol2", mol2file, "-osdf"])
         self.assertGreater(len(outputerr[0]), 0, "Did not generate output")
 
     def testXYZazete(self):
@@ -458,7 +458,7 @@ GASTEIGER
      6     2     3    2
      7     3     6    1
 '''
-        output, error = run_exec(xyz, "obabel -ixyz -omol2")
+        output, error = run_exec(xyz, ["obabel", "-ixyz", "-omol2"])
         self.maxDiff = None
         self.assertEqual(output.replace("\r", ""), mol2.replace("\r", ""))
 
@@ -504,7 +504,7 @@ charge 1
      6     2     7    1
      7     2     8    1
 '''
-        output, error = run_exec(xyz, "obabel -ixyz -p7 -omol2")
+        output, error = run_exec(xyz, ["obabel", "-ixyz", "-p7", "-omol2"])
         self.maxDiff = None
         # mol2 displays element twice
         self.assertEqual(output.count('H'), 12)
@@ -512,12 +512,12 @@ charge 1
     def testOBRMS(self):
         '''Sanity checks for obrms'''
         sdffile = self.getTestFile('testsym_2Dtests.sdf')
-        output, err = run_exec(None, "obrms -t 10 %s %s"%(sdffile,sdffile))
+        output, err = run_exec(None, ["obrms", "-t", "10", sdffile, sdffile])
         # all rmsds should be zero
         rmsds = [float(line.split()[-1]) for line in output.split('\n') if line]
         for rmsd in rmsds:
             self.assertEqual(rmsd, 0, "RMSD not zero between identical structures")
-        output, err = run_exec(None, "obrms -t 10 -f %s %s" % (sdffile,sdffile))
+        output, err = run_exec(None, ["obrms", "-t", "10", "-f", sdffile, sdffile])
         #first zero, second nonzero, last inf
         rmsds = [float(line.split()[-1]) for line in output.split('\n') if line]
         self.assertEqual(rmsds[0],0)
@@ -527,7 +527,7 @@ charge 1
     def testSeparateOnPipe(self):
         """Check that piped input works with --separate, see https://github.com/openbabel/openbabel/issues/2386"""
         self.canFindExecutable("obabel")
-        output, err = run_exec("[Na].[Cl]", "obabel -ismi -ocan --separate")
+        output, err = run_exec("[Na].[Cl]", ["obabel", "-ismi", "-ocan", "--separate"])
         self.assertEqual(output, "[Na]\t#1\n[Cl]\t#2\n")
 
 

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -226,18 +226,18 @@ TORSDOF 5
     def testMissingPlugins(self):
         if sys.platform.startswith("win32"):
             return
-        libdir = os.environ.pop("BABEL_LIBDIR", None)
-        os.environ["BABEL_LIBDIR"] = ""
+        env = os.environ.copy()
+        env["BABEL_LIBDIR"] = ""
 
         obabel = executable("obabel")
         with self.assertRaises(CalledProcessError) as cm:
-            check_output('%s -:C -osmi' % obabel, shell=True, stderr=STDOUT, universal_newlines=True)
+            check_output(
+                [obabel, "-:C", "-osmi"],
+                stderr=STDOUT,
+                universal_newlines=True,
+                env=env,
+            )
         msg = cm.exception.output
-        if libdir:
-            os.environ["BABEL_LIBDIR"] = libdir
-        else:
-            os.environ.pop("BABEL_LIBDIR")
-
         self.assertIn('BABEL_LIBDIR', msg)
 
     def testCOFtoCAN(self):

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -16,10 +16,11 @@ and so you can quickly develop the tests and try them out.
 
 import os
 import re
+import subprocess
 import sys
 import unittest
 
-from subprocess import CalledProcessError, Popen, PIPE, check_output, STDOUT
+from subprocess import CalledProcessError, PIPE, check_output, STDOUT
 
 INF = float("inf")
 
@@ -36,7 +37,7 @@ def run_exec(*args):
     if len(args) == 2:
         text, commandline = args
     elif len(args) == 1:
-        text, commandline = "", args[0]
+        text, commandline = None, args[0]
     else:
         raise Exception("One or two arguments expected")
 
@@ -44,15 +45,9 @@ def run_exec(*args):
     exe = executable(broken[0])
     # Note that bufsize = -1 means default buffering
     # Without this, it's unbuffered and it takes 10x longer on MacOSX
-    if text:
-        p = Popen([exe] + broken[1:],
-                  stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=1,
-                  universal_newlines=True)
-        stdout, stderr = p.communicate(text)
-    else:
-        p = Popen([exe] + broken[1:],
-                  stdout=PIPE, stderr=PIPE, bufsize=-1, universal_newlines=True)
-        stdout, stderr = p.communicate()
+    p = subprocess.run([exe] + broken[1:], input=text, stdout=PIPE, stderr=PIPE,
+                       bufsize=-1, universal_newlines=True)
+    stdout, stderr = p.stdout, p.stderr
 
     if p.returncode and len(stderr) == 0:
         #should never exit with an error without an error message

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -512,14 +512,15 @@ charge 1
     def testOBRMS(self):
         '''Sanity checks for obrms'''
         sdffile = self.getTestFile('testsym_2Dtests.sdf')
+        nmols = 7
         output, err = run_exec(None, ["obrms", "-t", "10", sdffile, sdffile])
         # all rmsds should be zero
         rmsds = [float(line.split()[-1]) for line in output.split('\n') if line]
-        for rmsd in rmsds:
-            self.assertEqual(rmsd, 0, "RMSD not zero between identical structures")
+        self.assertEqual(rmsds, [0.0] * nmols, msg="RMSD not zero between identical structures")
         output, err = run_exec(None, ["obrms", "-t", "10", "-f", sdffile, sdffile])
         #first zero, second nonzero, last inf
         rmsds = [float(line.split()[-1]) for line in output.split('\n') if line]
+        self.assertEqual(len(rmsds), nmols, msg="%s" % rmsds)
         self.assertEqual(rmsds[0],0)
         self.assertEqual(rmsds[1],2.73807)
         self.assertEqual(rmsds[-1],INF)

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -24,7 +24,7 @@ from subprocess import CalledProcessError, PIPE, check_output, STDOUT
 
 INF = float("inf")
 
-def run_exec(*args):
+def run_exec(text, commandline):
     """Run one of OpenBabel's executables
 
     With two arguments (stdin, commandline) it pipes
@@ -34,12 +34,6 @@ def run_exec(*args):
 
     Return a tuple (stdout, stderr)
     """
-    if len(args) == 2:
-        text, commandline = args
-    elif len(args) == 1:
-        text, commandline = None, args[0]
-    else:
-        raise Exception("One or two arguments expected")
 
     broken = commandline.split()
     exe = executable(broken[0])
@@ -108,7 +102,7 @@ class TestOBabel(BaseTest):
     def testNoInput(self):
         """Ensure that this does not segfault (PR#1818)"""
         self.canFindExecutable("obabel")
-        output, error = run_exec("obabel -i")
+        output, error = run_exec(None, "obabel -i")
         self.assertGreater(len(output), 1, "Did not generate output")
         self.assertGreater(len(error), 1, "Did not generate error message")
 
@@ -129,13 +123,13 @@ class TestOBabel(BaseTest):
         data = ["O>N>S", "O>>S", "O>N>", "O>>",
                 ">N>S", ">>S", ">>"]
         for rsmi in data:
-            output, error = run_exec('obabel -:%s -irsmi -orsmi' % rsmi)
+            output, error = run_exec(None, 'obabel -:%s -irsmi -orsmi' % rsmi)
             self.assertEqual(output.rstrip(), rsmi)
         # Check handling of invalid rxn components
         data = ["Noel>N>S", "O>Noel>S", "O>N>Noel"]
         errors = ["reactant", "agent", "product"]
         for rsmi, error in zip(data, errors):
-            output, errormsg = run_exec('obabel -:%s -irsmi -orsmi' % rsmi)
+            output, errormsg = run_exec(None, 'obabel -:%s -irsmi -orsmi' % rsmi)
             self.assertIn(error, errormsg)
 
     def sort(self, rsmi):
@@ -151,16 +145,16 @@ class TestOBabel(BaseTest):
         data = ["c1ccccc1", "c%11ccccc%11", "c%(1)ccccc%(1)", "c%(51)ccccc%51",
                 "c%(99999)ccccc%(99999)"]
         for smi in data:
-            output, error = run_exec("obabel -:%s -osmi" % smi)
+            output, error = run_exec(None, "obabel -:%s -osmi" % smi)
             self.assertEqual("c1ccccc1", output.rstrip())
         # Test negatives
         data = ["c%1ccccc%1", "c%a1cccc%a1", "c%(a1)ccccc%(a1)",
                 "c%(000001)ccccc%(000001)", "c%(51)ccccc%(15)"]
         for smi in data:
-            output, error = run_exec("obabel -:%s -osmi" % smi)
+            output, error = run_exec(None, "obabel -:%s -osmi" % smi)
             self.assertIn("0 molecules converted", error)
         # Now test writing of %(NNN) notation
-        output, error = run_exec("obabel %s -osmi" % self.getTestFile("102Uridine.smi"))
+        output, error = run_exec(None, "obabel %s -osmi" % self.getTestFile("102Uridine.smi"))
         self.assertIn("%(100)", output)
 
     def testPDBQT(self):
@@ -282,7 +276,7 @@ TORSDOF 5
                 cofname = 'mol24' # Special case: 'internal name' not the same as file name
             coffile = self.getTestFile(coffilename)
             cansmi = CAN + '\t' + cofname # Expected SMILES line plus molecule name
-            output, error = run_exec( "obabel -icof -ocan %s" % coffile)
+            output, error = run_exec(None, "obabel -icof -ocan %s" % coffile)
             self.assertEqual(output.rstrip('\r\n'), cansmi)
 
     def testCOFtoMOL(self):
@@ -306,7 +300,7 @@ TORSDOF 5
             if(cofname == 'culgi_06'):
                 cofname = 'mol24'
             coffile = self.getTestFile(coffilename)
-            output, error = run_exec( "obabel -icof -omol %s" % coffile)
+            output, error = run_exec(None, "obabel -icof -omol %s" % coffile)
             molfilename = cofname + '.mol'
             molfile = self.getTestFile(molfilename)
 
@@ -341,7 +335,7 @@ TORSDOF 5
             coffilename = molname + '_from_mol.cof'
             coffile = self.getTestFile(coffilename)
             molfile = self.getTestFile(molfilename)
-            output, error = run_exec( "obabel -imol -ocof %s --partialcharge none" % molfile)
+            output, error = run_exec(None, "obabel -imol -ocof %s --partialcharge none" % molfile)
 
             # Chop up the output and the baseline files into single lines
             # Skip first three lines: first line contains Culgi version,
@@ -374,7 +368,7 @@ TORSDOF 5
             if(cofname == 'culgi_06'):
                 cofname = 'mol24'
             coffile = self.getTestFile(coffilename)
-            output, error = run_exec( "obabel -icof -omol2 %s" % coffile)
+            output, error = run_exec(None, "obabel -icof -omol2 %s" % coffile)
             mol2filename = cofname + '.mol2'
             mol2file = self.getTestFile(mol2filename)
 
@@ -407,7 +401,7 @@ TORSDOF 5
             coffilename = mol2name + '_from_mol2.cof'
             coffile = self.getTestFile(coffilename)
             mol2file = self.getTestFile(mol2filename)
-            output, error = run_exec( "obabel -imol2 -ocof %s" % mol2file)
+            output, error = run_exec(None, "obabel -imol2 -ocof %s" % mol2file)
 
             # Chop up the output and the baseline files into single lines
             # Skip first three lines: first line contains Culgi version,
@@ -423,7 +417,7 @@ TORSDOF 5
         '''This is a regression test for a segfault, but could put
         other mol2 test here'''
         mol2file = self.getTestFile('5sun_protein.mol2')
-        outputerr = run_exec( "obabel -imol2 %s -osdf" % mol2file)
+        outputerr = run_exec(None, "obabel -imol2 %s -osdf" % mol2file)
         self.assertGreater(len(outputerr[0]), 0, "Did not generate output")
 
     def testXYZazete(self):
@@ -518,12 +512,12 @@ charge 1
     def testOBRMS(self):
         '''Sanity checks for obrms'''
         sdffile = self.getTestFile('testsym_2Dtests.sdf')
-        output, err = run_exec( "obrms -t 10 %s %s"%(sdffile,sdffile))
+        output, err = run_exec(None, "obrms -t 10 %s %s"%(sdffile,sdffile))
         # all rmsds should be zero
         rmsds = [float(line.split()[-1]) for line in output.split('\n') if line]
         for rmsd in rmsds:
             self.assertEqual(rmsd, 0, "RMSD not zero between identical structures")
-        output, err = run_exec( "obrms -t 10 -f %s %s" % (sdffile,sdffile))
+        output, err = run_exec(None, "obrms -t 10 -f %s %s" % (sdffile,sdffile))
         #first zero, second nonzero, last inf
         rmsds = [float(line.split()[-1]) for line in output.split('\n') if line]
         self.assertEqual(rmsds[0],0)

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -40,27 +40,24 @@ def run_exec(*args):
     else:
         raise Exception("One or two arguments expected")
 
-    if sys.platform.startswith("win"):
-        broken = commandline.split()
-        exe = executable(broken[0])
-    else:
-        broken = commandline.encode().split()
-        exe = executable(broken[0].decode())
+    broken = commandline.split()
+    exe = executable(broken[0])
     # Note that bufsize = -1 means default buffering
     # Without this, it's unbuffered and it takes 10x longer on MacOSX
     if text:
         p = Popen([exe] + broken[1:],
-                  stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=1)
-        stdout, stderr = p.communicate(text.encode())
+                  stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=1,
+                  universal_newlines=True)
+        stdout, stderr = p.communicate(text)
     else:
         p = Popen([exe] + broken[1:],
-                  stdout=PIPE, stderr=PIPE, bufsize=-1)
+                  stdout=PIPE, stderr=PIPE, bufsize=-1, universal_newlines=True)
         stdout, stderr = p.communicate()
 
     if p.returncode and len(stderr) == 0:
         #should never exit with an error without an error message
-        raise CalledProcessError(p.returncode,commandline,stdout.decode())
-    return stdout.decode(), stderr.decode()
+        raise CalledProcessError(p.returncode, commandline, stdout)
+    return stdout, stderr
 
 def executable(name):
     """Return the full path to an executable"""

--- a/test/testdistgeom.py
+++ b/test/testdistgeom.py
@@ -61,11 +61,11 @@ class TestDistanceGeomStereo(BaseTest):
 
         for smi in self.smiles:
             # generate a canonical SMILES in case the ordering changes
-            canSMI, error = run_exec(smi, "obabel -ismi -ocan")
+            canSMI, error = run_exec(smi, ["obabel", "-ismi", "-ocan"])
             # generate a mol2 (any 3D format without implicit hydrogens)
-            mol2, error = run_exec(smi, "obabel -ismi -osdf --gen3d dg")
+            mol2, error = run_exec(smi, ["obabel", "-ismi", "-osdf", "--gen3d", "dg"])
             # now check if it matches the previous canonical SMILES
-            output, error = run_exec(mol2, "obabel -isdf -ocan")
+            output, error = run_exec(mol2, ["obabel", "-isdf", "-ocan"])
 
             self.assertEqual(output.split('\t')[0].rstrip(), canSMI.rstrip())
 
@@ -87,9 +87,9 @@ class TestDistanceGeomStereo(BaseTest):
             '(CC1)C(=O)O)C)C)C',
         ]
         for smi in hard_smiles:
-            canSMI, error = run_exec(smi, "obabel -ismi -ocan")
-            mol2, error = run_exec(smi, "obabel -ismi -osdf --gen3d dg")
-            output, error = run_exec(mol2, "obabel -isdf -ocan")
+            canSMI, error = run_exec(smi, ["obabel", "-ismi", "-ocan"])
+            mol2, error = run_exec(smi, ["obabel", "-ismi", "-osdf", "--gen3d", "dg"])
+            output, error = run_exec(mol2, ["obabel", "-isdf", "-ocan"])
 
             self.assertEqual(output.split('\t')[0].rstrip(), canSMI.rstrip())
 

--- a/test/testfastsearch.py
+++ b/test/testfastsearch.py
@@ -42,15 +42,15 @@ c12[C]3([C@H]4([N@@](CCc1c1ccccc1[nH]2)C[C@H](C=C4CC)C3))C(=O)OC"""
         outputfile.write(smiles)
         outputfile.close()
 
-        output, error = run_exec(None, "obabel ten.smi -O ten.fs")
+        output, error = run_exec(None, ["obabel", "ten.smi", "-O", "ten.fs"])
         self.canFindFile("ten.fs")
         self.assertConverted(error, 10)
 
         query = "Nc2nc(c1ccccc1)nc3ccccc23"
-        output, error = run_exec(None, "obabel ten.fs -ifs -s %s -osmi" % query)
+        output, error = run_exec(None, ["obabel", "ten.fs", "-ifs", "-s", query, "-osmi"])
         self.assertConverted(error, 1)
 
-        output, error = run_exec(None, "obabel ten.fs -ifs -s %s -at 0.5 -aa -osmi" % query)
+        output, error = run_exec(None, ["obabel", "ten.fs", "-ifs", "-s", query, "-at", "0.5", "-aa", "-osmi"])
         self.assertConverted(error, 1)
 
 

--- a/test/testfastsearch.py
+++ b/test/testfastsearch.py
@@ -42,15 +42,15 @@ c12[C]3([C@H]4([N@@](CCc1c1ccccc1[nH]2)C[C@H](C=C4CC)C3))C(=O)OC"""
         outputfile.write(smiles)
         outputfile.close()
 
-        output, error = run_exec("obabel ten.smi -O ten.fs")
+        output, error = run_exec(None, "obabel ten.smi -O ten.fs")
         self.canFindFile("ten.fs")
         self.assertConverted(error, 10)
 
         query = "Nc2nc(c1ccccc1)nc3ccccc23"
-        output, error = run_exec("obabel ten.fs -ifs -s %s -osmi" % query)
+        output, error = run_exec(None, "obabel ten.fs -ifs -s %s -osmi" % query)
         self.assertConverted(error, 1)
 
-        output, error = run_exec("obabel ten.fs -ifs -s %s -at 0.5 -aa -osmi" % query)
+        output, error = run_exec(None, "obabel ten.fs -ifs -s %s -at 0.5 -aa -osmi" % query)
         self.assertConverted(error, 1)
 
 

--- a/test/testkekule.py
+++ b/test/testkekule.py
@@ -51,7 +51,7 @@ class TestKekuleAssignment(BaseTest):
             'Cn1ccn2c1nc1c2c(=O)n(C)c(=O)n1C'
             ]
         for i in range(0, len(self.smiles)):
-            output, error = run_exec(self.smiles[i], "obabel -ismi -osmi")
+            output, error = run_exec(self.smiles[i], ["obabel", "-ismi", "-osmi"])
             self.assertEqual(output.rstrip(), self.smiles[i])
 
 class TestKekuleIsotope(BaseTest):
@@ -82,7 +82,7 @@ class TestKekuleIsotope(BaseTest):
             '[14cH]1[14cH][14cH][14cH][14cH][14cH]1',
             ]
         for i in range(0, len(self.smiles)):
-            output, error = run_exec(self.smiles[i], "obabel -ismi -ocan")
+            output, error = run_exec(self.smiles[i], ["obabel", "-ismi", "-ocan"])
             self.assertEqual(output.rstrip(), self.cansmis[i])
 
 class TestKekuleCrashers(BaseTest):
@@ -135,7 +135,7 @@ H         -0.11977       -0.69915        5.13149
 H         -0.93979        0.86887        4.93917
 H          0.78936        0.80651        5.29109
 """
-        output, error = run_exec(self.xyz, "obabel -ixyz -oxyz")
+        output, error = run_exec(self.xyz, ["obabel", "-ixyz", "-oxyz"])
         self.assertConverted(error, 1)
 
 if __name__ == "__main__":

--- a/test/testpdbformat.py
+++ b/test/testpdbformat.py
@@ -50,7 +50,7 @@ ATOM     10  CB  CYS A  16      44.435  17.811  54.045  1.00  0.00         B C
 ATOM     11  SG  CYS A  16      44.084  19.337  54.921  1.00  0.00         B S  '''
 
       output, error = run_exec(self.pdbin,
-                                     "obabel -ipdb -opdb")
+                                     ["obabel", "-ipdb", "-opdb"])
       
       #pull out only atoms
       outatoms = '\n'.join([line for line in output.split('\n') if line.startswith('ATOM')])
@@ -146,7 +146,7 @@ ATOM    474  HE2 TYR L  32      48.145  19.172  44.648  1.00  0.00           H
 ATOM    475  HH  TYR L  32      46.462  17.658  44.280  1.00  0.00           H
 """
         output, error = run_exec(self.entryPDBwithInsertioncodes,
-                                     "obabel -ipdb -ofasta")
+                                     ["obabel", "-ipdb", "-ofasta"])
         self.assertEqual(output.rstrip().rsplit("\n",1)[1], "VSSSY")
 
 if __name__ == "__main__":

--- a/test/testsmartssym.py
+++ b/test/testsmartssym.py
@@ -21,7 +21,7 @@ from testbabel import run_exec, BaseTest
 def checkmatch(query, molecules):
     result = []
     for smi in molecules:
-        output, error = run_exec("obabel -:%s -s%s -osmi" % (smi, query))
+        output, error = run_exec(None, "obabel -:%s -s%s -osmi" % (smi, query))
         result.append(output.strip() != "")
     return result
 
@@ -52,7 +52,7 @@ class TestSmartsSym(BaseTest):
                 '[C@H]1(Cl)NC1'
             ]
         for smi in data:
-            output, error = run_exec("obabel -:%s -s%s -osmi" % (smi, smi))
+            output, error = run_exec(None, "obabel -:%s -s%s -osmi" % (smi, smi))
             self.assertEqual(output.rstrip(), smi)
 
     def testTetStereo(self):

--- a/test/testsmartssym.py
+++ b/test/testsmartssym.py
@@ -21,14 +21,14 @@ from testbabel import run_exec, BaseTest
 def checkmatch(query, molecules):
     result = []
     for smi in molecules:
-        output, error = run_exec(None, "obabel -:%s -s%s -osmi" % (smi, query))
+        output, error = run_exec(None, ["obabel", "-:%s" % smi, "-s%s" % query, "-osmi"])
         result.append(output.strip() != "")
     return result
 
 def fastcheckmatch(query, molecules):
     """May fail where Open Babel does not output the input query, e.g.
     [C@@]([H])(Br)(Cl)I is output as [C@@H](Br)(Cl)I"""
-    output, error = run_exec("\n".join(molecules), "obabel -ismi -s%s -osmi" % query)
+    output, error = run_exec("\n".join(molecules), ["obabel", "-ismi", "-s%s" % query, "-osmi"])
     converted = [x.rstrip() for x in output.split("\n")]
     results = [smi in converted for smi in molecules]
     return results
@@ -52,7 +52,7 @@ class TestSmartsSym(BaseTest):
                 '[C@H]1(Cl)NC1'
             ]
         for smi in data:
-            output, error = run_exec(None, "obabel -:%s -s%s -osmi" % (smi, smi))
+            output, error = run_exec(None, ["obabel", "-:%s" % smi, "-s%s" % smi, "-osmi"])
             self.assertEqual(output.rstrip(), smi)
 
     def testTetStereo(self):

--- a/test/testsym.py
+++ b/test/testsym.py
@@ -24,25 +24,25 @@ class TestSym(BaseTest):
 
     def testInChItoSMI(self):
         """Verify that the InChI is read correctly"""
-        output, error = run_exec(self.inchi, "obabel -iinchi -ocan")
+        output, error = run_exec(self.inchi, ["obabel", "-iinchi", "-ocan"])
         self.assertEqual(output.rstrip(), self.cansmi)
 
     def testSMItoInChI(self):
         """Verify that all molecules give the same InChI"""
-        output, error = run_exec("\n".join(self.smiles), "obabel -ismi -oinchi")
+        output, error = run_exec("\n".join(self.smiles), ["obabel", "-ismi", "-oinchi"])
         output = "\n".join([x.rstrip() for x in output.split("\n")])
         self.assertEqual(output.rstrip(), "\n".join([self.inchi] * len(self.smiles)))
 
     def testSMItoCAN(self):
         """Verify that all molecules give the same cansmi"""
-        output, error = run_exec("\n".join(self.smiles), "obabel -ismi -ocan")
+        output, error = run_exec("\n".join(self.smiles), ["obabel", "-ismi", "-ocan"])
         output = "\n".join([x.rstrip() for x in output.split("\n")])
         self.assertEqual(output.rstrip(), "\n".join([self.cansmi] * len(self.smiles)))
 
     def testSMIthruXML(self):
         """Verify that roundtripping through CML preserves stereo"""
-        output, error = run_exec("\n".join(self.smiles), "obabel -ismi -O tmp.cml")
-        output, error = run_exec(output.rstrip(), "obabel -icml tmp.cml -ocan")
+        output, error = run_exec("\n".join(self.smiles), ["obabel", "-ismi", "-O", "tmp.cml"])
+        output, error = run_exec(output.rstrip(), ["obabel", "-icml", "tmp.cml", "-ocan"])
         output = "\n".join([x.rstrip() for x in output.split("\n")])
         self.assertEqual(output.rstrip(), "\n".join([self.cansmi] * len(self.smiles)))
         os.remove("tmp.cml")
@@ -160,9 +160,9 @@ class TestConversions(BaseTest):
         # the InChI on the right.
         # The canonical smiles (in the middle) were derived from the SMILES.
         for smiles, can, inchi in self.data:
-            output, error = run_exec(smiles, "obabel -ismi -oinchi")
+            output, error = run_exec(smiles, ["obabel", "-ismi", "-oinchi"])
             self.assertEqual(output.rstrip(), inchi)
-            output, error = run_exec(inchi, "obabel -iinchi -ocan")
+            output, error = run_exec(inchi, ["obabel", "-iinchi", "-ocan"])
             self.assertEqual(output.rstrip(), can)
 
     def parseMDL(self, text):
@@ -183,8 +183,8 @@ class TestConversions(BaseTest):
     def testSMILESto2D(self):
         """Test gen2d for some basic cases"""
         for smi, can, inchi in self.data:
-            output, error = run_exec(smi, "obabel -ismi --gen2d -omdl")
-            output, error = run_exec(output.rstrip(), "obabel -imdl -ocan")
+            output, error = run_exec(smi, ["obabel", "-ismi", "--gen2d", "-omdl"])
+            output, error = run_exec(output.rstrip(), ["obabel", "-imdl", "-ocan"])
             self.assertEqual(can, output.rstrip())
 
     def testSMILESto3DMDL(self):
@@ -207,7 +207,7 @@ class TestConversions(BaseTest):
 ]
         for i, (atompar, bondstereo) in enumerate(data):
             smiles, can = self.data[i][0:2]
-            output, error = run_exec(smiles, "obabel -ismi -osdf --gen3d")
+            output, error = run_exec(smiles, ["obabel", "-ismi", "-osdf", "--gen3d"])
             atoms, bonds = self.parseMDL(output)
             parities = [atom['parity'] for atom in atoms]
             parities.sort()
@@ -216,7 +216,7 @@ class TestConversions(BaseTest):
             self.assertEqual(atompar, parities)
             if bondstereo:
                 self.assertEqual(bondstereo, stereos)
-            output, error = run_exec(output, "obabel -isdf -as -ocan")
+            output, error = run_exec(output, ["obabel", "-isdf", "-as", "-ocan"])
             # "-as" is necessary to identify the unknown stereo
             self.assertEqual(output.rstrip(), can)
 
@@ -246,12 +246,12 @@ class TestConversions(BaseTest):
             if i in [7, 8, 9]: continue # perception of S=O from XYZ fails
 
             smiles, can = self.data[i][0:2]
-            output, error = run_exec(smiles, "obabel -ismi -oxyz --gen3d")
+            output, error = run_exec(smiles, ["obabel", "-ismi", "-oxyz", "--gen3d"])
 
-            canoutput, error = run_exec(output, "obabel -ixyz -ocan")
+            canoutput, error = run_exec(output, ["obabel", "-ixyz", "-ocan"])
             self.assertEqual(canoutput.rstrip(), can)
 
-            sdfoutput, error = run_exec(output, "obabel -ixyz -osdf")
+            sdfoutput, error = run_exec(output, ["obabel", "-ixyz", "-osdf"])
             atoms, bonds = self.parseMDL(sdfoutput)
             parities = [atom['parity'] for atom in atoms]
             parities.sort()
@@ -267,11 +267,11 @@ class TestConversions(BaseTest):
         # the SMILES strings in data[x][0] below.
         filename = self.getTestFile("testsym_2Dtests.sdf")
 
-        output, error = run_exec(None, "obabel -isdf %s -ocan" % filename)
+        output, error = run_exec(None, ["obabel", "-isdf", filename, "-ocan"])
         for i, smiles in enumerate(output.rstrip().split("\n")):
             self.assertEqual(smiles.rstrip(), self.data[i][1])
 
-        output, error = run_exec(None, "obabel -isdf %s -oinchi" % filename)
+        output, error = run_exec(None, ["obabel", "-isdf", filename, "-oinchi"])
         for i, inchi in enumerate(output.rstrip().split("\n")):
             self.assertEqual(inchi.rstrip(), self.data[i][2])
 
@@ -283,8 +283,8 @@ class TestConversions(BaseTest):
         # The test files have the correct canonical SMILES string
         # stored in the data field "smiles"
 
-        output, error = run_exec(None, "obabel -isdf %s %s -ocan --append smiles" %
-                                 (filenames[0], filenames[1]))
+        output, error = run_exec(None,
+                                 ["obabel", "-isdf"] + filenames + ["-ocan", "--append", "smiles"])
         for line in output.rstrip().split("\n"):
             result, correct_answer = line.split()
             self.assertEqual(result, correct_answer)
@@ -297,9 +297,9 @@ class TestConversions(BaseTest):
         # The test files have the correct canonical SMILES string
         # stored in the data field "smiles"
 
-        output, error = run_exec(None, "obabel -isdf %s %s -osdf --append smiles" %
-                                 (filenames[0], filenames[1]))
-        finaloutput, error = run_exec(output, "obabel -isdf -ocan")
+        output, error = run_exec(None,
+                                 ["obabel", "-isdf"] + filenames + ["-osdf", "--append", "smiles"])
+        finaloutput, error = run_exec(output, ["obabel", "-isdf", "-ocan"])
         for line in finaloutput.rstrip().split("\n"):
             result, correct_answer = line.split()
             self.assertEqual(result, correct_answer)
@@ -315,10 +315,10 @@ class TestConversions(BaseTest):
         for i, (atompar, bondstereo) in enumerate(data):
             if i == 3:
                 smiles, can = self.data[6][0:2]
-                output, error = run_exec(smiles, "obabel -ismi -osdf -aS")
+                output, error = run_exec(smiles, ["obabel", "-ismi", "-osdf", "-aS"])
             else:
                 smiles, can = self.data[i + 4][0:2]
-                output, error = run_exec(smiles, "obabel -ismi -osdf")
+                output, error = run_exec(smiles, ["obabel", "-ismi", "-osdf"])
             atoms, bonds = self.parseMDL(output)
             parities = [atom['parity'] for atom in atoms]
             parities.sort()
@@ -326,7 +326,7 @@ class TestConversions(BaseTest):
             stereos.sort()
             self.assertEqual(atompar, parities)
             self.assertEqual(bondstereo, stereos)
-            output, error = run_exec(output, "obabel -isdf -as -ocan")
+            output, error = run_exec(output, ["obabel", "-isdf", "-as", "-ocan"])
             self.assertEqual(output.rstrip(), can)
 
 
@@ -337,11 +337,11 @@ class TestStereoConversion(BaseTest):
     def testInChIToSMILES_Bug(self):
         """PR#2101034- InChI <-> SMILES conv misrepresents stereo"""
         test_inchi = 'InChI=1S/C10H10/c1-2-3-7-10-8-5-4-6-9-10/h2-9H,1H2/b7-3+'
-        output, error = run_exec(test_inchi, "obabel -iinchi -osmi")
+        output, error = run_exec(test_inchi, ["obabel", "-iinchi", "-osmi"])
         self.assertEqual(output.rstrip(), "C=C/C=C/c1ccccc1")
 
         test_smiles = r"C=C\C=C/c1ccccc1"
-        output, error = run_exec(test_smiles, "obabel -ismi -oinchi")
+        output, error = run_exec(test_smiles, ["obabel", "-ismi", "-oinchi"])
         self.assertEqual(output.rstrip(), "InChI=1S/C10H10/c1-2-3-7-10-8-5-4-6-9-10/h2-9H,1H2/b7-3-")
     def testChiralToLonePair(self):
         """PR#3058701 - Handle stereochemistry at lone pair on S"""
@@ -351,11 +351,11 @@ class TestStereoConversion(BaseTest):
         can = 'C[S@](=O)Cl'
         smiles = [can, '[S@](Cl)(=O)C', 'O=[S@](Cl)C']
         for smile in smiles:
-            output, error = run_exec(smile, "obabel -ismi -ocan")
+            output, error = run_exec(smile, ["obabel", "-ismi", "-ocan"])
             self.assertEqual(output.rstrip(), can)
         # Check that regular chiral S still work fine
         smi = "[S@](=O)(=N)(C)O"
-        output, error = run_exec(smi, "obabel -ismi -osmi")
+        output, error = run_exec(smi, ["obabel", "-ismi", "-osmi"])
         self.assertEqual(output.rstrip(), smi)
 
 del TestSym # remove base class to avoid tests

--- a/test/testsym.py
+++ b/test/testsym.py
@@ -267,11 +267,11 @@ class TestConversions(BaseTest):
         # the SMILES strings in data[x][0] below.
         filename = self.getTestFile("testsym_2Dtests.sdf")
 
-        output, error = run_exec("obabel -isdf %s -ocan" % filename)
+        output, error = run_exec(None, "obabel -isdf %s -ocan" % filename)
         for i, smiles in enumerate(output.rstrip().split("\n")):
             self.assertEqual(smiles.rstrip(), self.data[i][1])
 
-        output, error = run_exec("obabel -isdf %s -oinchi" % filename)
+        output, error = run_exec(None, "obabel -isdf %s -oinchi" % filename)
         for i, inchi in enumerate(output.rstrip().split("\n")):
             self.assertEqual(inchi.rstrip(), self.data[i][2])
 
@@ -283,7 +283,7 @@ class TestConversions(BaseTest):
         # The test files have the correct canonical SMILES string
         # stored in the data field "smiles"
 
-        output, error = run_exec("obabel -isdf %s %s -ocan --append smiles" %
+        output, error = run_exec(None, "obabel -isdf %s %s -ocan --append smiles" %
                                  (filenames[0], filenames[1]))
         for line in output.rstrip().split("\n"):
             result, correct_answer = line.split()
@@ -297,7 +297,7 @@ class TestConversions(BaseTest):
         # The test files have the correct canonical SMILES string
         # stored in the data field "smiles"
 
-        output, error = run_exec("obabel -isdf %s %s -osdf --append smiles" %
+        output, error = run_exec(None, "obabel -isdf %s %s -osdf --append smiles" %
                                  (filenames[0], filenames[1]))
         finaloutput, error = run_exec(output, "obabel -isdf -ocan")
         for line in finaloutput.rstrip().split("\n"):

--- a/test/testunique.py
+++ b/test/testunique.py
@@ -49,7 +49,7 @@ C([2H])([2H])([2H])[2H]	deuteromethane"""
 
         for param in params:
             output, error = run_exec(self.smiles,
-                                     "obabel -ismi -osmi --unique %s" % param[0])
+                                     ["obabel", "-ismi", "-osmi", "--unique", param[0]])
             self.assertConverted(error, param[1])
 
 if __name__ == "__main__":


### PR DESCRIPTION
- refactor(testbabel.run_exec): specify universal_newlines=True in subprocess.Popen
- refactor(testbabel.run_exec)!: replace subprocess.Poepn with subprocess.run (python 3.5+)
- refactor(testbabel.run_exec): avoid arbitrary argument lists
- refactor(testbabel.run_exec): split argument beforehand
- refactor(testbabel.TestOBabel.testMissingPlugins): use env parameter; avoid modifying os.environ directly and shell=True