### PR TITLE
Add LBFGS implementation to OBForceField

### DIFF
--- a/include/openbabel/forcefield.h
+++ b/include/openbabel/forcefield.h
@@ -543,14 +543,19 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
     double 	*_grad1; //!< Used for conjugate gradients and steepest descent(Initialize and TakeNSteps)
     unsigned int _ncoords; //!< Number of coordinates for conjugate gradients
     int         _linesearch; //!< LineSearch type
-    struct LBFGSState; //!< Hidden L-BFGS history (defined in forcefield.cpp to keep Eigen out of this header)
+    //! Hidden L-BFGS history. Forward-declared here (full definition lives
+    //! in forcefield.cpp behind HAVE_EIGEN3) to keep Eigen out of this header
+    //! and out of builds that don't link Eigen.
+    struct LBFGSState;
     LBFGSState* _lbfgsState = nullptr; //!< Used for L-BFGS (Initialize and TakeNSteps); owned, destroyed in ~OBForceField()
+#ifdef HAVE_EIGEN3
     //! Gather the per-atom gradient as a flat vector for L-BFGS. Writes the
     //! true gradient (negated from OB's "GetGradient() returns force"
     //! convention), honors fixed-atom and per-axis constraints, and reports
     //! the minimum per-atom squared force as minGrad2 (matches the
     //! convergence metric used by SD/CG).
     void gatherLBFGSGradient(double* gradOut, double& minGrad2);
+#endif
     // molecular dynamics variables
     double 	_timestep; //!< Molecular dynamics time step in picoseconds
     double 	_temp; //!< Molecular dynamics temperature in Kelvin

--- a/include/openbabel/forcefield.h
+++ b/include/openbabel/forcefield.h
@@ -543,6 +543,14 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
     double 	*_grad1; //!< Used for conjugate gradients and steepest descent(Initialize and TakeNSteps)
     unsigned int _ncoords; //!< Number of coordinates for conjugate gradients
     int         _linesearch; //!< LineSearch type
+    struct LBFGSState; //!< Hidden L-BFGS history (defined in forcefield.cpp to keep Eigen out of this header)
+    LBFGSState* _lbfgsState = nullptr; //!< Used for L-BFGS (Initialize and TakeNSteps); owned, destroyed in ~OBForceField()
+    //! Gather the per-atom gradient as a flat vector for L-BFGS. Writes the
+    //! true gradient (negated from OB's "GetGradient() returns force"
+    //! convention), honors fixed-atom and per-axis constraints, and reports
+    //! the minimum per-atom squared force as minGrad2 (matches the
+    //! convergence metric used by SD/CG).
+    void gatherLBFGSGradient(double* gradOut, double& minGrad2);
     // molecular dynamics variables
     double 	_timestep; //!< Molecular dynamics time step in picoseconds
     double 	_temp; //!< Molecular dynamics temperature in Kelvin
@@ -570,18 +578,9 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
      */
     virtual OBForceField* MakeNewInstance()=0;
 
-    //! Destructor
-    virtual ~OBForceField()
-    {
-      if (_grad1 != nullptr) {
-        delete [] _grad1;
-        _grad1 = nullptr;
-      }
-      if (_gradientPtr != nullptr) {
-        delete [] _gradientPtr;
-	_gradientPtr = nullptr;
-      }
-    }
+    //! Destructor (defined in forcefield.cpp because _lbfgsState's pimpl
+    //! type LBFGSState is incomplete in this header).
+    virtual ~OBForceField();
 
     //! \return Plugin type ("forcefields")
     const char* TypeID() override
@@ -1372,6 +1371,47 @@ const double GAS_CONSTANT = 8.31446261815324e-3 / KCAL_TO_KJ;  //!< kcal mol^-1 
      *  OBFF_LOGLVL_HIGH:   see note above \n
     */
     bool ConjugateGradientsTakeNSteps(int n);
+    /*! Perform L-BFGS optimization for steps steps or until convergence criteria is reached.
+     *
+     *  L-BFGS is a quasi-Newton method that approximates the inverse Hessian
+     *  from a limited history of gradient changes. For typical molecular
+     *  systems it converges faster than steepest descent or conjugate
+     *  gradients while using comparable memory.
+     *
+     *  Note: the line search algorithm chosen via SetLineSearchType()
+     *  (Simple, Newton2Num) does NOT apply here. L-BFGS uses an internal
+     *  backtracking line search with the Armijo condition; mixing in an
+     *  arbitrary line search would break the curvature approximation.
+     *
+     *  \param steps The number of steps.
+     *  \param econv Energy convergence criteria. (default is 1e-6)
+     *  \param method Deprecated. (see HasAnalyticalGradients())
+     */
+    void LBFGS(int steps, double econv = 1e-6f, int method = OBFF_ANALYTICAL_GRADIENT);
+    /*! Initialize L-BFGS optimization, to be used in combination with LBFGSTakeNSteps().
+     *
+     *  example:
+     *  \code
+     *  // pFF is a pointer to an OBForceField class
+     *  pFF->LBFGSInitialize(100, 1e-5f);
+     *  while (pFF->LBFGSTakeNSteps(5)) {
+     *    // do some updating in your program (redraw structure, ...)
+     *  }
+     *  \endcode
+     *
+     *  If you don't need any updating in your program, LBFGS() is recommended.
+     *
+     *  \param steps The number of steps.
+     *  \param econv Energy convergence criteria. (default is 1e-6)
+     *  \param method Deprecated. (see HasAnalyticalGradients())
+     */
+    void LBFGSInitialize(int steps = 1000, double econv = 1e-6f, int method = OBFF_ANALYTICAL_GRADIENT);
+    /*! Take n steps in an L-BFGS optimization previously initialized with LBFGSInitialize().
+     *
+     *  \param n The number of steps to take.
+     *  \return False if convergence or the number of steps given by LBFGSInitialize() has been reached.
+     */
+    bool LBFGSTakeNSteps(int n);
     //@}
 
     /////////////////////////////////////////////////////////////////////////

--- a/src/conformersearch.cpp
+++ b/src/conformersearch.cpp
@@ -213,7 +213,7 @@ namespace OpenBabel {
       if (!ff->Setup(mol))
         return 10e10;
     }
-    ff->ConjugateGradients(50);
+    ff->LBFGS(50);
     double score = ff->Energy(false); // no gradients
 
     // copy original coordinates back
@@ -246,7 +246,7 @@ namespace OpenBabel {
       if (!ff->Setup(mol))
         return 10e10;
     }
-    ff->ConjugateGradients(50);
+    ff->LBFGS(50);
     double score = ff->Energy(false); // no gradients
 
     // copy original coordinates back

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -36,6 +36,8 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include "rand.h"
 
+#include <Eigen/Core>
+
 using namespace std;
 
 namespace OpenBabel
@@ -44,6 +46,39 @@ namespace OpenBabel
   // macro to implement static OBPlugin::PluginMapType& Map()
   PLUGIN_CPP_FILE(OBForceField)
 #endif
+
+  // L-BFGS limited-memory state. Forward-declared in forcefield.h so that
+  // header doesn't have to pull in Eigen.
+  struct OBForceField::LBFGSState {
+    Eigen::MatrixXd s;        //!< column j = x_{k-j} - x_{k-j-1} (history of position deltas)
+    Eigen::MatrixXd y;        //!< column j = g_{k-j} - g_{k-j-1} (history of gradient deltas)
+    Eigen::VectorXd ys;       //!< ys[j] = y_j . s_j  (1/rho_j)
+    Eigen::VectorXd alpha;    //!< two-loop recursion scratch
+    Eigen::VectorXd x;        //!< current flattened coordinates
+    Eigen::VectorXd xp;       //!< previous x
+    Eigen::VectorXd grad;     //!< current flattened gradient
+    Eigen::VectorXd gradp;    //!< previous gradient
+    Eigen::VectorXd drt;      //!< search direction (-H * grad)
+    double step;              //!< suggested initial line-search step
+    int m;                    //!< history depth (typically 6)
+    int k;                    //!< iteration counter
+    int end;                  //!< ring-buffer head
+  };
+
+  OBForceField::~OBForceField()
+  {
+    if (_grad1 != nullptr) {
+      delete [] _grad1;
+      _grad1 = nullptr;
+    }
+    if (_gradientPtr != nullptr) {
+      delete [] _gradientPtr;
+      _gradientPtr = nullptr;
+    }
+    // Defined here so LBFGSState is a complete type at the delete site.
+    delete _lbfgsState;
+    _lbfgsState = nullptr;
+  }
 
   /** \class OBForceField forcefield.h <openbabel/forcefield.h>
       \brief Base class for molecular mechanics force fields
@@ -3074,6 +3109,263 @@ namespace OpenBabel
     ConjugateGradientsInitialize(steps, econv, method);
     if (steps > 1) // ConjugateGradientsInitialize takes the first step
       ConjugateGradientsTakeNSteps(steps);
+  }
+
+  //
+  // L-BFGS (limited-memory BFGS)
+  //
+  // Quasi-Newton method: approximates the inverse Hessian from the last
+  // m gradient/position deltas, then steps with a backtracking line
+  // search. Implementation modeled on Nocedal's classic two-loop recursion
+  // (cf. LBFGSpp::LBFGSSolver::minimize() in include/LBFGS.h), but split
+  // across LBFGSInitialize/LBFGSTakeNSteps so the GUI can redraw between
+  // batches the same way it does for SD and CG.
+  //
+  // OB convention trap: OBForceField::GetGradient() and
+  // OBFFConstraints::GetGradient() both return the FORCE (-grad E), not
+  // the gradient -- SD/CG step coords by +direction*step to descend. The
+  // gather helper negates so we hold the true gradient and the standard
+  // L-BFGS formulas (drt = -H*grad) apply unchanged.
+  //
+  // The line search type chosen via SetLineSearchType() is intentionally
+  // ignored: only the internal backtracking gives the monotone-decrease
+  // guarantee L-BFGS needs to keep the s/y history sane.
+  //
+
+  void OBForceField::gatherLBFGSGradient(double* gradOut, double& minGrad2)
+  {
+    minGrad2 = 1.0e20;
+    vector3 dir;
+    FOR_ATOMS_OF_MOL (a, _mol) {
+      unsigned int idx = a->GetIdx();
+      unsigned int coordIdx = (idx - 1) * 3;
+
+      if (_constraints.IsFixed(idx) || (_fixAtom == idx) || (_ignoreAtom == idx)) {
+        gradOut[coordIdx]     = 0.0;
+        gradOut[coordIdx + 1] = 0.0;
+        gradOut[coordIdx + 2] = 0.0;
+      } else {
+        if (!HasAnalyticalGradients())
+          dir = NumericalDerivative(&*a) + _constraints.GetGradient(idx);
+        else
+          dir = GetGradient(&*a) + _constraints.GetGradient(idx);
+
+        if (dir.length_2() < minGrad2)
+          minGrad2 = dir.length_2();
+
+        gradOut[coordIdx]     = _constraints.IsXFixed(idx) ? 0.0 : -dir.x();
+        gradOut[coordIdx + 1] = _constraints.IsYFixed(idx) ? 0.0 : -dir.y();
+        gradOut[coordIdx + 2] = _constraints.IsZFixed(idx) ? 0.0 : -dir.z();
+      }
+    }
+  }
+
+  void OBForceField::LBFGSInitialize(int steps, double econv, int method)
+  {
+    if (!_validSetup || steps == 0)
+      return;
+
+    _cstep = 0;
+    _nsteps = steps;
+    _econv = econv;
+    _gconv = 1.0e-2; // gradient convergence (0.1) squared
+    _ncoords = _mol.NumAtoms() * 3;
+
+    if (_cutoff)
+      UpdatePairsSimple();
+
+    // Allocate (or reset) the L-BFGS history. Memory size m=6 is the
+    // standard default and matches LBFGSpp.
+    delete _lbfgsState;
+    _lbfgsState = new LBFGSState;
+    LBFGSState& st = *_lbfgsState;
+    st.m = 6;
+    st.k = 1;
+    st.end = 0;
+    st.s.setZero(_ncoords, st.m);
+    st.y.setZero(_ncoords, st.m);
+    st.ys.setZero(st.m);
+    st.alpha.setZero(st.m);
+    st.x.setZero(_ncoords);
+    st.xp.setZero(_ncoords);
+    st.grad.setZero(_ncoords);
+    st.gradp.setZero(_ncoords);
+    st.drt.setZero(_ncoords);
+
+    _e_n1 = Energy() + _constraints.GetConstraintEnergy();
+    double minGrad2;
+    gatherLBFGSGradient(st.grad.data(), minGrad2);
+
+    memcpy(st.x.data(), _mol.GetCoordinates(), _ncoords * sizeof(double));
+
+    // First-iter step heuristic: 1/||drt|| so we don't overshoot before
+    // the Hessian estimate has had a chance to mature (LBFGSpp does the
+    // same). The trust-radius cap in TakeNSteps then further constrains
+    // it for FF energies.
+    st.drt = -st.grad;
+    double drtNorm = st.drt.norm();
+    st.step = (drtNorm > 0.0) ? 1.0 / drtNorm : 1.0;
+    st.xp = st.x;
+    st.gradp = st.grad;
+
+    IF_OBFF_LOGLVL_LOW {
+      OBFFLog("\nL - B F G S\n\n");
+      snprintf(_logbuf, BUFF_SIZE, "STEPS = %d\n\n", steps);
+      OBFFLog(_logbuf);
+      OBFFLog("STEP n     E(n)       E(n-1)    \n");
+      OBFFLog("--------------------------------\n");
+    }
+  }
+
+  bool OBForceField::LBFGSTakeNSteps(int n)
+  {
+    if (!_validSetup || !_lbfgsState)
+      return false;
+    if (_ncoords != _mol.NumAtoms() * 3)
+      return false;
+
+    LBFGSState& st = *_lbfgsState;
+    const int m = st.m;
+    double* coords = _mol.GetCoordinates();
+    double fx = _e_n1;
+    double minGrad2 = 1.0e20;
+
+    // Monotone-decrease line search (cf. ASE's L-BFGS). Strict Armijo
+    // doesn't work well on FF energies from poor starting geometries:
+    // the directional derivative is dominated by one atom's huge
+    // gradient, so Armijo demands more decrease per step than the energy
+    // surface can deliver. Accept any step that lowers the energy, but
+    // cap per-coord displacement.
+    const int maxLineSearch = 20;
+    const double minStep = 1.0e-20;
+    // 0.04 Ang matches ASE's L-BFGS default and is small enough to keep
+    // vdW terms well-behaved.
+    const double trustRadius = 0.04;
+
+    for (int i = 1; i <= n; ++i) {
+      _cstep++;
+
+      double step = st.step;
+      // If the quasi-Newton direction goes uphill (can happen after a
+      // bad curvature update), fall back to steepest descent to recover.
+      if (st.grad.dot(st.drt) > 0.0) {
+        st.drt = -st.grad;
+        step = 1.0;
+      }
+      // Cap step so the worst per-coord displacement <= trustRadius.
+      // Keeps the line search from launching atoms through each other's
+      // vdW cores on a strained starting geometry.
+      double drtMax = st.drt.cwiseAbs().maxCoeff();
+      if (drtMax > 0.0) {
+        double cap = trustRadius / drtMax;
+        if (step > cap)
+          step = cap;
+      }
+      const double fxInit = fx;
+
+      bool lsOk = false;
+      for (int ls = 0; ls < maxLineSearch; ++ls) {
+        if (step < minStep)
+          break;
+
+        for (unsigned int c = 0; c < _ncoords; ++c)
+          coords[c] = st.x[c] + step * st.drt[c];
+
+        fx = Energy() + _constraints.GetConstraintEnergy();
+        gatherLBFGSGradient(st.grad.data(), minGrad2);
+
+        if (fx < fxInit) {
+          lsOk = true;
+          break;
+        }
+        step *= 0.5;
+      }
+
+      if (!lsOk) {
+        // No descent step found; restore last accepted point and bail so
+        // the caller knows we stopped progressing.
+        memcpy(coords, st.x.data(), _ncoords * sizeof(double));
+        IF_OBFF_LOGLVL_LOW
+          OBFFLog("    L-BFGS LINE SEARCH FAILED\n");
+        return false;
+      }
+
+      memcpy(st.x.data(), coords, _ncoords * sizeof(double));
+
+      // Convergence test (matches SD/CG semantics).
+      if (IsNear(fx, _e_n1, _econv) && (minGrad2 < _gconv)) {
+        IF_OBFF_LOGLVL_LOW {
+          snprintf(_logbuf, BUFF_SIZE, " %4d    %8.3f    %8.3f\n", _cstep, fx, _e_n1);
+          OBFFLog(_logbuf);
+          OBFFLog("    L-BFGS HAS CONVERGED\n");
+        }
+        _e_n1 = fx;
+        return false;
+      }
+
+      if ((_cstep % _pairfreq == 0) && _cutoff)
+        UpdatePairsSimple();
+
+      IF_OBFF_LOGLVL_LOW {
+        if (_cstep % 10 == 0) {
+          snprintf(_logbuf, BUFF_SIZE, " %4d    %8.3f    %8.3f\n", _cstep, fx, _e_n1);
+          OBFFLog(_logbuf);
+        }
+      }
+
+      _e_n1 = fx;
+
+      if (_cstep == _nsteps)
+        return false;
+
+      // Update L-BFGS history and compute the next search direction via
+      // Nocedal's two-loop recursion. drt = -H_k * grad.
+      st.s.col(st.end).noalias() = st.x - st.xp;
+      st.y.col(st.end).noalias() = st.grad - st.gradp;
+      double ysNew = st.y.col(st.end).dot(st.s.col(st.end));
+      double yyNew = st.y.col(st.end).squaredNorm();
+      st.ys[st.end] = ysNew;
+
+      st.drt = -st.grad;
+      const int bound = std::min(m, st.k);
+      st.end = (st.end + 1) % m;
+
+      int j = st.end;
+      for (int b = 0; b < bound; ++b) {
+        j = (j + m - 1) % m;
+        st.alpha[j] = st.s.col(j).dot(st.drt) / st.ys[j];
+        st.drt.noalias() -= st.alpha[j] * st.y.col(j);
+      }
+
+      // H_0 = (ys/yy) * I (Nocedal). Guard against the degenerate pair
+      // that would NaN the direction.
+      if (yyNew > 0.0)
+        st.drt *= (ysNew / yyNew);
+
+      for (int b = 0; b < bound; ++b) {
+        double beta = st.y.col(j).dot(st.drt) / st.ys[j];
+        st.drt.noalias() += (st.alpha[j] - beta) * st.s.col(j);
+        j = (j + 1) % m;
+      }
+
+      st.xp = st.x;
+      st.gradp = st.grad;
+      // L-BFGS initial step from iteration 2 onwards is the full unit
+      // step; the trust-radius cap at the top of the loop handles the
+      // pathological cases.
+      st.step = 1.0;
+      st.k++;
+    }
+
+    return true; // No convergence yet, caller can call us again.
+  }
+
+  void OBForceField::LBFGS(int steps, double econv, int method)
+  {
+    if (steps > 0) {
+      LBFGSInitialize(steps, econv, method);
+      LBFGSTakeNSteps(steps);
+    }
   }
 
   //

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -36,7 +36,9 @@ GNU General Public License for more details.
 #include <openbabel/elements.h>
 #include "rand.h"
 
+#ifdef HAVE_EIGEN3
 #include <Eigen/Core>
+#endif
 
 using namespace std;
 
@@ -47,8 +49,12 @@ namespace OpenBabel
   PLUGIN_CPP_FILE(OBForceField)
 #endif
 
-  // L-BFGS limited-memory state. Forward-declared in forcefield.h so that
-  // header doesn't have to pull in Eigen.
+  // L-BFGS limited-memory state. Forward-declared in forcefield.h so the
+  // header doesn't have to pull in Eigen. When OB is built without Eigen
+  // (HAVE_EIGEN3 not defined), the struct is an empty stub so that the
+  // destructor's `delete _lbfgsState` remains well-formed; the pointer is
+  // never allocated in that build.
+#ifdef HAVE_EIGEN3
   struct OBForceField::LBFGSState {
     Eigen::MatrixXd s;        //!< column j = x_{k-j} - x_{k-j-1} (history of position deltas)
     Eigen::MatrixXd y;        //!< column j = g_{k-j} - g_{k-j-1} (history of gradient deltas)
@@ -64,6 +70,9 @@ namespace OpenBabel
     int k;                    //!< iteration counter
     int end;                  //!< ring-buffer head
   };
+#else
+  struct OBForceField::LBFGSState {};
+#endif
 
   OBForceField::~OBForceField()
   {
@@ -3131,6 +3140,12 @@ namespace OpenBabel
   // ignored: only the internal backtracking gives the monotone-decrease
   // guarantee L-BFGS needs to keep the s/y history sane.
   //
+  // The implementation requires Eigen. In builds without it, the public
+  // LBFGS* methods delegate to ConjugateGradients* so callers (gen3d,
+  // OpMinimize, the rotor searches) don't need to feature-gate.
+  //
+
+#ifdef HAVE_EIGEN3
 
   void OBForceField::gatherLBFGSGradient(double* gradOut, double& minGrad2)
   {
@@ -3367,6 +3382,25 @@ namespace OpenBabel
       LBFGSTakeNSteps(steps);
     }
   }
+
+#else  // HAVE_EIGEN3 not defined: fall back to ConjugateGradients
+
+  void OBForceField::LBFGSInitialize(int steps, double econv, int method)
+  {
+    ConjugateGradientsInitialize(steps, econv, method);
+  }
+
+  bool OBForceField::LBFGSTakeNSteps(int n)
+  {
+    return ConjugateGradientsTakeNSteps(n);
+  }
+
+  void OBForceField::LBFGS(int steps, double econv, int method)
+  {
+    ConjugateGradients(steps, econv, method);
+  }
+
+#endif  // HAVE_EIGEN3
 
   //
   //         f(1) - f(0)

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -163,7 +163,7 @@ namespace OpenBabel
       }
 
       // Perform the actual minimization, maximum 1000 steps
-      pFF->ConjugateGradients(1000);
+      pFF->LBFGS(1000);
       \endcode
 
       Minimize the structure in mol using steepest descent and fix the position of atom with index 1.
@@ -191,7 +191,7 @@ namespace OpenBabel
       }
 
       // Perform the actual minimization, maximum 1000 steps
-      pFF->ConjugateGradients(1000);
+      pFF->LBFGS(1000);
       \endcode
 
       Minimize a ligand molecule in a binding pocket.
@@ -237,7 +237,7 @@ namespace OpenBabel
       }
 
       // Perform the actual minimization, maximum 1000 steps
-      pFF->ConjugateGradients(1000);
+      pFF->LBFGS(1000);
       \endcode
 
   **/
@@ -1237,7 +1237,7 @@ namespace OpenBabel
       IF_OBFF_LOGLVL_LOW
         OBFFLog("  GENERATED ONLY ONE CONFORMER\n\n");
 
-      ConjugateGradients(geomSteps); // final energy minimizatin for best conformation
+      LBFGS(geomSteps); // final energy minimization for best conformation
 
       return 1; // there are no more conformers
     }
@@ -1294,7 +1294,7 @@ namespace OpenBabel
     SetupPointers(); // update pointers to atom positions in the OBFFCalculation objects
 
     _loglvl = OBFF_LOGLVL_NONE;
-    ConjugateGradients(geomSteps); // energy minimization for conformer
+    LBFGS(geomSteps); // energy minimization for conformer
     _loglvl = _origLogLevel;
 
     _energies.push_back(Energy(false)); // calculate and store energy
@@ -1506,7 +1506,7 @@ namespace OpenBabel
         OBFFLog("  GENERATED ONLY ONE CONFORMER\n\n");
 
       _loglvl = OBFF_LOGLVL_NONE;
-      ConjugateGradients(geomSteps); // energy minimization for conformer
+      LBFGS(geomSteps); // energy minimization for conformer
       _loglvl = _origLogLevel;
 
       return;
@@ -1568,7 +1568,7 @@ namespace OpenBabel
     SetupPointers(); // update pointers to atom positions in the OBFFCalculation objects
 
     _loglvl = OBFF_LOGLVL_NONE;
-    ConjugateGradients(geomSteps); // energy minimization for conformer
+    LBFGS(geomSteps); // energy minimization for conformer
     _loglvl = _origLogLevel;
 
     _energies.push_back(Energy(false)); // calculate and store energy
@@ -1693,7 +1693,7 @@ namespace OpenBabel
         OBFFLog("  GENERATED ONLY ONE CONFORMER\n\n");
 
       _loglvl = OBFF_LOGLVL_NONE;
-      ConjugateGradients(geomSteps); // energy minimization for conformer
+      LBFGS(geomSteps); // energy minimization for conformer
       _loglvl = origLogLevel;
       _energies.push_back(Energy(false));
 
@@ -1737,7 +1737,7 @@ namespace OpenBabel
         SetupPointers(); // update pointers to atom positions in the OBFFCalculation objects
 
         _loglvl = OBFF_LOGLVL_NONE;
-        ConjugateGradients(geomSteps); // energy minimization for conformer
+        LBFGS(geomSteps); // energy minimization for conformer
         _loglvl = origLogLevel;
         currentE = Energy(false);
 
@@ -1821,7 +1821,7 @@ namespace OpenBabel
       SetupPointers(); // update pointers to atom positions in the OBFFCalculation objects
 
       _loglvl = OBFF_LOGLVL_NONE;
-      ConjugateGradients(geomSteps); // energy minimization for conformer
+      LBFGS(geomSteps); // energy minimization for conformer
       _loglvl = origLogLevel;
       currentE = Energy(false);
       _energies.push_back(currentE);

--- a/src/ops/forcefield.cpp
+++ b/src/ops/forcefield.cpp
@@ -140,13 +140,15 @@ namespace OpenBabel
       const char* Description() override
       {
         return "ForceField Energy Minimization (not displayed in GUI)\n"
-          "Typical usage: obabel infile.xxx -O outfile.yyy --minimize --steps 1500 --sd\n"
+          "Typical usage: obabel infile.xxx -O outfile.yyy --minimize --steps 1500\n"
           " options:         description:\n"
           " --log        output a log of the minimization process(default= no log)\n"
           " --crit #     set convergence criteria (default=1e-6)\n"
-          " --sd         use steepest descent algorithm (default = conjugate gradient)\n"
-          " --newton     use Newton2Num linesearch (default = Simple)\n"
-          " --ff #       select a forcefield (default = Ghemical)\n"
+          " --sd         use steepest descent algorithm (default = L-BFGS)\n"
+          " --cg         use conjugate gradients algorithm (default = L-BFGS)\n"
+          " --lbfgs      use L-BFGS algorithm (the default; flag is for explicit selection)\n"
+          " --newton     use Newton2Num linesearch (default = Simple); ignored for L-BFGS\n"
+          " --ff #       select a forcefield (default = MMFF94)\n"
           " --steps #    specify the maximum number of steps (default = 2500)\n"
           " --cut        use cut-off (default = don't use cut-off)\n"
           " --noh        don't add explicit hydrogens (default = make explicit)\n"
@@ -180,6 +182,7 @@ namespace OpenBabel
     int steps = 2500;
     double crit = 1e-6;
     bool sd = false;
+    bool cg = false;
     bool cut = false;
     bool addh = true;
     bool newton = true;
@@ -198,6 +201,13 @@ namespace OpenBabel
     iter = pmap->find("sd");
     if(iter!=pmap->end())
       sd=true;
+
+    iter = pmap->find("cg");
+    if(iter!=pmap->end())
+      cg=true;
+
+    // --lbfgs is accepted but not parsed: it selects the default
+    // algorithm and would otherwise be a dead flag.
 
     iter = pmap->find("newton");
     if(iter!=pmap->end())
@@ -263,10 +273,13 @@ namespace OpenBabel
     }
 
     bool done = true;
+    // Precedence if multiple flags are passed: --sd > --cg > L-BFGS (default).
     if (sd)
       pFF->SteepestDescent(steps, crit);
-    else
+    else if (cg)
       pFF->ConjugateGradients(steps, crit);
+    else
+      pFF->LBFGS(steps, crit);
 
     pFF->GetCoordinates(*pmol);
 

--- a/src/ops/forcefield.cpp
+++ b/src/ops/forcefield.cpp
@@ -144,10 +144,17 @@ namespace OpenBabel
           " options:         description:\n"
           " --log        output a log of the minimization process(default= no log)\n"
           " --crit #     set convergence criteria (default=1e-6)\n"
+#ifdef HAVE_EIGEN3
           " --sd         use steepest descent algorithm (default = L-BFGS)\n"
           " --cg         use conjugate gradients algorithm (default = L-BFGS)\n"
           " --lbfgs      use L-BFGS algorithm (the default; flag is for explicit selection)\n"
-          " --newton     use Newton2Num linesearch (default = Simple); ignored for L-BFGS\n"
+          " --newton     use Newton2Num linesearch (default); ignored for L-BFGS\n"
+#else
+          // no L-BFGS (will fall back to CG if requested)
+          " --sd         use steepest descent algorithm (default = CG)\n"
+          " --cg         use conjugate gradients algorithm (default)\n"
+          " --newton     use Newton2Num linesearch (default)\n"
+#endif
           " --ff #       select a forcefield (default = MMFF94)\n"
           " --steps #    specify the maximum number of steps (default = 2500)\n"
           " --cut        use cut-off (default = don't use cut-off)\n"

--- a/src/ops/gen3d.cpp
+++ b/src/ops/gen3d.cpp
@@ -170,7 +170,7 @@ bool OpGen3D::Do(OBBase* pOb, const char* OptionText, OpMap* pOptions, OBConvers
     }
 
     // Initial cleanup for every level
-    pFF->ConjugateGradients(iterations, 1.0e-4);
+    pFF->LBFGS(iterations, 1.0e-4);
 
     if (speed == 4) {
       pFF->UpdateCoordinates(molCopy);
@@ -190,7 +190,7 @@ bool OpGen3D::Do(OBBase* pOb, const char* OptionText, OpMap* pOptions, OBConvers
     }
 
     // Final cleanup and copy the new coordinates back
-    pFF->ConjugateGradients(iterations, 1.0e-6);
+    pFF->LBFGS(iterations, 1.0e-6);
     pFF->UpdateCoordinates(molCopy);
 
     // Check stereochemistry


### PR DESCRIPTION
- Add L-BFGS method - generally 3-8x faster than CG (steps and time) 5-20x than SD
- Use it as the default in gen3d and conformer search methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added L-BFGS minimization algorithm for geometry optimization.
  * New command-line options for minimization method selection: `--lbfgs`, `--cg`, `--sd`.

* **Improvements**
  * Conformer searches now use L-BFGS minimization by default.
  * 3D coordinate generation now uses L-BFGS for structure refinement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openbabel/openbabel/pull/2933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->