### PR TITLE
Fix tetrazole protonation handling in the pH model

### DIFF
--- a/data/phmodel.txt
+++ b/data/phmodel.txt
@@ -35,9 +35,8 @@ TRANSFORM [nD2:1]1c[nH]cc1 >> [n+:1]1c[nH]cc1				7.0
 TRANSFORM [ND3+0:1]=[#6] >> [ND3+:1]=[#6]				4.0 # pKa from conjugated acid (BH+)
 
 #tetrazole
-TRANSFORM [nD2:1]([#1:2])1[nD2-0][nD2-0][nD2-0]c1 >> [n-:1]1nnnc1	4.89 #pKa from acid (AH)
-TRANSFORM [nD2-0]1[nD2:1]([#1:2])[nD2-0][nD2-0]c1 >> n1[n-:1]nnc1	4.89 #pKa from acid (AH)
-TRANSFORM [nD2-0:1]1[nD2-0][nD2-0][nD2-0]c1 >> [n-:1]1nnnc1		4.89 #pKa from acid (AH)
+TRANSFORM c1[nH:1]nnn1 >> c1[n-:1]nnn1 4.89 # pKa from acid (AH)
+TRANSFORM c1n[nH:1]nn1 >> c1n[n-:1]nn1 4.89 # pKa from acid (AH)
 
 #azide (always apply these transformations)
 TRANSFORM [ND1:1]~[ND2:2]~[ND1:3] >> [N-:1]=[N+:2]=[N-:3] 1E+10	    # azide ion

--- a/test/testbabel.py
+++ b/test/testbabel.py
@@ -509,6 +509,27 @@ charge 1
         # mol2 displays element twice
         self.assertEqual(output.count('H'), 12)
 
+    def testTetrazolePhModel(self):
+        """Check tetrazole deprotonation at physiological pH (see https://github.com/openbabel/openbabel/issues/2284)"""
+        self.canFindExecutable("obabel")
+
+        tetrazoles = """c1[nH]nnn1
+c1nnn[nH]1
+c1n[nH]nn1
+c1nn[nH]n1
+"""
+        output, error = run_exec(tetrazoles, ["obabel", "-ismi", "-osmi", "-p", "7.4"])
+
+        self.assertConverted(error, 4)
+
+        smiles = [line.split()[0] for line in output.splitlines()]
+        self.assertEqual(len(smiles), 4)
+
+        for smi in smiles:
+            self.assertIn("[n-]", smi)
+            self.assertNotIn("[nH]", smi)
+            self.assertNotIn("[NH]", smi)
+            
     def testOBRMS(self):
         '''Sanity checks for obrms'''
         sdffile = self.getTestFile('testsym_2Dtests.sdf')


### PR DESCRIPTION
Fixes #2284.

This updates the tetrazole entries in data/phmodel.txt so that both graph-distinct protonated tetrazole forms are deprotonated while preserving aromaticity.

A regression test has also been added covering the four tetrazole examples reported in #2284. The test fails with the previous transforms and passes with the updated rules.

The change is based on the bug report, test cases, and proposed solution from @rubbs14 in https://github.com/openbabel/openbabel/issues/2284#issuecomment-706251272

The original pKa value of 4.89 from the existing tetrazole entries has been retained.