### PR TITLE
feat(InChI): show CURRENT_VER if available

### DIFF
--- a/include/openbabel/inchiformat.h
+++ b/include/openbabel/inchiformat.h
@@ -23,7 +23,14 @@ GNU General Public License for more details.
 
 #ifdef HAVE_SYSTEM_INCHI
 #include <inchi_api.h>
-#define CURRENT_VER "unknown" // bcf_s.h is not packaged
+#ifdef __has_include
+#if __has_include(<bcf_s.h>)
+#include <bcf_s.h>
+#endif
+#endif
+#ifndef CURRENT_VER
+#define CURRENT_VER "unknown"
+#endif
 #else
 #include "../inchi/inchi_api.h"
 #include "../inchi/bcf_s.h"  // for CURRENT_VER


### PR DESCRIPTION
## Summary by Sourcery

Use the system InChI version when available while preserving compatibility with installations that do not provide it.

New Features:
- Expose the InChI library's CURRENT_VER value when the system installation provides its version header.

Enhancements:
- Retain the unknown version fallback when CURRENT_VER is unavailable.