### PR TITLE
Guard vector3::normalize() against zero-length vectors

### DIFF
--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -165,7 +165,7 @@ namespace OpenBabel
     if( CanBeNormalized() )
       (*this) /= length();
 #else
-    (*this) /= length();
+    (*this) /= (DBL_EPSILON + length()); // avoid divide by zero
 #endif
     return(*this);
   }


### PR DESCRIPTION
`vector3::normalize()` — in the default branch (when `OB_OLD_MATH_CHECKS` is not defined) — divides the coordinates by `length()` unconditionally:

```cpp
(*this) /= length();
```

For a zero-length vector this is a divide-by-zero and produces `NaN` x/y/z, which can propagate from degenerate geometry into anything that normalizes a direction vector.

This guards the denominator:

```cpp
(*this) /= (DBL_EPSILON + length()); // avoid divide by zero
```

so a zero vector stays ~zero instead of becoming NaN, with negligible effect on normal-length vectors. Happy to instead branch only on the zero case (e.g. `if (length() > 0) (*this) /= length();`) if you'd prefer.
