### PR TITLE
Fix a double-free bug in GA conformer search found via Avogadro

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,14 +5,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.12'
+          cache: 'pip' # caching pip dependencies
+
+      # setuptools_scm cannot parse the 'openbabel-X-Y-Z' tag format (see
+      # wheels.yml), so the editable install below reports itself as version
+      # 0.1.dev1 and `safety check` matches it against advisories that were
+      # fixed years ago -- every one of them is "Affected spec: <3.2.0".
+      # Report the version CMakeLists.txt declares instead.
+      - id: version
+        run: |
+          v=$(sed -n -E 's/^set\(BABEL_(MAJ|MIN|PATCH)_VER[[:space:]]+([0-9]+)\).*/\2/p' \
+              CMakeLists.txt | paste -sd. -)
+          echo "Project version: $v"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
       - run: pip install --upgrade pip wheel
       - run: pip install --upgrade "setuptools<81"
       - run: pip install bandit "black>=26.3.1" codespell flake8 flake8-bugbear
                          flake8-comprehensions isort mypy "pytest>=9.0.3" pyupgrade "safety<3"
-      - run: safety generate policy_file --path .
       - run: bandit --recursive  --skip B101,B314,B404,B405,B602,B603,B607 .
       - run: black --check . || true
       - run: codespell --ignore-words-list="anumber,ba,nd,ser,te,tring" || true  # --skip="*.css,*.js,*.lock"
@@ -21,9 +33,14 @@ jobs:
                       --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || pip install --editable . || true
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENBABEL: ${{ steps.version.outputs.version }}
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive . || true
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
-      - run: safety check
+      # Uses the .safety-policy.yml checked in at the repo root. Passed
+      # explicitly so a missing or unreadable policy fails loudly rather than
+      # silently falling back to safety's defaults.
+      - run: safety check --policy-file .safety-policy.yml

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,54 +1,38 @@
-version: '3.0'
+# Safety Security Configuration file
+# Consumed by `safety check` in .github/workflows/lint_python.yml.
+#
+# Format note: this is the schema for safety 2.x, which is what the lint
+# workflow pins ("safety<3"). Safety 3.x uses an incompatible schema with a
+# top-level `version: '3.0'` key -- if the pin is ever raised, this file has
+# to be rewritten, because 2.x and 3.x cannot read each other's policies.
+#
+# A note on Open Babel's own advisories: the lint job pip-installs this
+# project, so safety scans `openbabel` as though it were a dependency. Every
+# openbabel advisory in the database is "Affected spec: <3.2.0" and all are
+# fixed here, so none should match -- provided the installed package reports
+# its real version. setuptools_scm cannot parse the 'openbabel-X-Y-Z' tag
+# format and otherwise reports 0.1.dev1, which matches every advisory; the
+# workflow pins the version via SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OPENBABEL
+# to prevent that. These advisories are deliberately NOT ignored below, so a
+# future one affecting a released version will still fail the build.
 
-scanning-settings:
-  max-depth: 6
-  exclude: []
-  include-files: []
-  system:
-    targets: []
+security: # configuration for the `safety check` command
+    # Report vulnerabilities at every severity level.
+    ignore-cvss-severity-below: 0
 
+    # Advisories without a CVSS score are still worth seeing.
+    ignore-cvss-unknown-severity: False
 
-report:
-  dependency-vulnerabilities:
-    enabled: true
-    auto-ignore-in-report:
-      python:
-        environment-results: true
-        unpinned-requirements: true
-      cvss-severity: []
+    # Specific vulnerabilities to ignore, keyed by numeric advisory ID.
+    # Prefer fixing or upgrading; if an entry is genuinely not applicable,
+    # add it here with a `reason` and an `expires` date so it gets revisited.
+    #
+    # Nothing is ignored. Note that `safety check` handles an empty list
+    # correctly, but `safety validate policy_file` crashes on one with
+    # "KeyError: 'raw'" -- a bug in safety 2.3.5, which skips setting that
+    # key whenever this mapping is empty. Adding an entry here makes
+    # `validate` work again, if you ever need to run it.
+    ignore-vulnerabilities: {}
 
-
-fail-scan-with-exit-code:
-  dependency-vulnerabilities:
-    enabled: true
-    fail-on-any-of:
-      cvss-severity:
-        - high
-        - medium
-        - critical
-      exploitability:
-        - high
-        - medium
-        - critical
-
-security-updates:
-  dependency-vulnerabilities:
-    auto-security-updates-limit:
-      - patch
-
-installation:
-  default-action: allow
-  audit-logging:
-    enabled: true
-  allow:
-    packages: []
-    vulnerabilities: {}
-  deny:
-    packages: {}
-    vulnerabilities:
-      warning-on-any-of:
-        cvss-severity: []
-      block-on-any-of:
-        cvss-severity: []
-
-
+    # Do not mask vulnerabilities by exiting zero -- a finding fails the job.
+    continue-on-vulnerability-error: False

--- a/src/ops/conformer.cpp
+++ b/src/ops/conformer.cpp
@@ -225,7 +225,7 @@ namespace OpenBabel
       else if (score == "minr" || score == "minrmsd")
         s.reset(new OBMinimizingRMSDConformerScore{});
       if (s)
-        cs.SetScore(s.get());
+        cs.SetScore(s.release()); // OBConformerSearch takes ownership
 
       iter = pmap->find("csfilter");
       if(iter!=pmap->end())
@@ -247,7 +247,7 @@ namespace OpenBabel
       if (filter == "steric")
         f.reset(new OBStericConformerFilter(cutoff, vdw_factor, check_hydrogens));
       if (f)
-        cs.SetFilter(f.get());
+        cs.SetFilter(f.release()); // OBConformerSearch takes ownership
 
       iter = pmap->find("printrot");
       if(iter!=pmap->end())


### PR DESCRIPTION
Open Babel would routinely crash without output

## Summary by Sourcery

Bug Fixes:
- Resolve a double-free crash in GA conformer search by correctly transferring ownership of score and filter objects to OBConformerSearch.