### PR TITLE
adjust workflow for 'build swig bindings'

### DIFF
--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -18,7 +18,7 @@ jobs:
             name: "Linux SWIG All Bindings",
             os: ubuntu-latest,
             cc: "gcc", cxx: "g++",
-            csharp_compiler: "mcs",  # Added for C# support
+            csharp_compiler: "mcs",
             cmake_flags: "-DPYTHON_BINDINGS=ON -DPERL_BINDINGS=ON -DPHP_BINDINGS=ON -DRUBY_BINDINGS=ON -DJAVA_BINDINGS=ON -DCSHARP_BINDINGS=ON -DRUN_SWIG=ON "
           }
 
@@ -49,22 +49,28 @@ jobs:
           -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" \
           ${{matrix.config.cmake_flags}}
       shell: bash
-      working-directory: ${{ github.workspace }}  # Removed "/openbabel" as it doesn't exist
+      working-directory: ${{ github.workspace }}
 
     - name: Build
       run: CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake --build . --parallel $(nproc)
       shell: bash
       working-directory: ${{ runner.workspace }}/../build
 
+    - name: Create Packing Directory
+      run: mkdir -p ${{ runner.workspace }}/packed/openbabel
+
+    - name: Copy Files for Packing
+      run: |
+        cp -r ${{ runner.workspace }}/../build/* ${{ runner.workspace }}/packed/openbabel/
+      shell: bash
+
     - name: Packing
       run: |
-        tar --exclude-vcs --exclude-backups --exclude='.github*' -cvjf openbabel-latest.tar.bz2 .
+        tar --exclude-vcs --exclude-backups --exclude='.github*' -cvjf openbabel-latest.tar.bz2 -C ${{ runner.workspace }}/packed/openbabel .
       shell: bash
-      working-directory: ${{ runner.workspace }}/../build
 
     - name: Upload
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        path: ${{ runner.workspace }}/../build/openbabel-latest.tar.bz2
+        path: ${{ runner.workspace }}/packed/openbabel-latest.tar.bz2
         name: openbabel.tar.bz2
-

--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -37,6 +37,8 @@ jobs:
         echo "Runner Workspace: ${{ runner.workspace }}"
         ls -la ${{ github.workspace }}
         ls -la ${{ runner.workspace }}
+        ls -la ${{ runner.workspace }}/packed || echo "Packed directory does not exist"
+        ls -la ${{ runner.workspace }}/packed/openbabel || echo "Openbabel directory does not exist"
 
     - name: Configure
       run: |
@@ -66,8 +68,17 @@ jobs:
 
     - name: Packing
       run: |
-        tar --exclude-vcs --exclude-backups --exclude='.github*' -cvjf openbabel-latest.tar.bz2 -C ${{ runner.workspace }}/packed/openbabel .
+        tar --exclude-vcs --exclude-backups --exclude='.github*' -cvjf ${{ runner.workspace }}/packed/openbabel-latest.tar.bz2 -C ${{ runner.workspace }}/packed/openbabel .
       shell: bash
+
+    - name: Verify Artifact Exists
+      run: |
+        if [ -f "${{ runner.workspace }}/packed/openbabel-latest.tar.bz2" ]; then
+          echo "Artifact exists!"
+        else
+          echo "Artifact does not exist!"
+          exit 1
+        fi
 
     - name: Upload
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -29,13 +29,33 @@ jobs:
         sudo apt-get -qq update
         sudo apt-get -qq install ninja-build swig libeigen3-dev libboost-all-dev r-base-core r-base-dev mono-devel
 
+    - name: Debug Directory Structure
+      run: |
+        echo "GitHub Workspace: ${{ github.workspace }}"
+        echo "Runner Workspace: ${{ runner.workspace }}"
+        ls -la ${{ github.workspace }}
+        ls -la ${{ runner.workspace }}
+
     - name: Configure
       run: |
-        mkdir "${{ runner.workspace }}/../build"
+        mkdir -p "${{ runner.workspace }}/../build"
         cd "${{ runner.workspace }}/../build"
-        cmake $GITHUB_WORKSPACE -GNinja -DCSHARP_EXECUTABLE=mcs -DCMAKE_C_COMPILER=${{matrix.config.cc}} -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" ${{matrix.config.cmake_flags}}
-      shell: bash
-      working-directory: ${{ runner.workspace }}/openbabel
+        cmake $GITHUB_WORKSPACE -GNinja \
+          -DCSHARP_EXECUTABLE=${{matrix.config.csharp_compiler}} \
+          -DCMAKE_C_COMPILER=${{matrix.config.cc}} \
+          -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} \
+          -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" \
+          ${{matrix.config.cmake_flags}}
+          shell: bash
+      working-directory: ${{ github.workspace }}/openbabel  # Corrected working directory
+
+#    - name: Configure
+#      run: |
+#        mkdir "${{ runner.workspace }}/../build"
+#        cd "${{ runner.workspace }}/../build"
+#        cmake $GITHUB_WORKSPACE -GNinja -DCSHARP_EXECUTABLE=mcs -DCMAKE_C_COMPILER=${{matrix.config.cc}} -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" ${{matrix.config.cmake_flags}}
+#      shell: bash
+#      working-directory: ${{ runner.workspace }}/openbabel
 
     - name: Build
       run: CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake --build .

--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -1,3 +1,4 @@
+---
 name: Build SWIG bindings
 
 on: [push, pull_request]
@@ -17,6 +18,7 @@ jobs:
             name: "Linux SWIG All Bindings",
             os: ubuntu-latest,
             cc: "gcc", cxx: "g++",
+            csharp_compiler: "mcs",  # Added for C# support
             cmake_flags: "-DPYTHON_BINDINGS=ON -DPERL_BINDINGS=ON -DPHP_BINDINGS=ON -DRUBY_BINDINGS=ON -DJAVA_BINDINGS=ON -DCSHARP_BINDINGS=ON -DRUN_SWIG=ON "
           }
 
@@ -27,7 +29,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qq install ninja-build swig libeigen3-dev libboost-all-dev r-base-core r-base-dev mono-devel
+        sudo apt-get -qq install -y ninja-build swig libeigen3-dev libboost-all-dev r-base-core r-base-dev mono-devel
 
     - name: Debug Directory Structure
       run: |
@@ -46,29 +48,23 @@ jobs:
           -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} \
           -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" \
           ${{matrix.config.cmake_flags}}
-          shell: bash
-      working-directory: ${{ github.workspace }}/openbabel  # Corrected working directory
-
-#    - name: Configure
-#      run: |
-#        mkdir "${{ runner.workspace }}/../build"
-#        cd "${{ runner.workspace }}/../build"
-#        cmake $GITHUB_WORKSPACE -GNinja -DCSHARP_EXECUTABLE=mcs -DCMAKE_C_COMPILER=${{matrix.config.cc}} -DCMAKE_CXX_COMPILER=${{matrix.config.cxx}} -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" ${{matrix.config.cmake_flags}}
-#      shell: bash
-#      working-directory: ${{ runner.workspace }}/openbabel
+      shell: bash
+      working-directory: ${{ github.workspace }}  # Removed "/openbabel" as it doesn't exist
 
     - name: Build
-      run: CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake --build .
+      run: CC=${{matrix.config.cc}} CXX=${{matrix.config.cxx}} cmake --build . --parallel $(nproc)
       shell: bash
       working-directory: ${{ runner.workspace }}/../build
 
     - name: Packing
       run: |
-        tar --exclude-vcs --exclude-backups --exclude='.github*' -cvjf openbabel-latest.tar.bz2 openbabel
-      working-directory: ${{ runner.workspace }}
+        tar --exclude-vcs --exclude-backups --exclude='.github*' -cvjf openbabel-latest.tar.bz2 .
+      shell: bash
+      working-directory: ${{ runner.workspace }}/../build
 
     - name: Upload
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        path: ${{ runner.workspace }}/openbabel-latest.tar.bz2
+        path: ${{ runner.workspace }}/../build/openbabel-latest.tar.bz2
         name: openbabel.tar.bz2
+


### PR DESCRIPTION
Departing from commit `0e94434` by July 11, 2026 of the blessed repository to
release Open Babel 3.2.1, the project includes workflows automatically launched
if a commit is pushed to GitHub.  These workflows equally can be triggered by an
empty commit (i.e., no change of the source code), too.

The blessed repository was forked multiple times into other repositories, the
subsequent launch of the workflows by an empty commit lead to fail of
"Build SWIG bindings / Linux SWIG All Bindings (push)".  In multiple attempts
(i.e., with multiple otherwise pristine repositories), this failure was
replicated.  With assistance of the subscription free AI by ecosia.org, the
workflow in `.github/workflows/build_bindings.yml` was edited for greater
reliablity.

In IEEE format, the robot can by referenced by

Ecosia AI, “Ecosia AI search assistant,” Large language model. Ecosia GmbH,
2026. [Online]. Available: https://www.ecosia.org.