### PR TITLE
fix: add a missed header inclusion (-Wdelete-incomplete)

### DIFF
--- a/src/obconversion.cpp
+++ b/src/obconversion.cpp
@@ -18,6 +18,7 @@ GNU General Public License for more details.
 ***********************************************************************/
 // Definition of OBConversion routines
 #include <openbabel/babelconfig.h>
+#include <openbabel/base.h>
 
 #ifdef _WIN32
 	#pragma warning (disable : 4786)


### PR DESCRIPTION
```
src/obconversion.cpp:703:21: error: deleting pointer to incomplete type
      'OBBase' is incompatible with C++2c and may cause undefined behavior [-Wdelete-incomplete]
```

https://github.com/openbabel/openbabel/blob/aa81cefd492e4fc8c47c2eedcb98c9351cc82eba/src/obconversion.cpp#L703