### PR TITLE
ci(build_bindings.yml): prevent concurrent runs

### DIFF
--- a/.github/workflows/build_bindings.yml
+++ b/.github/workflows/build_bindings.yml
@@ -5,6 +5,11 @@ on: [push, pull_request]
 env:
   BUILD_TYPE: Release
 
+# prevent concurrent workflows
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.config.name }}


### PR DESCRIPTION
Already defined in `build_cmake.yml`, to equally prevent concurrent instances
as defined by this workflow is deemed helpful.

## Summary by Sourcery

CI:
- Configure concurrency settings in build_bindings.yml to group runs by workflow and ref and cancel in-progress runs.