### PR TITLE
Refactor to remove many internal deprecated warnings

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -825,7 +825,7 @@ namespace OpenBabel
 
     rlist = mol->GetSSSR();
     for (i = rlist.begin();i != rlist.end();++i)
-      if ((*i)->IsInRing(GetIdx()) && static_cast<int>((*i)->PathSize()) == size)
+      if ((*i)->IsInRing(GetIdx()) && static_cast<int>((*i)->Size()) == size)
         return(true);
 
     return(false);

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -312,7 +312,7 @@ namespace OpenBabel
 
         bond1 = bond1.normalize();
         v1 = cross(bond1, bond2);
-        if (bond2 == VZero || v1 == VZero) {
+        if (bond2.length_2() == 0.0 || v1.length_2() == 0.0) {
           vector3 vrand;
           vrand.randomUnitVector();
           double angle = fabs(acos(dot(bond1, vrand)) * RAD_TO_DEG);
@@ -361,9 +361,9 @@ namespace OpenBabel
       //
       if (atom->GetExplicitDegree() == 2) {
         FOR_NBORS_OF_ATOM (nbr, atom) {
-          if (bond1 == VZero)
+          if (bond1.length_2() == 0.0)
             bond1 = atom->GetVector() - nbr->GetVector();
-          else if (bond2 == VZero)
+          else if (bond2.length_2() == 0.0)
             bond2 = atom->GetVector() - nbr->GetVector();
         }
 
@@ -432,11 +432,11 @@ namespace OpenBabel
       if (atom->GetExplicitDegree() == 3) {
         if (atom->GetHyb() == 3) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (bond1 == VZero)
+            if (bond1.length_2() == 0.0)
               bond1 = atom->GetVector() - nbr->GetVector();
-            else if (bond2 == VZero)
+            else if (bond2.length_2() == 0.0)
               bond2 = atom->GetVector() - nbr->GetVector();
-            else if (bond3 == VZero)
+            else if (bond3.length_2() == 0.0)
               bond3 = atom->GetVector() - nbr->GetVector();
           }
 
@@ -452,11 +452,11 @@ namespace OpenBabel
 
         if (atom->GetHyb() == 4) { // OK, we want this at -bond3, since bond1 & bond2 are opposite
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (bond1 == VZero)
+            if (bond1.length_2() == 0.0)
               bond1 = atom->GetVector() - nbr->GetVector();
-            else if (bond2 == VZero)
+            else if (bond2.length_2() == 0.0)
               bond2 = atom->GetVector() - nbr->GetVector();
-            else if (bond3 == VZero)
+            else if (bond3.length_2() == 0.0)
               bond3 = atom->GetVector() - nbr->GetVector();
           }
 
@@ -471,11 +471,11 @@ namespace OpenBabel
 
         if (atom->GetHyb() == 5) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (bond1 == VZero)
+            if (bond1.length_2() == 0.0)
               bond1 = atom->GetVector() - nbr->GetVector();
-            else if (bond2 == VZero)
+            else if (bond2.length_2() == 0.0)
               bond2 = atom->GetVector() - nbr->GetVector();
-            else if (bond3 == VZero)
+            else if (bond3.length_2() == 0.0)
               bond3 = atom->GetVector() - nbr->GetVector();
           }
 
@@ -496,11 +496,11 @@ namespace OpenBabel
 
         if (atom->GetHyb() == 6) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (bond1 == VZero)
+            if (bond1.length_2() == 0.0)
               bond1 = atom->GetVector() - nbr->GetVector();
-            else if (bond2 == VZero)
+            else if (bond2.length_2() == 0.0)
               bond2 = atom->GetVector() - nbr->GetVector();
-            else if (bond3 == VZero)
+            else if (bond3.length_2() == 0.0)
               bond3 = atom->GetVector() - nbr->GetVector();
           }
 
@@ -516,13 +516,13 @@ namespace OpenBabel
       if (atom->GetExplicitDegree() == 4) {
         if (atom->GetHyb() == 6) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (bond1 == VZero)
+            if (bond1.length_2() == 0.0)
               bond1 = atom->GetVector() - nbr->GetVector();
-            else if (bond2 == VZero)
+            else if (bond2.length_2() == 0.0)
               bond2 = atom->GetVector() - nbr->GetVector();
-            else if (bond3 == VZero)
+            else if (bond3.length_2() == 0.0)
               bond3 = atom->GetVector() - nbr->GetVector();
-            else if (bond4 == VZero)
+            else if (bond4.length_2() == 0.0)
               bond4 = atom->GetVector() - nbr->GetVector();
           }
 
@@ -535,13 +535,13 @@ namespace OpenBabel
 
         if (atom->GetHyb() == 5) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (bond1 == VZero)
+            if (bond1.length_2() == 0.0)
               bond1 = atom->GetVector() - nbr->GetVector();
-            else if (bond2 == VZero)
+            else if (bond2.length_2() == 0.0)
               bond2 = atom->GetVector() - nbr->GetVector();
-            else if (bond3 == VZero)
+            else if (bond3.length_2() == 0.0)
               bond3 = atom->GetVector() - nbr->GetVector();
-            else if (bond4 == VZero)
+            else if (bond4.length_2() == 0.0)
               bond4 = atom->GetVector() - nbr->GetVector();
           }
 
@@ -566,15 +566,15 @@ namespace OpenBabel
       if (atom->GetExplicitDegree() == 5) {
         if (atom->GetHyb() == 6) {
           FOR_NBORS_OF_ATOM (nbr, atom) {
-            if (bond1 == VZero)
+            if (bond1.length_2() == 0.0)
               bond1 = atom->GetVector() - nbr->GetVector();
-            else if (bond2 == VZero)
+            else if (bond2.length_2() == 0.0)
               bond2 = atom->GetVector() - nbr->GetVector();
-            else if (bond3 == VZero)
+            else if (bond3.length_2() == 0.0)
               bond3 = atom->GetVector() - nbr->GetVector();
-            else if (bond4 == VZero)
+            else if (bond4.length_2() == 0.0)
               bond4 = atom->GetVector() - nbr->GetVector();
-            else if (bond5 == VZero)
+            else if (bond5.length_2() == 0.0)
               bond5 = atom->GetVector() - nbr->GetVector();
           }
 
@@ -662,7 +662,7 @@ namespace OpenBabel
       //                          //
       if (atom->GetExplicitDegree() == 2) {
         for (OBAtom *nbr = atom->BeginNbrAtom(i); nbr; nbr = atom->NextNbrAtom(i)) {
-          if (bond1 == VZero)
+          if (bond1.length_2() == 0.0)
             bond1 = atom->GetVector() - nbr->GetVector();
           else
             bond2 = atom->GetVector() - nbr->GetVector();
@@ -720,9 +720,9 @@ namespace OpenBabel
           }
         } else {
           for (OBAtom *nbr = atom->BeginNbrAtom(i); nbr; nbr = atom->NextNbrAtom(i)) {
-            if (bond1 == VZero)
+            if (bond1.length_2() == 0.0)
               bond1 = atom->GetVector() - nbr->GetVector();
-            else if (bond2 == VZero)
+            else if (bond2.length_2() == 0.0)
               bond2 = atom->GetVector() - nbr->GetVector();
             else
               bond3 = atom->GetVector() - nbr->GetVector();
@@ -1093,7 +1093,7 @@ namespace OpenBabel
     // Trigger hybridisation perception now so it will be copied to workMol
     if (mol.NumAtoms() == 0)
       return true;
-    mol.GetFirstAtom()->GetHyb();
+    mol.GetAtom(1)->GetHyb();
 
     // copy the molecule to private data
     OBMol workMol = mol;
@@ -1618,7 +1618,7 @@ namespace OpenBabel
     bond1 = VZero;
     OBAtom atom1, atom2;
     FOR_NBORS_OF_ATOM(nbr, p) {
-      if (bond1 == VZero) {
+      if (bond1.length_2() == 0.0) {
         atom1 = *nbr;
         bond1 = posp - atom1.GetVector();
       }

--- a/src/forcefield.cpp
+++ b/src/forcefield.cpp
@@ -3308,7 +3308,7 @@ namespace OpenBabel
       memcpy(st.x.data(), coords, _ncoords * sizeof(double));
 
       // Convergence test (matches SD/CG semantics).
-      if (IsNear(fx, _e_n1, _econv) && (minGrad2 < _gconv)) {
+      if (fabs(fx - _e_n1) < _econv && (minGrad2 < _gconv)) {
         IF_OBFF_LOGLVL_LOW {
           snprintf(_logbuf, BUFF_SIZE, " %4d    %8.3f    %8.3f\n", _cstep, fx, _e_n1);
           OBFFLog(_logbuf);

--- a/src/formats/adfformat.cpp
+++ b/src/formats/adfformat.cpp
@@ -792,7 +792,11 @@ OBGridData *OBT41Format::NewData(const T41GridData &gd)
 {
         OBGridData *t41Data = new OBGridData;
   t41Data->SetNumberOfPoints( gd.numPoints[ 0 ], gd.numPoints[ 1 ], gd.numPoints[ 2 ] );
-        t41Data->SetLimits( gd.startPoint, gd.xAxis, gd.yAxis, gd.zAxis );
+        t41Data->SetLimits(
+          vector3(gd.startPoint[0], gd.startPoint[1], gd.startPoint[2]),
+          vector3(gd.xAxis[0], gd.xAxis[1], gd.xAxis[2]),
+          vector3(gd.yAxis[0], gd.yAxis[1], gd.yAxis[2]),
+          vector3(gd.zAxis[0], gd.zAxis[1], gd.zAxis[2]) );
   t41Data->SetUnrestricted( gd.unrestricted );
   t41Data->SetNumSymmetries( gd.numSymmetries );
 

--- a/src/formats/gausscubeformat.cpp
+++ b/src/formats/gausscubeformat.cpp
@@ -583,14 +583,14 @@ bool OBGaussianCubeFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
     }
 
     int nx, ny, nz;
-    double origin[3], xAxis[3], yAxis[3], zAxis[3];
+    double xAxis[3], yAxis[3], zAxis[3];
     gd->GetAxes(xAxis, yAxis, zAxis);
     gd->GetNumberOfPoints(nx, ny, nz);
-    gd->GetOriginVector(origin);
+    vector3 origin = gd->GetOriginVector();
 
     // line 3: number of atoms, origin x y z
     snprintf(buffer, BUFF_SIZE,"%5d%12.6f%12.6f%12.6f", - static_cast<signed int> (mol.NumAtoms()),
-        origin[0]*ANGSTROM_TO_BOHR, origin[1]*ANGSTROM_TO_BOHR, origin[2]*ANGSTROM_TO_BOHR);
+        origin.x()*ANGSTROM_TO_BOHR, origin.y()*ANGSTROM_TO_BOHR, origin.z()*ANGSTROM_TO_BOHR);
     ofs << buffer << endl;
 
     // line 4: number of points x direction, axis x direction x y z

--- a/src/formats/nwchemformat.cpp
+++ b/src/formats/nwchemformat.cpp
@@ -318,8 +318,8 @@ static const char* OPTIMIZATION_END_PATTERN = "  Optimization converged";
                 else if (vs[k+1][0] == '1')
                     i[j++] = k;
             }
-            quadrupole.Set(i[0], i[1], value);
-            quadrupole.Set(i[1], i[0], value);
+            quadrupole(i[0], i[1]) = value;
+            quadrupole(i[1], i[0]) = value;
         }
         else
             return;

--- a/src/formats/opendxformat.cpp
+++ b/src/formats/opendxformat.cpp
@@ -269,10 +269,10 @@ bool OBOpenDXCubeFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
       ofs << "# Molecule Title: " << str << "\n";
 
     int nx, ny, nz;
-    double origin[3], xAxis[3], yAxis[3], zAxis[3];
+    double xAxis[3], yAxis[3], zAxis[3];
     gd->GetAxes(xAxis, yAxis, zAxis);
     gd->GetNumberOfPoints(nx, ny, nz);
-    gd->GetOriginVector(origin);
+    vector3 origin = gd->GetOriginVector();
 
     // data line 1: # of points in x, y, z (nx, ny, nz)
     snprintf(buffer, BUFF_SIZE, "object 1 class gridpositions counts %5d %5d %5d", nx, ny, nz);
@@ -280,7 +280,7 @@ bool OBOpenDXCubeFormat::ReadMolecule( OBBase* pOb, OBConversion* pConv )
 
     // data line 2: origin (x, y, z)
     snprintf(buffer, BUFF_SIZE,"origin %12.6f %12.6f %12.6f",
-        origin[0], origin[1], origin[2]);
+        origin.x(), origin.y(), origin.z());
     ofs << buffer << "\n";
 
     // data line 3: x-displacement

--- a/src/formats/rinchiformat.cpp
+++ b/src/formats/rinchiformat.cpp
@@ -144,7 +144,7 @@ namespace OpenBabel
         case M_PRODUCTS: facade.GetComponent(&mol, PRODUCT, i); break;
         case M_AGENTS: facade.GetComponent(&mol, AGENT, i); break;
         }
-        if (mol.NumAtoms() == 1 && mol.GetFirstAtom()->GetAtomicNum() == 0) {
+        if (mol.NumAtoms() == 1 && mol.GetAtom(1)->GetAtomicNum() == 0) {
           // This represents an unknown component
           nonInchi[part]++;
           hasNonInchi = true;

--- a/src/formats/rxnformat.cpp
+++ b/src/formats/rxnformat.cpp
@@ -259,7 +259,7 @@ static void WriteMolFile(OBMol* pmol, OBConversion* pconv, OBFormat* pformat)
   ofs << "$MOL" << '\n';
   // Treat a dummy atom with "rxndummy" as the empty file
   if (pmol->NumAtoms() == 1) {
-    OBAtom *atm = pmol->GetFirstAtom();
+    OBAtom *atm = pmol->GetAtom(1);
     if (atm->GetAtomicNum() == 0 && atm->HasData("rxndummy"))
       pmol->DeleteAtom(atm);
   }

--- a/src/math/matrix3x3.cpp
+++ b/src/math/matrix3x3.cpp
@@ -270,9 +270,9 @@ namespace OpenBabel
   {
     vector3 vv;
 
-    vv.SetX(x()*m.Get(0,0) + y()*m.Get(0,1) + z()*m.Get(0,2));
-    vv.SetY(x()*m.Get(1,0) + y()*m.Get(1,1) + z()*m.Get(1,2));
-    vv.SetZ(x()*m.Get(2,0) + y()*m.Get(2,1) + z()*m.Get(2,2));
+    vv.SetX(x()*m(0,0) + y()*m(0,1) + z()*m(0,2));
+    vv.SetY(x()*m(1,0) + y()*m(1,1) + z()*m(1,2));
+    vv.SetZ(x()*m(2,0) + y()*m(2,1) + z()*m(2,2));
     x() = vv.x();
     y() = vv.y();
     z() = vv.z();

--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -2815,7 +2815,7 @@ namespace OpenBabel
     vector<OBAtom*>::iterator i;
 
     for (atom = BeginAtom(i);atom;atom = NextAtom(i))
-      if (atom->GetVector() != VZero)
+      if (atom->GetVector().length_2() != 0.0)
         return(true);
 
     return(false);
@@ -3279,7 +3279,7 @@ namespace OpenBabel
     rlist = GetSSSR();
     for (ringit = rlist.begin(); ringit != rlist.end(); ++ringit)
       {
-        if ((*ringit)->PathSize() == 5)
+        if ((*ringit)->Size() == 5)
           {
             path = (*ringit)->_path;
             torsions =
@@ -3301,7 +3301,7 @@ namespace OpenBabel
                   }
               }
           }
-        else if ((*ringit)->PathSize() == 6)
+        else if ((*ringit)->Size() == 6)
           {
             path = (*ringit)->_path;
             torsions =
@@ -3370,7 +3370,7 @@ namespace OpenBabel
     for (ringit = rlist.begin(); ringit != rlist.end(); ++ringit)
       {
         typed = false;
-        loopSize = (*ringit)->PathSize();
+        loopSize = (*ringit)->Size();
         if (loopSize == 5 || loopSize == 6 || loopSize == 7)
           {
             path = (*ringit)->_path;

--- a/src/ops/gen3d.cpp
+++ b/src/ops/gen3d.cpp
@@ -173,7 +173,7 @@ bool OpGen3D::Do(OBBase* pOb, const char* OptionText, OpMap* /*pOptions*/, OBCon
     pFF->LBFGS(iterations, 1.0e-4);
 
     if (speed == 4) {
-      pFF->UpdateCoordinates(molCopy);
+      pFF->GetCoordinates(molCopy);
       return true; // no conformer searching
     }
 
@@ -191,7 +191,7 @@ bool OpGen3D::Do(OBBase* pOb, const char* OptionText, OpMap* /*pOptions*/, OBCon
 
     // Final cleanup and copy the new coordinates back
     pFF->LBFGS(iterations, 1.0e-6);
-    pFF->UpdateCoordinates(molCopy);
+    pFF->GetCoordinates(molCopy);
 
     // Check stereochemistry
     success = stereoHelper.Check(&molCopy);

--- a/src/rotor.cpp
+++ b/src/rotor.cpp
@@ -111,7 +111,7 @@ namespace OpenBabel
       // check if the bond is "rotatable"
       if (bond->IsRotor(sampleRingBonds)) {
         // check if the bond is fixed (using deprecated fixed atoms or new fixed bonds)
-        if ((HasFixedAtoms() || HasFixedBonds()) && IsFixedBond(bond))
+        if ((!_fixedatoms.IsEmpty() || HasFixedBonds()) && IsFixedBond(bond))
           continue;
 
         if (bond->IsInRing()) {
@@ -135,7 +135,6 @@ namespace OpenBabel
       OBRotor *rotor = new OBRotor;
       rotor->SetBond((*j).first);
       rotor->SetIdx(count);
-      rotor->SetNumCoords(mol.NumAtoms()*3);
       _rotor.push_back(rotor);
     }
 
@@ -315,7 +314,7 @@ namespace OpenBabel
                 a1 = mol.GetAtom(j);
                 for (a2 = a1->BeginNbrAtom(k);a2;a2 = a1->NextNbrAtom(k))
                   if (!eval[a2->GetIdx()])
-                    if (!((OBBond*)*k)->IsRotor(_ringRotors)||((HasFixedAtoms()||HasFixedBonds())&&IsFixedBond((OBBond*)*k)))
+                    if (!((OBBond*)*k)->IsRotor(_ringRotors)||((!_fixedatoms.IsEmpty()||HasFixedBonds())&&IsFixedBond((OBBond*)*k)))
                       {
                         next.SetBitOn(a2->GetIdx());
                         eval.SetBitOn(a2->GetIdx());
@@ -352,7 +351,6 @@ namespace OpenBabel
       double delta;
       _rr.GetRotorIncrements(mol, bond, ref, angles, delta);
       rotor->SetTorsionValues(angles);
-      rotor->SetDelta(delta);
 
       // Find the smallest set of atoms to rotate. There are two candidate sets,
       // one on either side of the bond. If the first tried set size plus one is

--- a/test/math.cpp
+++ b/test/math.cpp
@@ -186,23 +186,23 @@ void testBasics_matrix3x3()
   m3 = matrix3x3(e);
   VERIFY( compare( m2, m3 ) );
 
-  // test const operator() and Get()
+  // test const operator()
   for( i = 0; i < 3; i++ )
     for( j = 0; j < 3; j++ )
     {
       VERIFY( compare( static_cast<const matrix3x3>(m2)(i,j), e[i][j] ) );
-      x = m2.Get( i, j );
+      x = m2(i, j);
       VERIFY( compare( x, e[i][j] ) );
     }
 
-  // test non-const operator() and Set()
+  // test non-const operator()
   for( i = 0; i < 3; i++ )
     for( j = 0; j < 3; j++ )
       m1(i,j) = m2(i,j);
   VERIFY( compare( m1, m2 ) );
   for( i = 0; i < 3; i++ )
     for( j = 0; j < 3; j++ )
-      m3.Set(i,j, m2(i,j) );
+      m3(i,j) = m2(i,j);
   VERIFY( compare( m3, m2 ) );
 
   // test SetColumn(), GetColumn(), SetRow(), GetRow(), transpose()
@@ -326,10 +326,10 @@ void testEigenvalues()
   matrix3x3 Diagonal;
   for(int i=0; i<3; i++)
     for(int j=0; j<3; j++)
-      Diagonal.Set(i, j, 0.0);
-  Diagonal.Set(0, 0, randomizer.UniformReal(0.0, 1.0));
-  Diagonal.Set(1, 1, Diagonal.Get(0,0) + randomizer.UniformReal(0.0, 1.0));
-  Diagonal.Set(2, 2, Diagonal.Get(1,1) + randomizer.UniformReal(0.0, 1.0));
+      Diagonal(i, j) = 0.0;
+  Diagonal(0, 0) = randomizer.UniformReal(0.0, 1.0);
+  Diagonal(1, 1) = Diagonal(0,0) + randomizer.UniformReal(0.0, 1.0);
+  Diagonal(2, 2) = Diagonal(1,1) + randomizer.UniformReal(0.0, 1.0);
 
   // test the isDiagonal() method
   VERIFY( Diagonal.isDiagonal() );
@@ -347,7 +347,7 @@ void testEigenvalues()
   toDiagonalize.findEigenvectorsIfSymmetric(eigenvals);
   
   for(unsigned int j=0; j<3; j++)
-    VERIFY( IsNegligible( eigenvals[j] - Diagonal.Get(j,j), Diagonal.Get(2,2) ) );
+    VERIFY( IsNegligible( eigenvals[j] - Diagonal(j,j), Diagonal(2,2) ) );
   
   VERIFY( eigenvals[0] < eigenvals[1] &&  eigenvals[1] < eigenvals[2] );
 }
@@ -361,9 +361,9 @@ void testEigenvectors()
 {
   matrix3x3 rnd;
   pickRandom( rnd );
-  rnd.Set(0,1, rnd.Get(1,0));
-  rnd.Set(0,2, rnd.Get(2,0));
-  rnd.Set(1,2, rnd.Get(2,1));
+  rnd(0,1) = rnd(1,0);
+  rnd(0,2) = rnd(2,0);
+  rnd(1,2) = rnd(2,1);
   vector3 eigenvals;
   matrix3x3 eigenvects = rnd.findEigenvectorsIfSymmetric(eigenvals);
   
@@ -377,7 +377,7 @@ void testEigenvectors()
   VERIFY( shouldBeDiagonal.isDiagonal() );
   
   for(unsigned int j=0; j<3; j++)
-    VERIFY( compare( shouldBeDiagonal.Get(j,j), eigenvals[j] ) );
+    VERIFY( compare( shouldBeDiagonal(j,j), eigenvals[j] ) );
   
   for(unsigned int i=0; i<3; i++ )
     {

--- a/tools/obconformer.cpp
+++ b/tools/obconformer.cpp
@@ -87,7 +87,7 @@ int main(int argc, char* argv[]) {
     if (pFF->Setup(mol)) {
       pFF->WeightedRotorSearch(weightSteps, geomSteps);
       pFF->ConjugateGradients(geomSteps);  // final cleanup
-      pFF->UpdateCoordinates(mol);
+      pFF->GetCoordinates(mol);
       conv.Write(&mol);
     } else {
       cerr << "Error! Cannot set up force field." << endl;
@@ -103,7 +103,7 @@ int main(int argc, char* argv[]) {
       }
       pFF->WeightedRotorSearch(weightSteps, geomSteps);
       pFF->ConjugateGradients(geomSteps);  // final cleanup
-      pFF->UpdateCoordinates(mol);
+      pFF->GetCoordinates(mol);
       conv.Write(&mol);
       pFF = OBForceField::FindForceField(forcefield);  // switch back to MMFF94
     }

--- a/tools/obgen.cpp
+++ b/tools/obgen.cpp
@@ -135,7 +135,7 @@ int main(int argc,char **argv)
       pFF->WeightedRotorSearch(250, 50);
       pFF->SteepestDescent(500, 1.0e-6);
 
-      pFF->UpdateCoordinates(mol);
+      pFF->GetCoordinates(mol);
       //pFF->ValidateGradients();
       //pFF->SetLogLevel(OBFF_LOGLVL_HIGH);
       //pFF->Energy();

--- a/tools/obmm.cpp
+++ b/tools/obmm.cpp
@@ -275,13 +275,13 @@ int main()
 
     if (EQn(commandline, "gen", 3)) {
       //pFF->GenerateCoordinates();
-      pFF->UpdateCoordinates(mol);
+      pFF->GetCoordinates(mol);
       continue;
     }
 
     if (EQn(commandline, "rs", 2)) {
       pFF->SystematicRotorSearch();
-      pFF->UpdateCoordinates(mol);
+      pFF->GetCoordinates(mol);
       continue;
     }
 
@@ -403,7 +403,7 @@ int main()
       }
 
       pFF->SteepestDescent(atoi(vs[1].c_str()), OBFF_ANALYTICAL_GRADIENT);
-      pFF->UpdateCoordinates(mol);
+      pFF->GetCoordinates(mol);
 
       continue;
     }
@@ -416,7 +416,7 @@ int main()
       }
 
       pFF->ConjugateGradients(atoi(vs[1].c_str()), OBFF_ANALYTICAL_GRADIENT);
-      pFF->UpdateCoordinates(mol);
+      pFF->GetCoordinates(mol);
 
       continue;
     }


### PR DESCRIPTION
Down to 17 warnings (from 81)

- GetFirstAtom
- VZero
- UpdateCoordinates
- etc.