### PR TITLE
ChemDraw CDX: handle additional aromatic/fractional bond-order codes

### DIFF
--- a/src/formats/chemdrawcdx.cpp
+++ b/src/formats/chemdrawcdx.cpp
@@ -607,11 +607,11 @@ bool ChemDrawBinaryXFormat::DoFragmentImpl(CDXReader& cdxr, OBMol* pmol,
             break;
           case 0x0040: // aromatic bond (0.5)
           case 0x0080: // aromatic bond (1.5)
-	  case 0x0100: // aromatic bond (2.5)
-	  case 0x0081: // single plus 1.5
-	  case 0x0082: // double plus 1.5
-	  case 0x0101: // single plus 2.5
-	  case 0x0102: // double plus 2.5
+          case 0x0100: // aromatic bond (2.5)
+          case 0x0081: // single plus 1.5
+          case 0x0082: // double plus 1.5
+          case 0x0101: // single plus 2.5
+          case 0x0102: // double plus 2.5
             order = 5;
             break;
           default: // other cases are just not supported, keep 1

--- a/src/formats/chemdrawcdx.cpp
+++ b/src/formats/chemdrawcdx.cpp
@@ -605,7 +605,13 @@ bool ChemDrawBinaryXFormat::DoFragmentImpl(CDXReader& cdxr, OBMol* pmol,
           case 0x0004:
             order = 3;
             break;
-          case 0x0080: // aromatic bond
+          case 0x0040: // aromatic bond (0.5)
+          case 0x0080: // aromatic bond (1.5)
+	  case 0x0100: // aromatic bond (2.5)
+	  case 0x0081: // single plus 1.5
+	  case 0x0082: // double plus 1.5
+	  case 0x0101: // single plus 2.5
+	  case 0x0102: // double plus 2.5
             order = 5;
             break;
           default: // other cases are just not supported, keep 1


### PR DESCRIPTION
`ChemDrawBinaryXFormat::DoFragmentImpl` mapped only CDX bond-order value `0x0080` to an aromatic bond (order 5); the other fractional/aromatic codes fell through to the default and were read as single bonds.

This adds the remaining aromatic/fractional CDX bond-order codes:

```
0x0040  // aromatic (0.5)
0x0080  // aromatic (1.5)   [existing]
0x0100  // aromatic (2.5)
0x0081  // single + 1.5
0x0082  // double + 1.5
0x0101  // single + 2.5
0x0102  // double + 2.5
```

all mapped to order 5 (aromatic), so molecules drawn in ChemDraw with these bond annotations import with correct aromaticity instead of as single bonds.

I'm happy to add a small `.cdx` round-trip test to the suite if that would help.
