### PR TITLE
Fix wrong formula when an explicit hydrogen is bonded to no heavy atom (#3008)

### DIFF
--- a/src/mol.cpp
+++ b/src/mol.cpp
@@ -1047,7 +1047,24 @@ namespace OpenBabel
         if(UseImplicitH)
           {
             if (anum == 1 && !IsHiso && HasHvyAtoms)
-              continue; // skip explicit hydrogens except D,T
+              {
+                // Skip an explicit hydrogen only when it is bonded to a heavy
+                // atom, because such hydrogens are already tallied through that
+                // atom's ExplicitHydrogenCount() below. A hydrogen bonded to no
+                // heavy atom (isolated, or bonded only to other hydrogens) is
+                // counted by nobody, so let it fall through to be added once;
+                // otherwise it is dropped from the formula even though it stays
+                // in the atom list and molecular weight (issue #3008).
+                bool boundToHeavyAtom = false;
+                FOR_NBORS_OF_ATOM(nbr, &*a)
+                  if (nbr->GetAtomicNum() > 1)
+                    {
+                      boundToHeavyAtom = true;
+                      break;
+                    }
+                if (boundToHeavyAtom)
+                  continue; // skip explicit hydrogens except D,T
+              }
             if(anum==1)
               {
                 if (IsHiso && HasHvyAtoms)

--- a/test/files/FormulaTest.smi
+++ b/test/files/FormulaTest.smi
@@ -67,3 +67,6 @@ n(=O)(=O)    NO2
 cccc     C4H6
 Cc(C)cCCc(C)cccc(C)cccc(C)ccccc(C)cccc(C)cccc(C)CCcc(C)C lycopene
 Os(=O)=O	radical HSO3
+[N][H][H]	H2N	stray H not dropped (issue #3008)
+[H].[O][H]	H2O	isolated H plus O-H (issue #3008)
+[He].[H].[H].[Co][C]	CH2CoHe	isolated H with a bonded fragment (issue #3008)

--- a/test/formula.cpp
+++ b/test/formula.cpp
@@ -204,6 +204,41 @@ int formula(int argc, char* argv[])
 
     }
 
+  // ---------------------------------------------------------------------------
+  // Regression test for issue #3008: molreport / GetFormula dropped an explicit
+  // hydrogen that is bonded to no heavy atom (isolated, or bonded only to other
+  // hydrogens). Such a hydrogen was counted by nobody, so it vanished from the
+  // formula even though it remained in the atom list and the molecular weight.
+  // ---------------------------------------------------------------------------
+  {
+    struct { const char *smiles; const char *formula; } issue3008[] = {
+      { "[N][H][H]",            "H2N"     }, // stray H must not be dropped
+      { "[H].[O][H]",           "H2O"     }, // isolated H plus an O-H fragment
+      { "[He].[H].[H].[Co][C]", "CH2CoHe" }, // isolated H with a bonded fragment
+      // Controls that must stay correct after the fix:
+      { "[H][O][H]",            "H2O"     }, // both H bonded to a heavy atom
+      { "[H].[O].[H]",          "H2O"     }, // no bonds: implicit-H path unused
+      { "[H][H]",               "H2"      }  // no heavy atoms present
+    };
+    OBConversion smiconv;
+    if (!smiconv.SetInFormat("smi"))
+      cout << "not ok " << ++currentTest << " # SMILES format not loaded\n";
+    else
+      for (size_t i = 0; i < sizeof(issue3008) / sizeof(issue3008[0]); ++i)
+        {
+          OBMol cmol;
+          smiconv.ReadString(&cmol, issue3008[i].smiles);
+          string got = cmol.GetFormula();
+          if (got != issue3008[i].formula)
+            cout << "not ok " << ++currentTest << " # formula \"" << got
+                 << "\" != \"" << issue3008[i].formula << "\" for "
+                 << issue3008[i].smiles << " (issue #3008)\n";
+          else
+            cout << "ok " << ++currentTest << " # formula \"" << got
+                 << "\" for " << issue3008[i].smiles << " (issue #3008)\n";
+        }
+  }
+
   // return number of tests run
   cout << "1.." << currentTest << endl;
 


### PR DESCRIPTION
Fixes #3008.

## Root cause
`OBMol::GetSpacedFormula()` (the engine behind `GetFormula`, molreport, and the SMILES/SDF writers) counts hydrogens only through each heavy atom's `ExplicitHydrogenCount()`, then unconditionally `continue`s past every explicit, non-isotope H atom when `UseImplicitH && HasHvyAtoms`. An H bonded to no heavy atom (isolated, or bonded only to another H) is therefore counted by nobody and silently dropped from the formula, even though it still appears in the atom list and in the molecular weight. Reproductions on 3.1.0:

```
[N][H][H]            -> "HN"    (should be "H2N")
[H].[O][H]           -> "HO"    (should be "H2O")
[He].[H].[H].[Co][C] -> "CCoHe" (should be "CH2CoHe")
```

## Fix
Skip an explicit H only when it is bonded to a heavy atom (already tallied via that atom's `ExplicitHydrogenCount`); otherwise let it fall through to be counted exactly once. The formula now matches the atom list and the molecular weight. Controls remain correct (`[H][O][H]` -> H2O, `[H].[O].[H]` -> H2O, `[H][H]` -> H2), and D/T isotopes are untouched.

## Testing
Red-green added to `test/formula.cpp` (I used the actual wired `formula` ctest, which reads `attype.00.smi`/`formularesults.txt` -- `FormulaTest.smi` is not read by any ctest -- so the load-bearing assertions live in `formula.cpp` to avoid perturbing the shared `attype.00.smi` fixture; the 3 documented lines were also added to `FormulaTest.smi`). Reverting only the `mol.cpp` change makes the three cases fail (HN/HO/CCoHe); with the fix all pass, and the full 274-molecule formula corpus is unaffected. Built and run via `ctest -R formula`.

Thanks to @silexinus for the clear report and reproductions.

---
This change was prepared with AI assistance and reviewed by me before submission.

## Summary by Sourcery

Correct molecular formula generation so every explicit hydrogen is counted exactly once.

Bug Fixes:
- Ensure molecular formulas include explicit hydrogens that are isolated or bonded only to other hydrogens.
- Preserve correct formula generation for hydrogens bonded to heavy atoms, standalone hydrogen fragments, and hydrogen isotopes.

Tests:
- Add regression coverage for formulas involving unconnected explicit hydrogens and related control cases.