### PR TITLE
build(plugin_descriptors): properly set the include directory of InChI

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -311,3 +311,7 @@ if(BUILD_SHARED)
 
   add_subdirectory(formats)
 endif(BUILD_SHARED)
+
+if("${WITH_INCHI}" AND "${OPENBABEL_USE_SYSTEM_INCHI}")
+  target_include_directories(plugin_descriptors PRIVATE "${INCHI_INCLUDE_DIR}")
+endif()

--- a/src/formats/libinchi/CMakeLists.txt
+++ b/src/formats/libinchi/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(inchi)
 set(INCHI_MAJ_VER   1)
 set(INCHI_MIN_VER   07)
-set(INCHI_PATCH_VER 4)
+set(INCHI_PATCH_VER 5)
 
 file(GLOB inchi_srcs "*.c")
 


### PR DESCRIPTION
fix regression of 35429f6c48f88dd7ec35467515d1eb81500d861c